### PR TITLE
Add the categorical metadata balancing sampling strategy

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
@@ -18,6 +18,7 @@ from lightly_studio.sampling.sampling_config import (
     EmbeddingDeduplicationStrategy,
     EmbeddingDiversityStrategy,
     EmbeddingSimilarityStrategy,
+    MetadataBalancingStrategy,
     MetadataWeightingStrategy,
     SamplingConfig,
 )
@@ -31,6 +32,7 @@ Strategy = Annotated[
         EmbeddingDeduplicationStrategy,
         EmbeddingDiversityStrategy,
         EmbeddingSimilarityStrategy,
+        MetadataBalancingStrategy,
         MetadataWeightingStrategy,
     ],
     Field(discriminator="strategy_name"),

--- a/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
+++ b/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
@@ -19,10 +19,8 @@ from lightly_studio.sampling.sampling_config import MetadataBalancingStrategy
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on the number of balanced values. The distribution matrix holds one column
+# Upper bound on the number of balanced values: the distribution matrix holds one column
 # per value, so an unbounded key such as a file path would allocate a column per sample.
-# The "uniform" and "input" targets balance the most frequent values and group the rest as
-# "other". An explicit target with more values is rejected instead of grouped.
 MAX_BALANCED_VALUES = 100
 
 
@@ -67,7 +65,6 @@ def get_metadata_balancing_data(
         ValueError: If the key does not exist in the collection, is not categorical, or an
             explicit target distribution has more than `MAX_BALANCED_VALUES` values.
     """
-    # Checked first because every target value becomes a column of the distribution matrix.
     if (
         isinstance(strat.target_distribution, dict)
         and len(strat.target_distribution) > MAX_BALANCED_VALUES
@@ -86,7 +83,6 @@ def get_metadata_balancing_data(
     )
     value_counts = Counter(sample_id_to_value.values())
     if not value_counts:
-        # No input sample has a value for the key, so there is nothing to balance.
         return np.zeros((len(input_sample_ids), 0), dtype=np.float32), []
 
     if strat.target_distribution == "uniform":
@@ -123,8 +119,6 @@ def _get_categorical_values(
     Raises:
         ValueError: If the key does not exist in the collection or is not categorical.
     """
-    # TODO(Nauryzbay, 08/2026): This resolves the values of the whole collection. Scope the
-    # query to `input_sample_ids` if it becomes a bottleneck for heavily filtered samplings.
     all_values, metadata_type = sample_metadata_resolver.get_metadata_values_for_key(
         session=session,
         collection_id=collection_id,

--- a/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
+++ b/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
@@ -63,7 +63,8 @@ def get_metadata_balancing_data(
 
     Raises:
         ValueError: If the key does not exist in the collection, is not categorical, or an
-            explicit target distribution has more than `MAX_BALANCED_VALUES` values.
+            explicit target distribution has more than `MAX_BALANCED_VALUES` values or two
+            keys that name the same value.
     """
     if (
         isinstance(strat.target_distribution, dict)
@@ -172,20 +173,33 @@ def _get_balanced_counts(value_counts: Mapping[str, int]) -> dict[_ColumnKey, in
 
 
 def _get_explicit_target(
-    target_distribution: Mapping[str, float],
+    target_distribution: Mapping[str | bool, float],
     value_counts: Mapping[str, int],
 ) -> tuple[list[_ColumnKey], list[float]]:
     """Resolve an explicit target distribution.
 
-    Values with a target keep it. All other values of the key are grouped as "other"
-    and share the target remaining to 1.0.
-    """
-    target_keys: list[_ColumnKey] = list(target_distribution)
-    target_values = list(target_distribution.values())
+    Boolean keys are formatted like the values they target. Values with a target keep it.
+    All other values of the key are grouped as "other" and share the target remaining
+    to 1.0.
 
-    if set(value_counts) - set(target_distribution):
+    Raises:
+        ValueError: If two keys name the same value.
+    """
+    targets: dict[str, float] = {}
+    for value, target in target_distribution.items():
+        formatted_value = _format_value(value)
+        if formatted_value in targets:
+            raise ValueError(
+                f"Metadata balancing got two targets for the value '{formatted_value}'."
+            )
+        targets[formatted_value] = target
+
+    target_keys: list[_ColumnKey] = list(targets)
+    target_values = list(targets.values())
+
+    if set(value_counts) - set(targets):
         target_keys.append(_OTHER)
-        target_values.append(max(1.0 - sum(target_distribution.values()), 0.0))
+        target_values.append(max(1.0 - sum(targets.values()), 0.0))
     return target_keys, target_values
 
 

--- a/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
+++ b/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
@@ -1,0 +1,209 @@
+"""Resolves metadata balancing strategies into distributions for the sampling algorithm."""
+
+from __future__ import annotations
+
+import enum
+import logging
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from uuid import UUID
+
+import numpy as np
+from numpy.typing import NDArray
+from sqlmodel import Session
+from typing_extensions import TypeAlias
+
+from lightly_studio.models.metadata import CATEGORICAL_TYPE_NAMES
+from lightly_studio.resolvers.metadata_resolver import sample as sample_metadata_resolver
+from lightly_studio.sampling.sampling_config import MetadataBalancingStrategy
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on the number of balanced values. The distribution matrix holds one column
+# per value, so an unbounded key such as a file path would allocate a column per sample.
+# The most frequent values are balanced and the remaining ones are grouped as "other".
+MAX_BALANCED_VALUES = 100
+
+
+class _OtherValue(enum.Enum):
+    """Column that groups all metadata values without their own target."""
+
+    OTHER = enum.auto()
+
+
+# Column key of the "other" group. Distinct from every metadata value, which are all strings.
+_OTHER = _OtherValue.OTHER
+
+_ColumnKey: TypeAlias = "str | _OtherValue"
+
+
+def get_metadata_balancing_data(
+    session: Session,
+    strat: MetadataBalancingStrategy,
+    collection_id: UUID,
+    input_sample_ids: Sequence[UUID],
+) -> tuple[NDArray[np.float32], list[float]]:
+    """Build the value distributions and target distribution for metadata balancing.
+
+    Every sample has at most one value for the key, so its row is one-hot. Samples
+    without a value for the key get an all-zero row: they do not influence the
+    balancing, but stay available for selection.
+
+    N is the number of input samples and V is the number of balanced values.
+
+    Args:
+        session: The database session.
+        strat: The metadata balancing strategy to resolve.
+        collection_id: The collection the input samples belong to.
+        input_sample_ids: The samples to sample from, in selection order.
+
+    Returns:
+        Tuple of:
+            The value distributions of shape (N, V) and dtype `np.float32`.
+            The target distribution of length V.
+
+    Raises:
+        ValueError: If the key does not exist in the collection or is not categorical.
+    """
+    sample_id_to_value = _get_categorical_values(
+        session=session,
+        metadata_key=strat.metadata_key,
+        collection_id=collection_id,
+        input_sample_ids=input_sample_ids,
+    )
+    value_counts = Counter(sample_id_to_value.values())
+    if not value_counts:
+        # No input sample has a value for the key, so there is nothing to balance.
+        return np.zeros((len(input_sample_ids), 0), dtype=np.float32), []
+
+    if strat.target_distribution == "uniform":
+        target_keys = list(_get_balanced_counts(value_counts=value_counts))
+        target_values = [1.0 / len(target_keys)] * len(target_keys)
+    elif strat.target_distribution == "input":
+        balanced_counts = _get_balanced_counts(value_counts=value_counts)
+        target_keys = list(balanced_counts)
+        target_values = [float(count) for count in balanced_counts.values()]
+    else:
+        target_keys, target_values = _get_explicit_target(
+            target_distribution=strat.target_distribution,
+            value_counts=value_counts,
+        )
+
+    value_distributions = _build_value_distributions(
+        input_sample_ids=input_sample_ids,
+        sample_id_to_value=sample_id_to_value,
+        target_keys=target_keys,
+    )
+    return value_distributions, target_values
+
+
+def _get_categorical_values(
+    session: Session,
+    metadata_key: str,
+    collection_id: UUID,
+    input_sample_ids: Sequence[UUID],
+) -> dict[UUID, str]:
+    """Resolve the categorical metadata value of every input sample that has one.
+
+    Values are returned as strings so that booleans and strings share one column type.
+
+    Raises:
+        ValueError: If the key does not exist in the collection or is not categorical.
+    """
+    # TODO(Nauryzbay, 08/2026): This resolves the values of the whole collection. Scope the
+    # query to `input_sample_ids` if it becomes a bottleneck for heavily filtered samplings.
+    all_values, metadata_type = sample_metadata_resolver.get_metadata_values_for_key(
+        session=session,
+        collection_id=collection_id,
+        key=metadata_key,
+    )
+    if metadata_type is None:
+        raise ValueError(
+            f"Metadata key '{metadata_key}' does not exist in collection {collection_id}."
+        )
+    if metadata_type not in CATEGORICAL_TYPE_NAMES:
+        raise ValueError(
+            f"Metadata key '{metadata_key}' has type '{metadata_type}', but balancing "
+            f"requires one of {CATEGORICAL_TYPE_NAMES}."
+        )
+
+    return {
+        sample_id: _format_value(all_values[sample_id])
+        for sample_id in input_sample_ids
+        if sample_id in all_values
+    }
+
+
+def _format_value(value: str | bool) -> str:
+    """Format a categorical metadata value as its column key."""
+    if isinstance(value, bool):
+        # Match the lowercase spelling used when metadata values are read as text.
+        return "true" if value else "false"
+    return value
+
+
+def _get_balanced_counts(value_counts: Mapping[str, int]) -> dict[_ColumnKey, int]:
+    """Count the samples per balanced value, grouping the rarest values if there are many.
+
+    Returns:
+        The sample count per balanced value, in sorted value order. An "other" entry
+        holding the combined count of the rarest values is appended when the key has
+        more than `MAX_BALANCED_VALUES` distinct values.
+    """
+    if len(value_counts) <= MAX_BALANCED_VALUES:
+        return {value: value_counts[value] for value in sorted(value_counts)}
+
+    most_common = Counter(value_counts).most_common(MAX_BALANCED_VALUES)
+    balanced_counts: dict[_ColumnKey, int] = dict(sorted(most_common))
+    balanced_counts[_OTHER] = sum(value_counts.values()) - sum(count for _, count in most_common)
+    logger.warning(
+        f"Metadata balancing found {len(value_counts)} distinct values, but balances at most "
+        f"{MAX_BALANCED_VALUES}. The {len(value_counts) - MAX_BALANCED_VALUES} rarest values "
+        f"are balanced together as one group."
+    )
+    return balanced_counts
+
+
+def _get_explicit_target(
+    target_distribution: Mapping[str, float],
+    value_counts: Mapping[str, int],
+) -> tuple[list[_ColumnKey], list[float]]:
+    """Resolve an explicit target distribution.
+
+    Values with a target keep it. All other values of the key are grouped as "other"
+    and share the target remaining to 1.0.
+    """
+    target_keys: list[_ColumnKey] = list(target_distribution)
+    target_values = list(target_distribution.values())
+
+    if set(value_counts) - set(target_distribution):
+        target_keys.append(_OTHER)
+        target_values.append(max(1.0 - sum(target_distribution.values()), 0.0))
+    return target_keys, target_values
+
+
+def _build_value_distributions(
+    input_sample_ids: Sequence[UUID],
+    sample_id_to_value: Mapping[UUID, str],
+    target_keys: Sequence[_ColumnKey],
+) -> NDArray[np.float32]:
+    """Build the one-hot value distributions of the input samples.
+
+    N is the number of input samples and V is the number of balanced values.
+
+    Returns:
+        The value distributions of shape (N, V) and dtype `np.float32`. Samples without a
+        value for the key have an all-zero row.
+    """
+    value_to_column = {value: column for column, value in enumerate(target_keys)}
+    other_column = value_to_column.get(_OTHER)
+
+    value_distributions = np.zeros((len(input_sample_ids), len(target_keys)), dtype=np.float32)
+    for row, sample_id in enumerate(input_sample_ids):
+        value = sample_id_to_value.get(sample_id)
+        if value is None:
+            continue
+        column = value_to_column.get(value, other_column)
+        if column is not None:
+            value_distributions[row, column] = 1.0
+    return value_distributions

--- a/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
+++ b/lightly_studio/src/lightly_studio/sampling/metadata_balancing.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 # Upper bound on the number of balanced values. The distribution matrix holds one column
 # per value, so an unbounded key such as a file path would allocate a column per sample.
-# The most frequent values are balanced and the remaining ones are grouped as "other".
+# The "uniform" and "input" targets balance the most frequent values and group the rest as
+# "other". An explicit target with more values is rejected instead of grouped.
 MAX_BALANCED_VALUES = 100
 
 
@@ -63,8 +64,20 @@ def get_metadata_balancing_data(
             The target distribution of length V.
 
     Raises:
-        ValueError: If the key does not exist in the collection or is not categorical.
+        ValueError: If the key does not exist in the collection, is not categorical, or an
+            explicit target distribution has more than `MAX_BALANCED_VALUES` values.
     """
+    # Checked first because every target value becomes a column of the distribution matrix.
+    if (
+        isinstance(strat.target_distribution, dict)
+        and len(strat.target_distribution) > MAX_BALANCED_VALUES
+    ):
+        raise ValueError(
+            f"Metadata balancing supports at most {MAX_BALANCED_VALUES} target values, but the "
+            f"target distribution for key '{strat.metadata_key}' has "
+            f"{len(strat.target_distribution)}."
+        )
+
     sample_id_to_value = _get_categorical_values(
         session=session,
         metadata_key=strat.metadata_key,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -91,6 +91,9 @@ class MetadataBalancingStrategy(SamplingStrategy):
     combining one strategy per key; each key is balanced on its own rather than over
     the combinations of their values. Samples without a value for the key are not
     influenced by this strategy, but stay available for selection.
+
+    At most 100 values are balanced: a ``target_distribution`` mapping holds at most 100
+    values, and ``"uniform"`` and ``"input"`` group the rarest values beyond that.
     """
 
     strategy_name: Literal["metadata_balance"] = "metadata_balance"

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -11,6 +11,9 @@ from pydantic import BaseModel, Field
 AnnotationsClassName = str
 AnnotationClassToTarget = dict[AnnotationsClassName, float]
 
+MetadataValueName = str
+MetadataValueToTarget = dict[MetadataValueName, float]
+
 
 class SamplingConfig(BaseModel):
     """Configuration for the sampling process."""
@@ -79,3 +82,17 @@ class AnnotationClassBalancingStrategy(SamplingStrategy):
     strategy_name: Literal["balance"] = "balance"
     target_distribution: AnnotationClassToTarget | Literal["uniform"] | Literal["input"]
     annotation_source_id: UUID | None = None
+
+
+class MetadataBalancingStrategy(SamplingStrategy):
+    """Sampling strategy that balances the selection over one categorical metadata key.
+
+    Balances a single ``string`` or ``boolean`` metadata key. Balance several keys by
+    combining one strategy per key; each key is balanced on its own rather than over
+    the combinations of their values. Samples without a value for the key are not
+    influenced by this strategy, but stay available for selection.
+    """
+
+    strategy_name: Literal["metadata_balance"] = "metadata_balance"
+    metadata_key: str
+    target_distribution: MetadataValueToTarget | Literal["uniform"] | Literal["input"]

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -87,13 +87,10 @@ class AnnotationClassBalancingStrategy(SamplingStrategy):
 class MetadataBalancingStrategy(SamplingStrategy):
     """Sampling strategy that balances the selection over one categorical metadata key.
 
-    Balances a single ``string`` or ``boolean`` metadata key. Balance several keys by
-    combining one strategy per key; each key is balanced on its own rather than over
-    the combinations of their values. Samples without a value for the key are not
-    influenced by this strategy, but stay available for selection.
-
-    At most 100 values are balanced: a ``target_distribution`` mapping holds at most 100
-    values, and ``"uniform"`` and ``"input"`` group the rarest values beyond that.
+    Balances a single ``string`` or ``boolean`` key over at most 100 values. Combine one
+    strategy per key to balance several keys, each on its own rather than over the
+    combinations of their values. Samples without a value for the key are unaffected but
+    stay available for selection.
     """
 
     strategy_name: Literal["metadata_balance"] = "metadata_balance"

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import Literal, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -11,7 +11,8 @@ from pydantic import BaseModel, Field
 AnnotationsClassName = str
 AnnotationClassToTarget = dict[AnnotationsClassName, float]
 
-MetadataValueName = str
+# Values of a boolean key can be named either as booleans or as their lowercase names.
+MetadataValueName = Union[str, bool]
 MetadataValueToTarget = dict[MetadataValueName, float]
 
 
@@ -91,6 +92,11 @@ class MetadataBalancingStrategy(SamplingStrategy):
     strategy per key to balance several keys, each on its own rather than over the
     combinations of their values. Samples without a value for the key are unaffected but
     stay available for selection.
+
+    An explicit target distribution names the values of a ``boolean`` key either as
+    ``True`` and ``False`` or as the lowercase strings ``"true"`` and ``"false"``. It may
+    give a target to only some values; the remaining values then share the target left
+    to 1.0.
     """
 
     strategy_name: Literal["metadata_balance"] = "metadata_balance"

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -23,13 +23,14 @@ from lightly_studio.resolvers import (
     metadata_resolver,
     tag_resolver,
 )
-from lightly_studio.sampling import sampling_helpers, sequence_sampling
+from lightly_studio.sampling import metadata_balancing, sampling_helpers, sequence_sampling
 from lightly_studio.sampling.mundig import Mundig
 from lightly_studio.sampling.sampling_config import (
     AnnotationClassBalancingStrategy,
     EmbeddingDeduplicationStrategy,
     EmbeddingDiversityStrategy,
     EmbeddingSimilarityStrategy,
+    MetadataBalancingStrategy,
     MetadataWeightingStrategy,
     SamplingConfig,
 )
@@ -456,6 +457,18 @@ def _add_strategy_to_mundig(
         mundig.add_class_balancing(
             class_distributions=class_distributions,
             target=target_values,
+            strength=strat.strength,
+        )
+    elif isinstance(strat, MetadataBalancingStrategy):
+        value_distributions, value_targets = metadata_balancing.get_metadata_balancing_data(
+            session=session,
+            strat=strat,
+            collection_id=context.collection_id,
+            input_sample_ids=context.input_sample_ids,
+        )
+        mundig.add_class_balancing(
+            class_distributions=value_distributions,
+            target=value_targets,
             strength=strat.strength,
         )
     else:

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -25,6 +25,7 @@ from lightly_studio.sampling.sampling_config import EmbeddingDiversityStrategy
 from tests import helpers_resolvers
 from tests.helpers_resolvers import ImageStub
 from tests.resolvers.video import helpers as video_helpers
+from tests.sampling import helpers_sampling
 
 
 def test_create_combination_sampling__diversity_success(
@@ -570,6 +571,77 @@ def test_create_combination_sampling__annotation_class_balancing_success(
         for annotation in selected_annotations
     )
     assert selected_class_frequencies == {"class_a": 1, "class_b": 1}
+
+
+def test_create_combination_sampling__metadata_balancing_success(
+    test_client: TestClient, db_session: Session
+) -> None:
+    """Test successful metadata balancing sampling."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session,
+        metadata=["sunny", "sunny", "rainy"],
+        metadata_key="weather",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/sampling",
+        json={
+            "n_samples_to_select": 2,
+            "sampling_result_tag_name": "balanced_weather",
+            "strategies": [
+                {
+                    "strategy_name": "metadata_balance",
+                    "metadata_key": "weather",
+                    "target_distribution": "uniform",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 204
+    assert response.text == ""
+
+    created_tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="balanced_weather", collection_id=collection_id
+    )
+    assert created_tag is not None
+
+    tag_filter = ImageFilter(sample_filter=SampleFilter(tag_ids=[created_tag.tag_id]))
+    result = image_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection_id, filters=tag_filter
+    )
+    # One sunny and one rainy sample give the uniform distribution.
+    assert len(result.samples) == 2
+    assert "sample_2.jpg" in [sample.file_name for sample in result.samples]
+
+
+def test_create_combination_sampling__metadata_balancing_non_categorical_key(
+    test_client: TestClient, db_session: Session
+) -> None:
+    """Test that balancing a non-categorical metadata key is rejected."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session,
+        metadata=[0.1, 0.2, 0.3],
+        metadata_key="sharpness",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/sampling",
+        json={
+            "n_samples_to_select": 2,
+            "sampling_result_tag_name": "balanced_sharpness",
+            "strategies": [
+                {
+                    "strategy_name": "metadata_balance",
+                    "metadata_key": "sharpness",
+                    "target_distribution": "uniform",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert "balancing requires" in response.json()["error"]
 
 
 def test_create_combination_sampling__image_filter_success(

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -610,7 +610,6 @@ def test_create_combination_sampling__metadata_balancing_success(
     result = image_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection_id, filters=tag_filter
     )
-    # One sunny and one rainy sample give the uniform distribution.
     assert len(result.samples) == 2
     assert "sample_2.jpg" in [sample.file_name for sample in result.samples]
 

--- a/lightly_studio/tests/sampling/test_metadata_balancing.py
+++ b/lightly_studio/tests/sampling/test_metadata_balancing.py
@@ -1,0 +1,220 @@
+"""Tests for resolving metadata balancing strategies into distributions."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import numpy as np
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.resolvers import image_resolver
+from lightly_studio.sampling import metadata_balancing
+from lightly_studio.sampling.sampling_config import (
+    MetadataBalancingStrategy,
+    MetadataValueToTarget,
+)
+from tests.helpers_resolvers import create_image
+from tests.sampling import helpers_sampling
+
+
+@pytest.mark.parametrize(
+    ("metadata", "metadata_key", "target_distribution", "expected_matrix", "expected_target"),
+    [
+        pytest.param(
+            ["sunny", "sunny", "rainy"],
+            "weather",
+            "uniform",
+            # Columns are the sorted values ["rainy", "sunny"].
+            [[0.0, 1.0], [0.0, 1.0], [1.0, 0.0]],
+            [0.5, 0.5],
+            id="uniform",
+        ),
+        pytest.param(
+            ["sunny", "sunny", "rainy"],
+            "weather",
+            "input",
+            [[0.0, 1.0], [0.0, 1.0], [1.0, 0.0]],
+            # The input target holds the raw counts of ["rainy", "sunny"].
+            [1.0, 2.0],
+            id="input",
+        ),
+        pytest.param(
+            [True, True, False],
+            "is_blurry",
+            "uniform",
+            # Boolean values become their lowercase names, sorted as ["false", "true"].
+            [[0.0, 1.0], [0.0, 1.0], [1.0, 0.0]],
+            [0.5, 0.5],
+            id="boolean",
+        ),
+        pytest.param(
+            ["sunny", "rainy", "foggy"],
+            "weather",
+            # The values without a target are grouped as one "other" value, so this
+            # distribution becomes `sunny: 0.5, rainy+foggy: 0.5`.
+            {"sunny": 0.5},
+            # Columns are ["sunny", other].
+            [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]],
+            [0.5, 0.5],
+            id="explicit_target",
+        ),
+        pytest.param(
+            ["sunny", "rainy"],
+            "weather",
+            # No sample is foggy, so that column stays empty instead of catching the
+            # values without a target.
+            {"sunny": 0.5, "foggy": 0.5},
+            # Columns are ["sunny", "foggy", other], and "rainy" falls into "other".
+            [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+            [0.5, 0.5, 0.0],
+            id="target_value_not_present",
+        ),
+    ],
+)
+def test_get_metadata_balancing_data(  # noqa: PLR0913
+    db_session: Session,
+    metadata: list[Any],
+    metadata_key: str,
+    target_distribution: MetadataValueToTarget | str,
+    expected_matrix: list[list[float]],
+    expected_target: list[float],
+) -> None:
+    """Resolves the three target distributions into one-hot value distributions."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=metadata, metadata_key=metadata_key
+    )
+
+    value_distributions, target_values = metadata_balancing.get_metadata_balancing_data(
+        session=db_session,
+        strat=MetadataBalancingStrategy(
+            metadata_key=metadata_key,
+            target_distribution=target_distribution,  # type: ignore[arg-type]
+        ),
+        collection_id=collection_id,
+        input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),
+    )
+
+    np.testing.assert_array_equal(value_distributions, np.array(expected_matrix, dtype=np.float32))
+    assert target_values == expected_target
+
+
+def test_get_metadata_balancing_data__missing_value(db_session: Session) -> None:
+    """Gives a sample without a value for the key an all-zero row."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=["sunny", "rainy"], metadata_key="weather"
+    )
+    sample_without_value = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="no_weather.jpg"
+    )
+    input_sample_ids = _all_sample_ids(session=db_session, collection_id=collection_id)
+    row_without_value = input_sample_ids.index(sample_without_value.sample_id)
+
+    value_distributions, _ = metadata_balancing.get_metadata_balancing_data(
+        session=db_session,
+        strat=MetadataBalancingStrategy(metadata_key="weather", target_distribution="uniform"),
+        collection_id=collection_id,
+        input_sample_ids=input_sample_ids,
+    )
+
+    assert value_distributions.shape == (3, 2)
+    np.testing.assert_array_equal(
+        value_distributions[row_without_value], np.array([0.0, 0.0], dtype=np.float32)
+    )
+
+
+def test_get_metadata_balancing_data__no_values(db_session: Session) -> None:
+    """Balances nothing when no input sample has a value for the key."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=["sunny", "rainy"], metadata_key="weather"
+    )
+    # Restrict the input to a sample that has no value for the balanced key.
+    sample_without_value = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="no_weather.jpg"
+    )
+
+    value_distributions, target_values = metadata_balancing.get_metadata_balancing_data(
+        session=db_session,
+        strat=MetadataBalancingStrategy(metadata_key="weather", target_distribution="uniform"),
+        collection_id=collection_id,
+        input_sample_ids=[sample_without_value.sample_id],
+    )
+
+    assert value_distributions.shape == (1, 0)
+    assert target_values == []
+
+
+def test_get_metadata_balancing_data__more_values_than_balanced(db_session: Session) -> None:
+    """Groups the rarest values when the key has more distinct values than balanced."""
+    n_values = metadata_balancing.MAX_BALANCED_VALUES + 5
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session,
+        metadata=[f"value_{index:03d}" for index in range(n_values)],
+        metadata_key="serial",
+    )
+
+    value_distributions, target_values = metadata_balancing.get_metadata_balancing_data(
+        session=db_session,
+        strat=MetadataBalancingStrategy(metadata_key="serial", target_distribution="uniform"),
+        collection_id=collection_id,
+        input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),
+    )
+
+    # The rarest values share one "other" column on top of the balanced ones.
+    assert value_distributions.shape == (n_values, metadata_balancing.MAX_BALANCED_VALUES + 1)
+    assert len(target_values) == metadata_balancing.MAX_BALANCED_VALUES + 1
+    # Every sample still has exactly one value, so every row is one-hot.
+    np.testing.assert_array_equal(
+        value_distributions.sum(axis=1), np.ones(n_values, dtype=np.float32)
+    )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "metadata_key", "balanced_key", "expected_error"),
+    [
+        pytest.param(
+            [0.1, 0.2, 0.3],
+            "sharpness",
+            "sharpness",
+            "has type 'float', but balancing requires",
+            id="non_categorical_key",
+        ),
+        pytest.param(
+            ["sunny", "rainy"],
+            "weather",
+            "missing",
+            "does not exist in collection",
+            id="unknown_key",
+        ),
+    ],
+)
+def test_get_metadata_balancing_data__invalid_key(
+    db_session: Session,
+    metadata: list[Any],
+    metadata_key: str,
+    balanced_key: str,
+    expected_error: str,
+) -> None:
+    """Rejects a key that does not exist in the collection or is not categorical."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=metadata, metadata_key=metadata_key
+    )
+
+    with pytest.raises(ValueError, match=expected_error):
+        metadata_balancing.get_metadata_balancing_data(
+            session=db_session,
+            strat=MetadataBalancingStrategy(
+                metadata_key=balanced_key, target_distribution="uniform"
+            ),
+            collection_id=collection_id,
+            input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),
+        )
+
+
+def _all_sample_ids(session: Session, collection_id: UUID) -> list[UUID]:
+    """Return all sample ids of the collection, ordered as the resolver returns them."""
+    samples = image_resolver.get_all_by_collection_id(
+        session=session, collection_id=collection_id, pagination=None
+    ).samples
+    return [sample.sample_id for sample in samples]

--- a/lightly_studio/tests/sampling/test_metadata_balancing.py
+++ b/lightly_studio/tests/sampling/test_metadata_balancing.py
@@ -71,6 +71,16 @@ from tests.sampling import helpers_sampling
             [0.5, 0.5, 0.0],
             id="target_value_not_present",
         ),
