### PR TITLE
Adjust collection embedding model table

### DIFF
--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -19,8 +19,8 @@ from lightly_studio.models.collection import (
 from lightly_studio.models.dataset import (
     DatasetTable,  # noqa: F401, required for SQLModel to work properly
 )
-from lightly_studio.models.default_embedding_space import (
-    DefaultEmbeddingSpaceTable,  # noqa: F401, required for SQLModel to work properly
+from lightly_studio.models.collection_embedding_model import (
+    CollectionEmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly
 )
 from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly

--- a/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
@@ -18,7 +18,7 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import (
     annotation_resolver,
-    default_embedding_space_resolver,
+    collection_embedding_model_resolver,
     image_resolver,
     twodim_embedding_resolver,
     video_resolver,
@@ -55,7 +55,7 @@ def get_2d_embeddings(
     _validate_filter_type(collection=collection, filters=body.filters)
 
     # TODO(Malte, 09/2025): Support choosing the embedding model via API parameter.
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -23,8 +23,8 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate, Embeddin
 from lightly_studio.models.sample_embedding import SampleEmbeddingCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -184,17 +184,17 @@ class EmbeddingManager:
 
         # Record the default in two places: the in-memory map caches the loaded generator
         # for this process, and the default_embedding_space table persists the choice for
-        # query-layer callers (default_embedding_space_resolver.get_by_collection_id).
+        # query-layer callers (collection_embedding_model_resolver.get_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
         if (
             set_as_default
-            or default_embedding_space_resolver.get_by_collection_id(
+            or collection_embedding_model_resolver.get_by_collection_id(
                 session=session, collection_id=collection_id
             )
             is None
         ):
-            default_embedding_space_resolver.set_default(
+            collection_embedding_model_resolver.set_default(
                 session=session, collection_id=collection_id, embedding_model_id=model_id
             )
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -185,6 +185,9 @@ class EmbeddingManager:
         # Record the default in two places: the in-memory map caches the loaded generator
         # for this process, and the collection_embedding_model table persists the choice for
         # query-layer callers (collection_embedding_model_resolver.get_by_collection_id).
+        # TODO(Michal, 08/2026): Update to use the updated collection_embedding_model_resolver
+        # interface once ready. Currently, registering multiple collection models might lead
+        # to an inconsistent state.
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
         if (

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -183,7 +183,7 @@ class EmbeddingManager:
         self._models[model_id] = embedding_generator
 
         # Record the default in two places: the in-memory map caches the loaded generator
-        # for this process, and the default_embedding_space table persists the choice for
+        # for this process, and the collection_embedding_model table persists the choice for
         # query-layer callers (collection_embedding_model_resolver.get_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -33,8 +33,8 @@ from lightly_studio.models.image import ImageTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -124,7 +124,7 @@ class ClassifierManager:
         Returns:
             The created classifier name and ID.
         """
-        embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
             session=session,
             collection_id=collection_id,
         )
@@ -626,7 +626,7 @@ def _get_embedding_model_by_hash(
         raise ValueError(f"Collection {collection_id} not found.")
 
     # TODO(Michal, 08/2026): Remove once embedding models are unique per dataset and hash.
-    default_embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    default_embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session, collection_id=collection_id
     )
     if default_embedding_model_id is not None:

--- a/lightly_studio/src/lightly_studio/migrations/env.py
+++ b/lightly_studio/src/lightly_studio/migrations/env.py
@@ -57,7 +57,11 @@ def _include_object(
 
     Used only by ``revision --autogenerate``; ``upgrade`` does not call this hook.
     """
-    return not (type_ == "index" and name == "uq_collection_name_root")
+    postgres_only_indexes = {
+        "uq_collection_name_root",
+        "uq_collection_embedding_model_default",
+    }
+    return not (type_ == "index" and name in postgres_only_indexes)
 
 
 def _run_migrations_on(connection: Connection) -> None:

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
@@ -48,7 +48,9 @@ def upgrade() -> None:
         sa.Column("is_default", sa.Boolean(), nullable=False),
     )
     _backfill_defaults()
-    # At most one default embedding model per collection.
+    # At most one default embedding model per collection. Postgres-only: DuckDB cannot
+    # create partial indexes, so on DuckDB the invariant is not enforced at the database
+    # level and callers must maintain it.
     op.create_index(
         "uq_collection_embedding_model_default",
         "collection_embedding_model",

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
@@ -1,14 +1,17 @@
 """rename default embedding space to collection embedding model.
 
 Renames the `default_embedding_space` table to `collection_embedding_model` and adds an
-`is_default` flag. The current contents are dropped and re-seeded from `embedding_model`
-(the oldest model per collection by `created_at ASC, embedding_model_id ASC`, the same
-rule the earlier backfill used), so every seeded row is a default and `is_default` is
-`true`.
+`is_default` flag. The current contents are dropped and re-seeded from `embedding_model`:
+one row per model, so a collection with several models gets a row for each. Only the
+oldest model per collection (by `created_at ASC, embedding_model_id ASC`) is the default,
+with `is_default = true`; the rest are `false`.
 
 Re-seeding from `embedding_model` keeps this migration independent of the table's prior
-contents. It reads `embedding_model.collection_id`, which still exists at this revision
-(its drop lands in a later revision).
+contents. The prior `default_embedding_space` rows held only the defaults, which this
+backfill reproduces from `embedding_model`, so dropping them loses nothing. It reads
+`embedding_model.collection_id`, which still exists at this revision (its drop lands in a
+later revision). This table is where `collection_id` moves to as it is removed from
+`embedding_model`.
 
 A partial unique index then enforces at most one default per collection. It is
 Postgres-only (DuckDB cannot create partial indexes), so it is not declared on
@@ -58,7 +61,7 @@ def upgrade() -> None:
         "collection_embedding_model",
         ["collection_id", "embedding_model_id"],
     )
-    _backfill_defaults()
+    _backfill_collection_embedding_models()
     # At most one default embedding model per collection. Postgres-only: DuckDB cannot
     # create partial indexes, so on DuckDB the invariant is not enforced at the database
     # level and callers must maintain it.
@@ -84,19 +87,26 @@ def downgrade() -> None:
     op.rename_table("collection_embedding_model", "default_embedding_space")
 
 
-def _backfill_defaults() -> None:
-    """Seed one default per collection: its oldest embedding model.
+def _backfill_collection_embedding_models() -> None:
+    """Seed every embedding model per collection, the oldest one as the default.
 
-    `DISTINCT ON` keeps the first row per `collection_id` under the `ORDER BY`, so the
-    `created_at ASC, embedding_model_id ASC` tie-break selects the oldest model.
+    Each `embedding_model` row becomes one `collection_embedding_model` row. `ROW_NUMBER`
+    ranks a collection's models by `created_at ASC, embedding_model_id ASC`, so rank 1 is
+    the oldest; only that row gets `is_default = true`, which satisfies the one-default
+    -per-collection partial unique index.
     """
     op.get_bind().execute(
         sa.text(
             """
             INSERT INTO collection_embedding_model (collection_id, embedding_model_id, is_default)
-            SELECT DISTINCT ON (collection_id) collection_id, embedding_model_id, true
+            SELECT
+                collection_id,
+                embedding_model_id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY collection_id
+                    ORDER BY created_at ASC, embedding_model_id ASC
+                ) = 1 AS is_default
             FROM embedding_model
-            ORDER BY collection_id, created_at ASC, embedding_model_id ASC
             """
         )
     )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
@@ -1,0 +1,83 @@
+"""rename default embedding space to collection embedding model.
+
+Renames the `default_embedding_space` table to `collection_embedding_model` and adds an
+`is_default` flag. The current contents are dropped and re-seeded from `embedding_model`
+(the oldest model per collection by `created_at ASC, embedding_model_id ASC`, the same
+rule the earlier backfill used), so every seeded row is a default and `is_default` is
+`true`.
+
+Re-seeding from `embedding_model` keeps this migration independent of the table's prior
+contents. It reads `embedding_model.collection_id`, which still exists at this revision
+(its drop lands in a later revision).
+
+A partial unique index then enforces at most one default per collection. It is
+Postgres-only (DuckDB cannot create partial indexes), so it is not declared on
+`CollectionEmbeddingModelTable` and `_include_object` in `migrations/env.py` keeps
+autogenerate from dropping it.
+
+DuckDB builds its schema with `create_all` and has no backfill step, so this migration
+only matters for tracked Postgres databases.
+
+Revision ID: d4e5f6a7b8c9
+Revises: c2d3e4f5a6b7
+Create Date: 2026-08-26 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "c2d3e4f5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.rename_table("default_embedding_space", "collection_embedding_model")
+    # Empty first so the new NOT NULL column needs no server default; the rows are
+    # re-seeded below.
+    op.get_bind().execute(sa.text("DELETE FROM collection_embedding_model"))
+    op.add_column(
+        "collection_embedding_model",
+        sa.Column("is_default", sa.Boolean(), nullable=False),
+    )
+    _backfill_defaults()
+    # At most one default embedding model per collection.
+    op.create_index(
+        "uq_collection_embedding_model_default",
+        "collection_embedding_model",
+        ["collection_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("uq_collection_embedding_model_default", table_name="collection_embedding_model")
+    op.drop_column("collection_embedding_model", "is_default")
+    op.rename_table("collection_embedding_model", "default_embedding_space")
+
+
+def _backfill_defaults() -> None:
+    """Seed one default per collection: its oldest embedding model.
+
+    `DISTINCT ON` keeps the first row per `collection_id` under the `ORDER BY`, so the
+    `created_at ASC, embedding_model_id ASC` tie-break selects the oldest model.
+    """
+    op.get_bind().execute(
+        sa.text(
+            """
+            INSERT INTO collection_embedding_model (collection_id, embedding_model_id, is_default)
+            SELECT DISTINCT ON (collection_id) collection_id, embedding_model_id, true
+            FROM embedding_model
+            ORDER BY collection_id, created_at ASC, embedding_model_id ASC
+            """
+        )
+    )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
@@ -80,6 +80,9 @@ def downgrade() -> None:
     op.drop_constraint(
         "collection_embedding_model_pkey", "collection_embedding_model", type_="primary"
     )
+    # The old table held one row per collection (its default). Drop the non-default rows
+    # so the collection-only primary key has no duplicate collection_id values.
+    op.get_bind().execute(sa.text("DELETE FROM collection_embedding_model WHERE NOT is_default"))
     op.create_primary_key(
         "default_embedding_space_pkey", "collection_embedding_model", ["collection_id"]
     )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787846400_d4e5f6a7b8c9_rename_default_embedding_space_to_collection_embedding_model.py
@@ -47,6 +47,17 @@ def upgrade() -> None:
         "collection_embedding_model",
         sa.Column("is_default", sa.Boolean(), nullable=False),
     )
+    # A collection may now use several embedding models, so the primary key becomes the
+    # (collection_id, embedding_model_id) pair. Renaming the table left the old key
+    # constraint under its original name, so drop it before adding the composite one.
+    op.drop_constraint(
+        "default_embedding_space_pkey", "collection_embedding_model", type_="primary"
+    )
+    op.create_primary_key(
+        "collection_embedding_model_pkey",
+        "collection_embedding_model",
+        ["collection_id", "embedding_model_id"],
+    )
     _backfill_defaults()
     # At most one default embedding model per collection. Postgres-only: DuckDB cannot
     # create partial indexes, so on DuckDB the invariant is not enforced at the database
@@ -63,6 +74,12 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade schema."""
     op.drop_index("uq_collection_embedding_model_default", table_name="collection_embedding_model")
+    op.drop_constraint(
+        "collection_embedding_model_pkey", "collection_embedding_model", type_="primary"
+    )
+    op.create_primary_key(
+        "default_embedding_space_pkey", "collection_embedding_model", ["collection_id"]
+    )
     op.drop_column("collection_embedding_model", "is_default")
     op.rename_table("collection_embedding_model", "default_embedding_space")
 

--- a/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
@@ -8,15 +8,20 @@ from sqlmodel import Field, SQLModel
 
 
 class CollectionEmbeddingModelTable(SQLModel, table=True):
-    """Link table: the default embedding space of a collection.
+    """Link table: an embedding model used by a collection.
 
-    One row per collection (the ``collection_id`` primary key enforces this). The
-    embedding space is identified by the embedding model that produced it, so the row
-    points at the ``embedding_model`` used whenever a caller does not name one
-    explicitly, e.g. the 2D projection endpoints and similarity search.
+    One row per collection (the ``collection_id`` primary key enforces this). The row
+    points at the ``embedding_model`` used whenever a caller does not name one explicitly,
+    e.g. the 2D projection endpoints and similarity search. ``is_default`` flags that
+    model as the collection's default.
+
+    A partial unique index enforces at most one default per collection. It is Postgres-only
+    (DuckDB cannot create partial indexes), so it lives in the migration rather than here,
+    and ``_include_object`` in ``migrations/env.py`` keeps autogenerate from dropping it.
     """
 
-    __tablename__ = "default_embedding_space"
+    __tablename__ = "collection_embedding_model"
 
     collection_id: UUID = Field(foreign_key="collection.collection_id", primary_key=True)
     embedding_model_id: UUID = Field(foreign_key="embedding_model.embedding_model_id")
+    is_default: bool = Field(default=True)

--- a/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
@@ -26,4 +26,4 @@ class CollectionEmbeddingModelTable(SQLModel, table=True):
 
     collection_id: UUID = Field(foreign_key="collection.collection_id", primary_key=True)
     embedding_model_id: UUID = Field(foreign_key="embedding_model.embedding_model_id")
-    is_default: bool = Field(default=True)
+    is_default: bool = Field(default=False)

--- a/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
@@ -1,4 +1,4 @@
-"""This module defines the DefaultEmbeddingSpace model for the application."""
+"""This module defines the CollectionEmbeddingModel model for the application."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlmodel import Field, SQLModel
 
 
-class DefaultEmbeddingSpaceTable(SQLModel, table=True):
+class CollectionEmbeddingModelTable(SQLModel, table=True):
     """Link table: the default embedding space of a collection.
 
     One row per collection (the ``collection_id`` primary key enforces this). The

--- a/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
@@ -10,10 +10,10 @@ from sqlmodel import Field, SQLModel
 class CollectionEmbeddingModelTable(SQLModel, table=True):
     """Link table: an embedding model used by a collection.
 
-    One row per collection (the ``collection_id`` primary key enforces this). The row
-    points at the ``embedding_model`` used whenever a caller does not name one explicitly,
-    e.g. the 2D projection endpoints and similarity search. ``is_default`` flags that
-    model as the collection's default.
+    One row per (collection, embedding model) pair, enforced by the composite
+    ``(collection_id, embedding_model_id)`` primary key. A row records that the model is
+    used by the collection, e.g. for the 2D projection endpoints and similarity search.
+    ``is_default`` flags one of those models as the collection's default.
 
     A partial unique index enforces at most one default per collection, but only on
     Postgres. DuckDB cannot create partial indexes, so the index lives in the migration
@@ -25,5 +25,7 @@ class CollectionEmbeddingModelTable(SQLModel, table=True):
     __tablename__ = "collection_embedding_model"
 
     collection_id: UUID = Field(foreign_key="collection.collection_id", primary_key=True)
-    embedding_model_id: UUID = Field(foreign_key="embedding_model.embedding_model_id")
+    embedding_model_id: UUID = Field(
+        foreign_key="embedding_model.embedding_model_id", primary_key=True
+    )
     is_default: bool = Field(default=False)

--- a/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
@@ -15,9 +15,11 @@ class CollectionEmbeddingModelTable(SQLModel, table=True):
     e.g. the 2D projection endpoints and similarity search. ``is_default`` flags that
     model as the collection's default.
 
-    A partial unique index enforces at most one default per collection. It is Postgres-only
-    (DuckDB cannot create partial indexes), so it lives in the migration rather than here,
-    and ``_include_object`` in ``migrations/env.py`` keeps autogenerate from dropping it.
+    A partial unique index enforces at most one default per collection, but only on
+    Postgres. DuckDB cannot create partial indexes, so the index lives in the migration
+    rather than here (``_include_object`` in ``migrations/env.py`` keeps autogenerate from
+    dropping it). On DuckDB the invariant is not enforced at the database level; callers
+    must maintain it.
     """
 
     __tablename__ = "collection_embedding_model"

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -1,4 +1,8 @@
-"""Handler for database operations related to a collection's default embedding space."""
+"""Handler for database operations related to a collection's default embedding space.
+
+TODO(Michal, 08/2026): Rename the functions and change the interface so that it reflects
+the new "all collection models" semantics, not the old "only default model" semantics.
+"""
 
 from __future__ import annotations
 

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 
@@ -12,10 +12,12 @@ from lightly_studio.models.collection_embedding_model import CollectionEmbedding
 def set_default(
     session: Session, collection_id: UUID, embedding_model_id: UUID
 ) -> CollectionEmbeddingModelTable:
-    """Set (or replace) the default embedding space of a collection.
+    """Set the default embedding model of a collection.
 
-    A collection has at most one default, so an existing row is updated in place rather
-    than inserted a second time.
+    A collection may link several embedding models but has at most one default. The
+    current default (if any) is cleared and the target model is flagged instead. The
+    target keeps its existing link row when it already has one, so the composite primary
+    key is never mutated.
 
     Args:
         session: The database session.
@@ -23,22 +25,33 @@ def set_default(
         embedding_model_id: The embedding model to record as the default.
 
     Returns:
-        The persisted default embedding space row.
+        The persisted default embedding model row.
     """
-    default = _get_by_collection_id(session=session, collection_id=collection_id)
-    if default is None:
-        default = CollectionEmbeddingModelTable(
+    current_default = _get_by_collection_id(session=session, collection_id=collection_id)
+    if current_default is not None and current_default.embedding_model_id == embedding_model_id:
+        return current_default
+
+    # Clear the old default first so the one-default-per-collection unique index (Postgres)
+    # never sees two defaults at once.
+    if current_default is not None:
+        current_default.is_default = False
+        session.add(current_default)
+        session.flush()
+
+    target = session.get(CollectionEmbeddingModelTable, (collection_id, embedding_model_id))
+    if target is None:
+        target = CollectionEmbeddingModelTable(
             collection_id=collection_id,
             embedding_model_id=embedding_model_id,
             is_default=True,
         )
     else:
-        default.embedding_model_id = embedding_model_id
+        target.is_default = True
 
-    session.add(default)
+    session.add(target)
     session.commit()
-    session.refresh(default)
-    return default
+    session.refresh(target)
+    return target
 
 
 def get_by_collection_id(session: Session, collection_id: UUID) -> UUID | None:
@@ -65,9 +78,10 @@ def delete_by_collection_id(session: Session, collection_id: UUID) -> bool:
 def _get_by_collection_id(
     session: Session, collection_id: UUID
 ) -> CollectionEmbeddingModelTable | None:
-    """Return the collection's default embedding space row, or None if it has none."""
+    """Return the collection's default embedding model row, or None if it has none."""
     return session.exec(
         select(CollectionEmbeddingModelTable).where(
-            CollectionEmbeddingModelTable.collection_id == collection_id
+            CollectionEmbeddingModelTable.collection_id == collection_id,
+            col(CollectionEmbeddingModelTable.is_default).is_(True),
         )
     ).one_or_none()

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -6,12 +6,12 @@ from uuid import UUID
 
 from sqlmodel import Session, select
 
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 
 
 def set_default(
     session: Session, collection_id: UUID, embedding_model_id: UUID
-) -> DefaultEmbeddingSpaceTable:
+) -> CollectionEmbeddingModelTable:
     """Set (or replace) the default embedding space of a collection.
 
     A collection has at most one default, so an existing row is updated in place rather
@@ -27,7 +27,7 @@ def set_default(
     """
     default = _get_by_collection_id(session=session, collection_id=collection_id)
     if default is None:
-        default = DefaultEmbeddingSpaceTable(
+        default = CollectionEmbeddingModelTable(
             collection_id=collection_id, embedding_model_id=embedding_model_id
         )
     else:
@@ -62,10 +62,10 @@ def delete_by_collection_id(session: Session, collection_id: UUID) -> bool:
 
 def _get_by_collection_id(
     session: Session, collection_id: UUID
-) -> DefaultEmbeddingSpaceTable | None:
+) -> CollectionEmbeddingModelTable | None:
     """Return the collection's default embedding space row, or None if it has none."""
     return session.exec(
-        select(DefaultEmbeddingSpaceTable).where(
-            DefaultEmbeddingSpaceTable.collection_id == collection_id
+        select(CollectionEmbeddingModelTable).where(
+            CollectionEmbeddingModelTable.collection_id == collection_id
         )
     ).one_or_none()

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -28,7 +28,9 @@ def set_default(
     default = _get_by_collection_id(session=session, collection_id=collection_id)
     if default is None:
         default = CollectionEmbeddingModelTable(
-            collection_id=collection_id, embedding_model_id=embedding_model_id
+            collection_id=collection_id,
+            embedding_model_id=embedding_model_id,
+            is_default=True,
         )
     else:
         default.embedding_model_id = embedding_model_id

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -43,8 +43,8 @@ from lightly_studio.models.annotation_collection_coverage import (
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import (
     EvaluationAnnotationMetricTable,
@@ -789,7 +789,7 @@ def _copy_default_embedding_spaces(session: Session) -> None:
     The inner joins on the collection and embedding-model maps drop any row whose
     collection or model is not part of the dataset.
     """
-    src = _table(DefaultEmbeddingSpaceTable).alias("src")
+    src = _table(CollectionEmbeddingModelTable).alias("src")
     map_collection = _map(_MAP_COLLECTION)
     map_model = _map(_MAP_EMBEDDING_MODEL)
     from_clause = src.join(map_collection, map_collection.c.old_id == src.c["collection_id"]).join(
@@ -801,7 +801,7 @@ def _copy_default_embedding_spaces(session: Session) -> None:
     }
     _copy_table(
         session=session,
-        target=DefaultEmbeddingSpaceTable,
+        target=CollectionEmbeddingModelTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -36,8 +36,8 @@ from lightly_studio.models.annotation_collection_coverage import (
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -323,8 +323,10 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
 def _delete_default_embedding_spaces(session: Session, dataset_id: UUID) -> None:
     """Delete default embedding spaces for the dataset's collections."""
     session.exec(
-        delete(DefaultEmbeddingSpaceTable).where(
-            col(DefaultEmbeddingSpaceTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        delete(CollectionEmbeddingModelTable).where(
+            col(CollectionEmbeddingModelTable.collection_id).in_(
+                _collection_ids_subquery(dataset_id)
+            )
         ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,7 +11,7 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
-# - default_embedding_space is handled by both deep_copy and delete_dataset.
+# - collection_embedding_model is handled by both deep_copy and delete_dataset.
 _HANDLED_TABLES_COUNT = 26
 
 # Tables not relevant for collection operations:

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,7 +11,6 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
-# - collection_embedding_model is handled by both deep_copy and delete_dataset.
 _HANDLED_TABLES_COUNT = 26
 
 # Tables not relevant for collection operations:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -15,7 +15,7 @@ from numpy.typing import NDArray
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_region import EmbeddingRegion
-from lightly_studio.resolvers import default_embedding_space_resolver, twodim_embedding_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver, twodim_embedding_resolver
 
 
 def get_sample_ids_in_region(
@@ -28,7 +28,7 @@ def get_sample_ids_in_region(
     # so the region is tested against the exact projection the user lassoed over.
     # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
     # matching embeddings2d.get_2d_embeddings.
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, col
 
 from lightly_studio.database import db_vector
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
-from lightly_studio.resolvers import default_embedding_space_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver
 from lightly_studio.type_definitions import QueryType
 
 
@@ -27,7 +27,7 @@ def get_distance_expression(
     if not text_embedding:
         return None, None
 
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session, collection_id=collection_id
     )
 

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -75,6 +75,26 @@ def _reset_postgres_database(engine_url: str) -> None:
         raw_engine.dispose()
 
 
+def _restore_shared_database_to_head(engine: Engine, engine_url: str) -> None:
+    """Return the session-scoped Postgres database to a clean schema at head.
+
+    These migration tests run against the ``postgres_url`` database, which is session
+    scoped and shared with every data test on the same xdist worker. A test that
+    downgrades or resets that database leaves the schema off head, so the data tests find
+    the wrong tables and their ``TRUNCATE`` teardown fails. Upgrading to head first
+    normalizes the table names (a downgrade may have renamed one), then a drop and a fresh
+    upgrade leave an empty schema matching the session engine's initial state.
+    """
+    config = db_migrations.get_alembic_config(engine_url=engine_url)
+    db_migrations._run_alembic_command(
+        engine=engine, config=config, fn=command.upgrade, revision="head"
+    )
+    _reset_postgres_database(engine_url=engine_url)
+    db_migrations._run_alembic_command(
+        engine=engine, config=config, fn=command.upgrade, revision="head"
+    )
+
+
 def test_postgres_fresh_database__upgrade_head(
     postgres_url: str | None,
 ) -> None:
@@ -98,6 +118,7 @@ def test_postgres_fresh_database__upgrade_head(
             ).scalar_one()
         assert version == head_revision
     finally:
+        _restore_shared_database_to_head(engine=engine._engine, engine_url=postgres_url)
         engine.close()
 
 
@@ -173,6 +194,7 @@ def test_postgres_embedding_model_dataset_id__backfilled(
         config.attributes.pop("connection", None)
         command.check(config)
     finally:
+        _restore_shared_database_to_head(engine=engine, engine_url=postgres_url)
         engine.dispose()
 
 
@@ -282,4 +304,5 @@ def test_postgres_collection_embedding_model__backfills_all_models(
             ).all()
         assert [str(model_id) for (model_id,) in remaining] == [older_model_id]
     finally:
+        _restore_shared_database_to_head(engine=engine, engine_url=postgres_url)
         engine.dispose()

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -261,5 +261,25 @@ def test_postgres_collection_embedding_model__backfills_all_models(
 
         defaults = {str(model_id): is_default for model_id, is_default in rows}
         assert defaults == {older_model_id: True, newer_model_id: False}
+
+        # Downgrade must keep only the default row so the collection-only key holds.
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.downgrade,
+            revision="c2d3e4f5a6b7",
+        )
+        with engine.connect() as connection:
+            remaining = connection.execute(
+                statement=text(
+                    """
+                    SELECT embedding_model_id
+                    FROM default_embedding_space
+                    WHERE collection_id = :collection_id
+                    """
+                ),
+                parameters={"collection_id": collection_id},
+            ).all()
+        assert [str(model_id) for (model_id,) in remaining] == [older_model_id]
     finally:
         engine.dispose()

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -174,3 +174,92 @@ def test_postgres_embedding_model_dataset_id__backfilled(
         command.check(config)
     finally:
         engine.dispose()
+
+
+def test_postgres_collection_embedding_model__backfills_all_models(
+    postgres_url: str | None,
+) -> None:
+    """The rename migration seeds every embedding model, the oldest one as default."""
+    if postgres_url is None:
+        pytest.skip("Requires --postgres")
+
+    _reset_postgres_database(engine_url=postgres_url)
+    normalized_url = db_url.ensure_psycopg3_driver(engine_url=postgres_url)
+    engine = create_engine(normalized_url)
+    config = db_migrations.get_alembic_config(engine_url=postgres_url)
+    dataset_id = "00000000-0000-0000-0000-000000000001"
+    collection_id = "00000000-0000-0000-0000-000000000002"
+    older_model_id = "00000000-0000-0000-0000-000000000010"
+    newer_model_id = "00000000-0000-0000-0000-000000000011"
+
+    try:
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="c2d3e4f5a6b7",
+        )
+        with engine.begin() as connection:
+            connection.execute(
+                statement=text("INSERT INTO dataset (dataset_id) VALUES (:dataset_id)"),
+                parameters={"dataset_id": dataset_id},
+            )
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO collection (
+                        name, sample_type, collection_id, dataset_id, created_at, updated_at
+                    ) VALUES (
+                        'collection', 'IMAGE', :collection_id, :dataset_id, NOW(), NOW()
+                    )
+                    """
+                ),
+                parameters={"collection_id": collection_id, "dataset_id": dataset_id},
+            )
+            # Two models for the same collection; the older one must become the default.
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO embedding_model (
+                        name, embedding_dimension, collection_id, dataset_id,
+                        embedding_model_id, created_at
+                    ) VALUES (
+                        'older', 128, :collection_id, :dataset_id,
+                        :older_model_id, '2020-01-01 00:00:00+00'
+                    ), (
+                        'newer', 128, :collection_id, :dataset_id,
+                        :newer_model_id, '2021-01-01 00:00:00+00'
+                    )
+                    """
+                ),
+                parameters={
+                    "collection_id": collection_id,
+                    "dataset_id": dataset_id,
+                    "older_model_id": older_model_id,
+                    "newer_model_id": newer_model_id,
+                },
+            )
+
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="d4e5f6a7b8c9",
+        )
+        with engine.connect() as connection:
+            rows = connection.execute(
+                statement=text(
+                    """
+                    SELECT embedding_model_id, is_default
+                    FROM collection_embedding_model
+                    WHERE collection_id = :collection_id
+                    ORDER BY embedding_model_id
+                    """
+                ),
+                parameters={"collection_id": collection_id},
+            ).all()
+
+        defaults = {str(model_id): is_default for model_id, is_default in rows}
+        assert defaults == {older_model_id: True, newer_model_id: False}
+    finally:
+        engine.dispose()

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -22,7 +22,7 @@ from lightly_studio.models.embedding_model import (
 )
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
-    default_embedding_space_resolver,
+    collection_embedding_model_resolver,
     embedding_model_resolver,
 )
 
@@ -66,7 +66,7 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
     )
     created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
     # Register it as the collection's default so it resolves as the collection's model.
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=created.embedding_model_id,

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -30,8 +30,8 @@ from lightly_studio.models.sample_embedding import (
 )
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -56,7 +56,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -84,7 +84,7 @@ class TestClassifierManager:
         """create_classifier raises when the collection has no default embedding model."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=None,
         )
@@ -109,7 +109,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -176,7 +176,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -231,7 +231,7 @@ class TestClassifierManager:
         """Test dropping a classifier in the finetuning step."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -369,7 +369,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier first
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -432,7 +432,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier with initial samples
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -549,7 +549,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -632,7 +632,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -721,7 +721,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -989,7 +989,7 @@ def test_get_embedding_model_by_hash__prefers_default(db_session: Session) -> No
         embedding_model_name="model_in_child",
         embedding_model_hash="same_hash",
     )
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=child.collection_id,
         embedding_model_id=child_model.embedding_model_id,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -37,8 +37,8 @@ from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
     caption_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -310,7 +310,7 @@ def create_embedding_model(  # noqa: PLR0913
     """Helper function to create a embedding model.
 
     With ``set_as_default`` the model is recorded as the collection's default embedding
-    model, so ``default_embedding_space_resolver.get_by_collection_id`` resolves to it. It
+    model, so ``collection_embedding_model_resolver.get_by_collection_id`` resolves to it. It
     is off by default to avoid the ``default_embedding_space`` foreign key blocking model
     or collection deletes in tests that do not need a default.
     """
@@ -330,7 +330,7 @@ def create_embedding_model(  # noqa: PLR0913
         ),
     )
     if set_as_default:
-        default_embedding_space_resolver.set_default(
+        collection_embedding_model_resolver.set_default(
             session=session,
             collection_id=collection_id,
             embedding_model_id=model.embedding_model_id,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -311,7 +311,7 @@ def create_embedding_model(  # noqa: PLR0913
 
     With ``set_as_default`` the model is recorded as the collection's default embedding
     model, so ``collection_embedding_model_resolver.get_by_collection_id`` resolves to it. It
-    is off by default to avoid the ``default_embedding_space`` foreign key blocking model
+    is off by default to avoid the ``collection_embedding_model`` foreign key blocking model
     or collection deletes in tests that do not need a default.
     """
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -18,9 +18,9 @@ from lightly_studio.models.image import ImageCreate
 from lightly_studio.models.temporal_span import TemporalSpanTable
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
     dataset_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
@@ -383,7 +383,7 @@ def test_deep_copy__with_default_embedding_space(db_session: Session) -> None:
     copied_model_id = copied_models[0].embedding_model_id
     assert copied_model_id != embedding_model.embedding_model_id
 
-    copied_default_id = default_embedding_space_resolver.get_by_collection_id(
+    copied_default_id = collection_embedding_model_resolver.get_by_collection_id(
         session=db_session, collection_id=copied.collection_id
     )
     assert copied_default_id == copied_model_id

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -111,7 +111,7 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
         "embedding_model": count(
             EmbeddingModelTable, col(EmbeddingModelTable.collection_id).in_(collection_ids)
         ),
-        "default_embedding_space": count(
+        "collection_embedding_model": count(
             CollectionEmbeddingModelTable,
             col(CollectionEmbeddingModelTable.collection_id).in_(collection_ids),
         ),
@@ -270,7 +270,7 @@ def test_deep_copy_then_delete_round_trip(db_session: Session) -> None:
         "tag",
         "sample_tag_link",
         "embedding_model",
-        "default_embedding_space",
+        "collection_embedding_model",
         "annotation_label",
         "object_track",
         "evaluation_run",

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -20,8 +20,8 @@ from lightly_studio.models.annotation_collection_coverage import AnnotationColle
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -112,8 +112,8 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
             EmbeddingModelTable, col(EmbeddingModelTable.collection_id).in_(collection_ids)
         ),
         "default_embedding_space": count(
-            DefaultEmbeddingSpaceTable,
-            col(DefaultEmbeddingSpaceTable.collection_id).in_(collection_ids),
+            CollectionEmbeddingModelTable,
+            col(CollectionEmbeddingModelTable.collection_id).in_(collection_ids),
         ),
         "annotation_collection_coverage": count(
             AnnotationCollectionCoverageTable,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -14,9 +14,9 @@ from lightly_studio.models.evaluation_run import EvaluationRunCreate, Evaluation
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
     dataset_resolver,
-    default_embedding_space_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
@@ -210,7 +210,7 @@ def test_delete_dataset__with_default_embedding_space(db_session: Session) -> No
     # Assert - collection and its default embedding space deleted
     assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection_id
         )
         is None

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from sqlmodel import Session
+from sqlmodel import Session, col, select
 
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.resolvers import collection_embedding_model_resolver
 from tests.helpers_resolvers import (
     create_collection,
@@ -56,6 +57,59 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         )
         == model_2.embedding_model_id
     )
+
+
+def test_set_default__promotes_existing_link(db_session: Session) -> None:
+    # A collection that already links two models, as after the backfill migration.
+    collection = create_collection(session=db_session)
+    model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_1",
+        embedding_model_hash="hash_1",
+    )
+    model_2 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_2",
+        embedding_model_hash="hash_2",
+    )
+    db_session.add(
+        CollectionEmbeddingModelTable(
+            collection_id=collection.collection_id,
+            embedding_model_id=model_1.embedding_model_id,
+            is_default=True,
+        )
+    )
+    db_session.add(
+        CollectionEmbeddingModelTable(
+            collection_id=collection.collection_id,
+            embedding_model_id=model_2.embedding_model_id,
+            is_default=False,
+        )
+    )
+    db_session.commit()
+
+    collection_embedding_model_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model_2.embedding_model_id,
+    )
+
+    # The existing model_2 link is promoted; model_1 is demoted, so a single default holds.
+    assert (
+        collection_embedding_model_resolver.get_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == model_2.embedding_model_id
+    )
+    defaults = db_session.exec(
+        select(CollectionEmbeddingModelTable).where(
+            CollectionEmbeddingModelTable.collection_id == collection.collection_id,
+            col(CollectionEmbeddingModelTable.is_default).is_(True),
+        )
+    ).all()
+    assert [row.embedding_model_id for row in defaults] == [model_2.embedding_model_id]
 
 
 def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
-from lightly_studio.resolvers import default_embedding_space_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver
 from tests.helpers_resolvers import (
     create_collection,
     create_embedding_model,
@@ -13,7 +13,7 @@ def test_set_default__inserts(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
 
-    default = default_embedding_space_resolver.set_default(
+    default = collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
@@ -38,12 +38,12 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         embedding_model_hash="hash_2",
     )
 
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model_1.embedding_model_id,
     )
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model_2.embedding_model_id,
@@ -51,7 +51,7 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
 
     # The collection still has a single default, now pointing at the second model.
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         == model_2.embedding_model_id
@@ -62,7 +62,7 @@ def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is None
@@ -72,14 +72,14 @@ def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:
 def test_get_by_collection_id__returns_id(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
     )
 
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         == model.embedding_model_id
@@ -89,19 +89,19 @@ def test_get_by_collection_id__returns_id(db_session: Session) -> None:
 def test_delete_by_collection_id__deletes(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
     )
 
-    deleted = default_embedding_space_resolver.delete_by_collection_id(
+    deleted = collection_embedding_model_resolver.delete_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
 
     assert deleted is True
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is None
@@ -112,7 +112,7 @@ def test_delete_by_collection_id__returns_false_when_absent(db_session: Session)
     collection = create_collection(session=db_session)
 
     assert (
-        default_embedding_space_resolver.delete_by_collection_id(
+        collection_embedding_model_resolver.delete_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is False


### PR DESCRIPTION
## What has changed and why?

- Rename the persisted table to `collection_embedding_model` and track the default with `is_default`.
- Allow multiple embedding models per collection with a composite primary key.
- Add the PostgreSQL migration, backfill, and partial unique index for one default per collection.

Not done, scoped to a follow-up (next in stack):
- The resolver functions need to change to allow management of multiple models, not just the default. The current model registration is not completely consistent.

## How has it been tested?

- `make static-checks`
- Targeted resolver and dataset lifecycle tests: 6 passed, 30 skipped.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections can now be linked to multiple embedding models.
  * One embedding model can be designated as the collection’s default.

* **Bug Fixes**
  * Changing the default embedding model now correctly preserves existing model links.
  * Database migrations retain all linked models and select the oldest as the initial default.

* **Tests**
  * Added coverage for migration backfills, default-model switching, and dataset copy/delete workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->