+        pytest.param(
+            [True, True, False],
+            "is_blurry",
+            # A boolean key is targeted with booleans or with their lowercase names.
+            {True: 0.75},
+            # Columns are ["true", other], and the false sample falls into "other".
+            [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            [0.75, 0.25],
+            id="boolean_explicit_target",
+        ),
     ],
 )
 def test_get_metadata_balancing_data(  # noqa: PLR0913
@@ -175,7 +185,7 @@ def test_get_metadata_balancing_data__target_values_at_limit(db_session: Session
     collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
         session=db_session, metadata=["sunny", "rainy"], metadata_key="weather"
     )
-    target_distribution = {
+    target_distribution: MetadataValueToTarget = {
         f"value_{index:03d}": 0.0 for index in range(metadata_balancing.MAX_BALANCED_VALUES)
     }
 
@@ -198,7 +208,7 @@ def test_get_metadata_balancing_data__too_many_target_values(db_session: Session
     collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
         session=db_session, metadata=["sunny", "rainy"], metadata_key="weather"
     )
-    target_distribution = {
+    target_distribution: MetadataValueToTarget = {
         f"value_{index:03d}": 0.0 for index in range(metadata_balancing.MAX_BALANCED_VALUES + 1)
     }
 
@@ -207,6 +217,23 @@ def test_get_metadata_balancing_data__too_many_target_values(db_session: Session
             session=db_session,
             strat=MetadataBalancingStrategy(
                 metadata_key="weather", target_distribution=target_distribution
+            ),
+            collection_id=collection_id,
+            input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),
+        )
+
+
+def test_get_metadata_balancing_data__duplicate_target_value(db_session: Session) -> None:
+    """Rejects an explicit target that names the same boolean value twice."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=[True, False], metadata_key="is_blurry"
+    )
+
+    with pytest.raises(ValueError, match="two targets for the value 'true'"):
+        metadata_balancing.get_metadata_balancing_data(
+            session=db_session,
+            strat=MetadataBalancingStrategy(
+                metadata_key="is_blurry", target_distribution={True: 0.5, "true": 0.5}
             ),
             collection_id=collection_id,
             input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),

--- a/lightly_studio/tests/sampling/test_metadata_balancing.py
+++ b/lightly_studio/tests/sampling/test_metadata_balancing.py
@@ -170,6 +170,49 @@ def test_get_metadata_balancing_data__more_values_than_balanced(db_session: Sess
     )
 
 
+def test_get_metadata_balancing_data__target_values_at_limit(db_session: Session) -> None:
+    """Accepts an explicit target that holds exactly as many values as are balanced."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=["sunny", "rainy"], metadata_key="weather"
+    )
+    target_distribution = {
+        f"value_{index:03d}": 0.0 for index in range(metadata_balancing.MAX_BALANCED_VALUES)
+    }
+
+    value_distributions, target_values = metadata_balancing.get_metadata_balancing_data(
+        session=db_session,
+        strat=MetadataBalancingStrategy(
+            metadata_key="weather", target_distribution=target_distribution
+        ),
+        collection_id=collection_id,
+        input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),
+    )
+
+    # No sample matches a target value, so both fall into the appended "other" column.
+    assert value_distributions.shape == (2, metadata_balancing.MAX_BALANCED_VALUES + 1)
+    assert len(target_values) == metadata_balancing.MAX_BALANCED_VALUES + 1
+
+
+def test_get_metadata_balancing_data__too_many_target_values(db_session: Session) -> None:
+    """Rejects an explicit target that holds more values than are balanced."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session, metadata=["sunny", "rainy"], metadata_key="weather"
+    )
+    target_distribution = {
+        f"value_{index:03d}": 0.0 for index in range(metadata_balancing.MAX_BALANCED_VALUES + 1)
+    }
+
+    with pytest.raises(ValueError, match="supports at most"):
+        metadata_balancing.get_metadata_balancing_data(
+            session=db_session,
+            strat=MetadataBalancingStrategy(
+                metadata_key="weather", target_distribution=target_distribution
+            ),
+            collection_id=collection_id,
+            input_sample_ids=_all_sample_ids(session=db_session, collection_id=collection_id),
+        )
+
+
 @pytest.mark.parametrize(
     ("metadata", "metadata_key", "balanced_key", "expected_error"),
     [

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -24,6 +24,7 @@ from lightly_studio.sampling.sampling_config import (
     EmbeddingDeduplicationStrategy,
     EmbeddingDiversityStrategy,
     EmbeddingSimilarityStrategy,
+    MetadataBalancingStrategy,
     SamplingConfig,
     SamplingStrategy,
 )
@@ -36,9 +37,11 @@ from tests.helpers_resolvers import (
     AnnotationDetails,
     create_annotation_label,
     create_annotations,
+    create_image,
     create_tag,
     fill_db_with_samples_and_embeddings,
 )
+from tests.sampling import helpers_sampling
 
 
 def test_sampling_via_database__embedding_diversity(
@@ -1234,6 +1237,97 @@ def test_check_result_tag_name_free__existing_tag_is_not_the_preselected_one(
                 strategies=[],
             ),
         )
+
+
+def test_sampling_via_database__metadata_balancing(db_session: Session) -> None:
+    """Balances a categorical metadata key towards a uniform distribution.
+
+    The distributions themselves are covered by `tests/sampling/test_metadata_balancing.py`.
+    """
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session,
+        metadata=["sunny", "sunny", "rainy"],
+        metadata_key="weather",
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+    config = SamplingConfig(
+        n_samples_to_select=2,
+        collection_id=collection_id,
+        sampling_result_tag_name="sampling-tag",
+        strategies=[
+            MetadataBalancingStrategy(metadata_key="weather", target_distribution="uniform")
+        ],
+    )
+
+    sampling_via_database(session=db_session, config=config, input_sample_ids=sample_ids)
+
+    tags = tag_resolver.get_all_by_collection_id(session=db_session, collection_id=collection_id)
+    selected = _sample_ids_by_tag(db_session, collection_id, tags[0].tag_id)
+    # One sunny and one rainy sample give the uniform distribution, so the only rainy
+    # sample must be selected.
+    assert len(selected) == 2
+    rainy_sample_id = sample_ids[2]
+    assert rainy_sample_id in selected
+
+
+def test_sampling_via_database__metadata_balancing_missing_values_not_dropped(
+    db_session: Session,
+) -> None:
+    """Keeps samples without a value for the balanced key selectable."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session,
+        metadata=["sunny", "rainy"],
+        metadata_key="weather",
+    )
+    # A third sample that has no "weather" value at all.
+    create_image(session=db_session, collection_id=collection_id, file_path_abs="no_weather.jpg")
+    sample_ids = _all_sample_ids(db_session, collection_id)
+    config = SamplingConfig(
+        n_samples_to_select=3,
+        collection_id=collection_id,
+        sampling_result_tag_name="sampling-tag",
+        strategies=[
+            MetadataBalancingStrategy(metadata_key="weather", target_distribution="uniform")
+        ],
+    )
+
+    sampling_via_database(session=db_session, config=config, input_sample_ids=sample_ids)
+
+    tags = tag_resolver.get_all_by_collection_id(session=db_session, collection_id=collection_id)
+    assert len(_sample_ids_by_tag(db_session, collection_id, tags[0].tag_id)) == 3
+
+
+def test_sampling_via_database__metadata_balancing_two_keys(
+    db_session: Session, mocker: MockerFixture
+) -> None:
+    """Balances two metadata keys by combining one strategy per key."""
+    collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
+        session=db_session,
+        metadata=["sunny", "sunny", "rainy"],
+        metadata_key="weather",
+    )
+    helpers_sampling.fill_db_metadata(
+        session=db_session,
+        collection_id=collection_id,
+        metadata=["day", "night", "night"],
+        metadata_key="time_of_day",
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+    config = SamplingConfig(
+        n_samples_to_select=2,
+        collection_id=collection_id,
+        sampling_result_tag_name="sampling-tag",
+        strategies=[
+            MetadataBalancingStrategy(metadata_key="weather", target_distribution="uniform"),
+            MetadataBalancingStrategy(metadata_key="time_of_day", target_distribution="uniform"),
+        ],
+    )
+
+    spy_add_class_balancing = mocker.spy(Mundig, "add_class_balancing")
+    sampling_via_database(session=db_session, config=config, input_sample_ids=sample_ids)
+
+    # Each key is balanced on its own, so each adds its own balancing strategy.
+    assert spy_add_class_balancing.call_count == 2
 
 
 def test_aggregate_class_distributions() -> None:

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -1240,10 +1240,7 @@ def test_check_result_tag_name_free__existing_tag_is_not_the_preselected_one(
 
 
 def test_sampling_via_database__metadata_balancing(db_session: Session) -> None:
-    """Balances a categorical metadata key towards a uniform distribution.
-
-    The distributions themselves are covered by `tests/sampling/test_metadata_balancing.py`.
-    """
+    """Balances a categorical metadata key towards a uniform distribution."""
     collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
         session=db_session,
         metadata=["sunny", "sunny", "rainy"],
@@ -1265,8 +1262,6 @@ def test_sampling_via_database__metadata_balancing(db_session: Session) -> None:
     selected = _sample_ids_by_tag(
         session=db_session, collection_id=collection_id, tag_id=tags[0].tag_id
     )
-    # One sunny and one rainy sample give the uniform distribution, so the only rainy
-    # sample must be selected.
     assert len(selected) == 2
     rainy_sample_id = sample_ids[2]
     assert rainy_sample_id in selected

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -1249,7 +1249,7 @@ def test_sampling_via_database__metadata_balancing(db_session: Session) -> None:
         metadata=["sunny", "sunny", "rainy"],
         metadata_key="weather",
     )
-    sample_ids = _all_sample_ids(db_session, collection_id)
+    sample_ids = _all_sample_ids(session=db_session, collection_id=collection_id)
     config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
@@ -1262,7 +1262,9 @@ def test_sampling_via_database__metadata_balancing(db_session: Session) -> None:
     sampling_via_database(session=db_session, config=config, input_sample_ids=sample_ids)
 
     tags = tag_resolver.get_all_by_collection_id(session=db_session, collection_id=collection_id)
-    selected = _sample_ids_by_tag(db_session, collection_id, tags[0].tag_id)
+    selected = _sample_ids_by_tag(
+        session=db_session, collection_id=collection_id, tag_id=tags[0].tag_id
+    )
     # One sunny and one rainy sample give the uniform distribution, so the only rainy
     # sample must be selected.
     assert len(selected) == 2
@@ -1281,7 +1283,7 @@ def test_sampling_via_database__metadata_balancing_missing_values_not_dropped(
     )
     # A third sample that has no "weather" value at all.
     create_image(session=db_session, collection_id=collection_id, file_path_abs="no_weather.jpg")
-    sample_ids = _all_sample_ids(db_session, collection_id)
+    sample_ids = _all_sample_ids(session=db_session, collection_id=collection_id)
     config = SamplingConfig(
         n_samples_to_select=3,
         collection_id=collection_id,
@@ -1294,7 +1296,10 @@ def test_sampling_via_database__metadata_balancing_missing_values_not_dropped(
     sampling_via_database(session=db_session, config=config, input_sample_ids=sample_ids)
 
     tags = tag_resolver.get_all_by_collection_id(session=db_session, collection_id=collection_id)
-    assert len(_sample_ids_by_tag(db_session, collection_id, tags[0].tag_id)) == 3
+    selected = _sample_ids_by_tag(
+        session=db_session, collection_id=collection_id, tag_id=tags[0].tag_id
+    )
+    assert len(selected) == 3
 
 
 def test_sampling_via_database__metadata_balancing_two_keys(
@@ -1312,7 +1317,7 @@ def test_sampling_via_database__metadata_balancing_two_keys(
         metadata=["day", "night", "night"],
         metadata_key="time_of_day",
     )
-    sample_ids = _all_sample_ids(db_session, collection_id)
+    sample_ids = _all_sample_ids(session=db_session, collection_id=collection_id)
     config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,


### PR DESCRIPTION
## What has changed and why?

This PR adds a sampling strategy that balances the selection over the values of one categorical metadata key. The strategy works from Python with `multi_strategies([MetadataBalancingStrategy(...)])` and over the REST API with `"strategy_name": "metadata_balance"`. The public `Sampling.metadata_balancing()` method, the docs, and the example are in PR 3 (#2092).


This PR is 2 of 3 and it follows #2090, which is now merged. Of the 677 added lines, 428 are tests.

## How has it been tested?

```bash
cd lightly_studio
uv run pytest tests/sampling/ tests/api/routes/api/test_sampling.py
```

Result: 101 passed. `make static-checks` is clean.

- `tests/sampling/test_metadata_balancing.py` holds 12 tests on `get_metadata_balancing_data`. They cover:
  - the three target distributions and boolean values
  - a target value that no sample has, missing values, and no values at all
  - more distinct values than the strategy balances
  - an explicit target at the limit and above the limit
  - the three error cases

  These are unit tests and not full samplings, because none of them assert anything about the selection.

- `test_sampling_via_db.py` keeps the three cases that need a real sampling: the uniform selection, that a sample without a value stays selectable, and that two keys each add their own balancing. The API route tests cover the `metadata_balance` payload and the rejection of a non-categorical key.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

The user-facing entry is in PR 3, together with the public method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata-based sampling for categorical values.
  * Supports uniform, input-proportional, and custom target distributions.
  * Handles boolean values, missing metadata, and high-cardinality fields.
  * Supports combining multiple metadata-balancing strategies.

* **Bug Fixes**
  * Added validation for unsupported metadata fields and invalid target distributions.

* **Tests**
  * Added coverage for metadata balancing, edge cases, missing values, and combined strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
