### PR TITLE
Refactor collection_embedding_model_resolver interface

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
@@ -55,7 +55,7 @@ def get_2d_embeddings(
     _validate_filter_type(collection=collection, filters=body.filters)
 
     # TODO(Malte, 09/2025): Support choosing the embedding model via API parameter.
-    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -187,7 +187,7 @@ class EmbeddingManager:
         # query-layer callers (collection_embedding_model_resolver.get_default_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
-        collection_embedding_model_resolver.get_or_create(
+        collection_embedding_model_resolver.get_or_add_collection_model(
             session=session, collection_id=collection_id, embedding_model_id=model_id
         )
         # The first model linked to a collection becomes its default; an explicit request

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -182,17 +182,19 @@ class EmbeddingManager:
 
         self._models[model_id] = embedding_generator
 
-        # Record the default in two places: the in-memory map caches the loaded generator
-        # for this process, and the collection_embedding_model table persists the choice for
-        # query-layer callers (collection_embedding_model_resolver.get_by_collection_id).
-        # TODO(Michal, 08/2026): Update to use the updated collection_embedding_model_resolver
-        # interface once ready. Currently, registering multiple collection models might lead
-        # to an inconsistent state.
+        # Record the model in two places: the in-memory map caches the loaded generator for
+        # this process, and the collection_embedding_model table persists the link for
+        # query-layer callers (collection_embedding_model_resolver.get_default_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
+        collection_embedding_model_resolver.get_or_create(
+            session=session, collection_id=collection_id, embedding_model_id=model_id
+        )
+        # The first model linked to a collection becomes its default; an explicit request
+        # re-points it. "First model auto-defaults" is caller policy, kept out of the resolver.
         if (
             set_as_default
-            or collection_embedding_model_resolver.get_by_collection_id(
+            or collection_embedding_model_resolver.get_default_by_collection_id(
                 session=session, collection_id=collection_id
             )
             is None

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -124,7 +124,7 @@ class ClassifierManager:
         Returns:
             The created classifier name and ID.
         """
-        embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
+        embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
             session=session,
             collection_id=collection_id,
         )
@@ -626,7 +626,7 @@ def _get_embedding_model_by_hash(
         raise ValueError(f"Collection {collection_id} not found.")
 
     # TODO(Michal, 08/2026): Remove once embedding models are unique per dataset and hash.
-    default_embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
+    default_embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=session, collection_id=collection_id
     )
     if default_embedding_model_id is not None:

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -1,7 +1,8 @@
-"""Handler for database operations related to a collection's default embedding space.
+"""Handler for database operations on the collection-to-embedding-model link table.
 
-TODO(Michal, 08/2026): Rename the functions and change the interface so that it reflects
-the new "all collection models" semantics, not the old "only default model" semantics.
+Each row links one embedding model to one collection, with an ``is_default`` flag marking
+at most one of a collection's models as its default. Linking a model and choosing the
+default are separate operations: ``get_or_create`` links, ``set_default`` flips the flag.
 """
 
 from __future__ import annotations
@@ -13,73 +14,99 @@ from sqlmodel import Session, col, select
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 
 
+def get_or_create(
+    session: Session, collection_id: UUID, embedding_model_id: UUID
+) -> CollectionEmbeddingModelTable:
+    """Link an embedding model to a collection, returning the existing or new link row.
+
+    Idempotent: linking a model that is already linked returns its current row and never
+    touches ``is_default``. The composite primary key makes the link naturally unique, so
+    no separate "fail if exists" insert is needed. Whether a linked model is the
+    collection's default is a separate concern owned by ``set_default``.
+
+    Args:
+        session: The database session.
+        collection_id: The collection to link the model to.
+        embedding_model_id: The embedding model to link.
+
+    Returns:
+        The persisted link row.
+    """
+    link = session.get(CollectionEmbeddingModelTable, (collection_id, embedding_model_id))
+    if link is not None:
+        return link
+
+    link = CollectionEmbeddingModelTable(
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_id,
+    )
+    session.add(link)
+    session.commit()
+    session.refresh(link)
+    return link
+
+
 def set_default(
     session: Session, collection_id: UUID, embedding_model_id: UUID
 ) -> CollectionEmbeddingModelTable:
-    """Set the default embedding model of a collection.
+    """Make an already-linked embedding model the collection's default.
 
-    A collection may link several embedding models but has at most one default. The
-    current default (if any) is cleared and the target model is flagged instead. The
-    target keeps its existing link row when it already has one, so the composite primary
-    key is never mutated.
+    A collection has at most one default. The current default (if any) is cleared and the
+    target model is flagged instead. The target must already be linked via
+    ``get_or_create``; an unlinked model reaching here is a caller bug and raises.
 
     Args:
         session: The database session.
         collection_id: The collection whose default is set.
-        embedding_model_id: The embedding model to record as the default.
+        embedding_model_id: The already-linked embedding model to flag as the default.
 
     Returns:
         The persisted default embedding model row.
+
+    Raises:
+        ValueError: If the model is not linked to the collection.
     """
-    current_default = _get_by_collection_id(session=session, collection_id=collection_id)
-    if current_default is not None and current_default.embedding_model_id == embedding_model_id:
-        return current_default
+    target = session.get(CollectionEmbeddingModelTable, (collection_id, embedding_model_id))
+    if target is None:
+        raise ValueError(
+            f"Embedding model {embedding_model_id} is not linked to collection {collection_id}."
+        )
+    if target.is_default:
+        return target
 
     # Clear the old default first so the one-default-per-collection unique index (Postgres)
     # never sees two defaults at once.
+    current_default = _get_default_by_collection_id(session=session, collection_id=collection_id)
     if current_default is not None:
         current_default.is_default = False
         session.add(current_default)
         session.flush()
 
-    target = session.get(CollectionEmbeddingModelTable, (collection_id, embedding_model_id))
-    if target is None:
-        target = CollectionEmbeddingModelTable(
-            collection_id=collection_id,
-            embedding_model_id=embedding_model_id,
-            is_default=True,
-        )
-    else:
-        target.is_default = True
-
+    target.is_default = True
     session.add(target)
     session.commit()
     session.refresh(target)
     return target
 
 
-def get_by_collection_id(session: Session, collection_id: UUID) -> UUID | None:
+def get_default_by_collection_id(session: Session, collection_id: UUID) -> UUID | None:
     """Return the collection's default embedding model id, or None if it has none."""
-    default = _get_by_collection_id(session=session, collection_id=collection_id)
+    default = _get_default_by_collection_id(session=session, collection_id=collection_id)
     return None if default is None else default.embedding_model_id
 
 
-def delete_by_collection_id(session: Session, collection_id: UUID) -> bool:
-    """Delete the collection's default embedding space row.
-
-    Returns:
-        True if a row was deleted, False if the collection had no default.
-    """
-    default = _get_by_collection_id(session=session, collection_id=collection_id)
-    if default is None:
-        return False
-
-    session.delete(default)
-    session.commit()
-    return True
+def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[UUID]:
+    """Return the ids of all embedding models linked to the collection."""
+    return list(
+        session.exec(
+            select(CollectionEmbeddingModelTable.embedding_model_id).where(
+                CollectionEmbeddingModelTable.collection_id == collection_id
+            )
+        ).all()
+    )
 
 
-def _get_by_collection_id(
+def _get_default_by_collection_id(
     session: Session, collection_id: UUID
 ) -> CollectionEmbeddingModelTable | None:
     """Return the collection's default embedding model row, or None if it has none."""

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -14,15 +14,12 @@ from sqlmodel import Session, col, select
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 
 
-def get_or_create(
+def get_or_add_collection_model(
     session: Session, collection_id: UUID, embedding_model_id: UUID
 ) -> CollectionEmbeddingModelTable:
     """Link an embedding model to a collection, returning the existing or new link row.
 
-    Idempotent: linking a model that is already linked returns its current row and never
-    touches ``is_default``. The composite primary key makes the link naturally unique, so
-    no separate "fail if exists" insert is needed. Whether a linked model is the
-    collection's default is a separate concern owned by ``set_default``.
+    If the link does not exist it is created as non-default.
 
     Args:
         session: The database session.

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -121,7 +121,7 @@ def delete_dataset(
     _delete_annotation_labels(session=session, dataset_id=dataset_id)
     _delete_tags(session=session, dataset_id=dataset_id)
     # Must precede embedding_model and collections (FKs to both, deleted below and in step 6).
-    _delete_default_embedding_spaces(session=session, dataset_id=dataset_id)
+    _delete_collection_embedding_models(session=session, dataset_id=dataset_id)
     _delete_embedding_models(session=session, dataset_id=dataset_id)
     _delete_object_tracks(session=session, dataset_id=dataset_id)
     _delete_evaluation_runs(session=session, dataset_id=dataset_id)
@@ -320,8 +320,8 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
     )
 
 
-def _delete_default_embedding_spaces(session: Session, dataset_id: UUID) -> None:
-    """Delete default embedding spaces for the dataset's collections."""
+def _delete_collection_embedding_models(session: Session, dataset_id: UUID) -> None:
+    """Delete all embedding-model links for the dataset's collections."""
     session.exec(
         delete(CollectionEmbeddingModelTable).where(
             col(CollectionEmbeddingModelTable.collection_id).in_(

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -28,7 +28,7 @@ def get_sample_ids_in_region(
     # so the region is tested against the exact projection the user lassoed over.
     # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
     # matching embeddings2d.get_2d_embeddings.
-    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -27,7 +27,7 @@ def get_distance_expression(
     if not text_embedding:
         return None, None
 
-    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=session, collection_id=collection_id
     )
 

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -65,7 +65,12 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
         embedding_dimension=3,
     )
     created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
-    # Register it as the collection's default so it resolves as the collection's model.
+    # Link it and register it as the collection's default so it resolves as the model.
+    collection_embedding_model_resolver.get_or_create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=created.embedding_model_id,
+    )
     collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -66,7 +66,7 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
     )
     created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
     # Link it and register it as the collection's default so it resolves as the model.
-    collection_embedding_model_resolver.get_or_create(
+    collection_embedding_model_resolver.get_or_add_collection_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=created.embedding_model_id,

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -57,7 +57,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -85,7 +85,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=None,
         )
         get_by_id = mocker.patch.object(embedding_model_resolver, "get_by_id")
@@ -110,7 +110,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -177,7 +177,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -232,7 +232,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -370,7 +370,7 @@ class TestClassifierManager:
         # Setup: Create a classifier first
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -433,7 +433,7 @@ class TestClassifierManager:
         # Setup: Create a classifier with initial samples
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -550,7 +550,7 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -633,7 +633,7 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -722,7 +722,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             collection_embedding_model_resolver,
-            "get_by_collection_id",
+            "get_default_by_collection_id",
             return_value=uuid4(),
         )
         mocker.patch.object(
@@ -988,11 +988,7 @@ def test_get_embedding_model_by_hash__prefers_default(db_session: Session) -> No
         collection_id=child.collection_id,
         embedding_model_name="model_in_child",
         embedding_model_hash="same_hash",
-    )
-    collection_embedding_model_resolver.set_default(
-        session=db_session,
-        collection_id=child.collection_id,
-        embedding_model_id=child_model.embedding_model_id,
+        set_as_default=True,
     )
 
     result = classifier_manager_module._get_embedding_model_by_hash(

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -330,7 +330,7 @@ def create_embedding_model(  # noqa: PLR0913
         ),
     )
     if set_as_default:
-        collection_embedding_model_resolver.get_or_create(
+        collection_embedding_model_resolver.get_or_add_collection_model(
             session=session,
             collection_id=collection_id,
             embedding_model_id=model.embedding_model_id,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -309,10 +309,10 @@ def create_embedding_model(  # noqa: PLR0913
 ) -> EmbeddingModelTable:
     """Helper function to create a embedding model.
 
-    With ``set_as_default`` the model is recorded as the collection's default embedding
-    model, so ``collection_embedding_model_resolver.get_by_collection_id`` resolves to it. It
-    is off by default to avoid the ``collection_embedding_model`` foreign key blocking model
-    or collection deletes in tests that do not need a default.
+    With ``set_as_default`` the model is linked to the collection and recorded as its
+    default embedding model, so ``get_default_by_collection_id`` resolves to it. It is off
+    by default to avoid the ``collection_embedding_model`` foreign key blocking model or
+    collection deletes in tests that do not need a default.
     """
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
@@ -330,6 +330,11 @@ def create_embedding_model(  # noqa: PLR0913
         ),
     )
     if set_as_default:
+        collection_embedding_model_resolver.get_or_create(
+            session=session,
+            collection_id=collection_id,
+            embedding_model_id=model.embedding_model_id,
+        )
         collection_embedding_model_resolver.set_default(
             session=session,
             collection_id=collection_id,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -383,7 +383,7 @@ def test_deep_copy__with_default_embedding_space(db_session: Session) -> None:
     copied_model_id = copied_models[0].embedding_model_id
     assert copied_model_id != embedding_model.embedding_model_id
 
-    copied_default_id = collection_embedding_model_resolver.get_by_collection_id(
+    copied_default_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=db_session, collection_id=copied.collection_id
     )
     assert copied_default_id == copied_model_id

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -210,7 +210,7 @@ def test_delete_dataset__with_default_embedding_space(db_session: Session) -> No
     # Assert - collection and its default embedding space deleted
     assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
     assert (
-        collection_embedding_model_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_default_by_collection_id(
             session=db_session, collection_id=collection_id
         )
         is None

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -49,11 +49,9 @@ def test_get_or_create__idempotent_keeps_default(db_session: Session) -> None:
     )
 
     assert link.is_default is True
-    all_links = db_session.exec(
-        select(CollectionEmbeddingModelTable).where(
-            CollectionEmbeddingModelTable.collection_id == collection.collection_id
-        )
-    ).all()
+    all_links = collection_embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
     assert len(all_links) == 1
 
 

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -15,7 +15,7 @@ def test_get_or_create__links_model(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
 
-    link = collection_embedding_model_resolver.get_or_create(
+    link = collection_embedding_model_resolver.get_or_add_collection_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
@@ -30,7 +30,7 @@ def test_get_or_create__links_model(db_session: Session) -> None:
 def test_get_or_create__idempotent_keeps_default(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    collection_embedding_model_resolver.get_or_create(
+    collection_embedding_model_resolver.get_or_add_collection_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
@@ -42,7 +42,7 @@ def test_get_or_create__idempotent_keeps_default(db_session: Session) -> None:
     )
 
     # Re-linking an already-default model returns the same row without clearing its flag.
-    link = collection_embedding_model_resolver.get_or_create(
+    link = collection_embedding_model_resolver.get_or_add_collection_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
@@ -58,7 +58,7 @@ def test_get_or_create__idempotent_keeps_default(db_session: Session) -> None:
 def test_set_default__flags_linked_model(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    collection_embedding_model_resolver.get_or_create(
+    collection_embedding_model_resolver.get_or_add_collection_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
@@ -89,7 +89,7 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         embedding_model_hash="hash_2",
     )
     for model in (model_1, model_2):
-        collection_embedding_model_resolver.get_or_create(
+        collection_embedding_model_resolver.get_or_add_collection_model(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_id=model.embedding_model_id,
@@ -186,7 +186,7 @@ def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> No
         embedding_model_hash="hash_2",
     )
     for model in (model_1, model_2):
-        collection_embedding_model_resolver.get_or_create(
+        collection_embedding_model_resolver.get_or_add_collection_model(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_id=model.embedding_model_id,

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
@@ -10,9 +11,60 @@ from tests.helpers_resolvers import (
 )
 
 
-def test_set_default__inserts(db_session: Session) -> None:
+def test_get_or_create__links_model(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+
+    link = collection_embedding_model_resolver.get_or_create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    assert link.collection_id == collection.collection_id
+    assert link.embedding_model_id == model.embedding_model_id
+    # Linking never makes a model the default on its own.
+    assert link.is_default is False
+
+
+def test_get_or_create__idempotent_keeps_default(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+    collection_embedding_model_resolver.get_or_create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+    collection_embedding_model_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    # Re-linking an already-default model returns the same row without clearing its flag.
+    link = collection_embedding_model_resolver.get_or_create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    assert link.is_default is True
+    all_links = db_session.exec(
+        select(CollectionEmbeddingModelTable).where(
+            CollectionEmbeddingModelTable.collection_id == collection.collection_id
+        )
+    ).all()
+    assert len(all_links) == 1
+
+
+def test_set_default__flags_linked_model(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+    collection_embedding_model_resolver.get_or_create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
 
     default = collection_embedding_model_resolver.set_default(
         session=db_session,
@@ -20,8 +72,8 @@ def test_set_default__inserts(db_session: Session) -> None:
         embedding_model_id=model.embedding_model_id,
     )
 
-    assert default.collection_id == collection.collection_id
     assert default.embedding_model_id == model.embedding_model_id
+    assert default.is_default is True
 
 
 def test_set_default__replaces_existing(db_session: Session) -> None:
@@ -38,6 +90,12 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         embedding_model_name="model_2",
         embedding_model_hash="hash_2",
     )
+    for model in (model_1, model_2):
+        collection_embedding_model_resolver.get_or_create(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_id=model.embedding_model_id,
+        )
 
     collection_embedding_model_resolver.set_default(
         session=db_session,
@@ -50,55 +108,9 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         embedding_model_id=model_2.embedding_model_id,
     )
 
-    # The collection still has a single default, now pointing at the second model.
+    # The old default is demoted, so a single default holds and points at the second model.
     assert (
-        collection_embedding_model_resolver.get_by_collection_id(
-            session=db_session, collection_id=collection.collection_id
-        )
-        == model_2.embedding_model_id
-    )
-
-
-def test_set_default__promotes_existing_link(db_session: Session) -> None:
-    # A collection that already links two models, as after the backfill migration.
-    collection = create_collection(session=db_session)
-    model_1 = create_embedding_model(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_name="model_1",
-        embedding_model_hash="hash_1",
-    )
-    model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_name="model_2",
-        embedding_model_hash="hash_2",
-    )
-    db_session.add(
-        CollectionEmbeddingModelTable(
-            collection_id=collection.collection_id,
-            embedding_model_id=model_1.embedding_model_id,
-            is_default=True,
-        )
-    )
-    db_session.add(
-        CollectionEmbeddingModelTable(
-            collection_id=collection.collection_id,
-            embedding_model_id=model_2.embedding_model_id,
-            is_default=False,
-        )
-    )
-    db_session.commit()
-
-    collection_embedding_model_resolver.set_default(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_id=model_2.embedding_model_id,
-    )
-
-    # The existing model_2 link is promoted; model_1 is demoted, so a single default holds.
-    assert (
-        collection_embedding_model_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_default_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         == model_2.embedding_model_id
@@ -112,62 +124,78 @@ def test_set_default__promotes_existing_link(db_session: Session) -> None:
     assert [row.embedding_model_id for row in defaults] == [model_2.embedding_model_id]
 
 
-def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:
+def test_set_default__raises_when_unlinked(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+
+    # The model exists but was never linked, so flagging it as default is a caller bug.
+    with pytest.raises(ValueError, match="not linked"):
+        collection_embedding_model_resolver.set_default(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_id=model.embedding_model_id,
+        )
+
+
+def test_get_default_by_collection_id__none_when_unset(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
     assert (
-        collection_embedding_model_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_default_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is None
     )
 
 
-def test_get_by_collection_id__returns_id(db_session: Session) -> None:
+def test_get_default_by_collection_id__returns_id(db_session: Session) -> None:
     collection = create_collection(session=db_session)
-    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    collection_embedding_model_resolver.set_default(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_id=model.embedding_model_id,
+    model = create_embedding_model(
+        session=db_session, collection_id=collection.collection_id, set_as_default=True
     )
 
     assert (
-        collection_embedding_model_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_default_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         == model.embedding_model_id
     )
 
 
-def test_delete_by_collection_id__deletes(db_session: Session) -> None:
+def test_get_all_by_collection_id__empty(db_session: Session) -> None:
     collection = create_collection(session=db_session)
-    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    collection_embedding_model_resolver.set_default(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_id=model.embedding_model_id,
+
+    assert (
+        collection_embedding_model_resolver.get_all_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == []
     )
 
-    deleted = collection_embedding_model_resolver.delete_by_collection_id(
+
+def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_1",
+        embedding_model_hash="hash_1",
+    )
+    model_2 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_2",
+        embedding_model_hash="hash_2",
+    )
+    for model in (model_1, model_2):
+        collection_embedding_model_resolver.get_or_create(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_id=model.embedding_model_id,
+        )
+
+    linked = collection_embedding_model_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
 
-    assert deleted is True
-    assert (
-        collection_embedding_model_resolver.get_by_collection_id(
-            session=db_session, collection_id=collection.collection_id
-        )
-        is None
-    )
-
-
-def test_delete_by_collection_id__returns_false_when_absent(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-
-    assert (
-        collection_embedding_model_resolver.delete_by_collection_id(
-            session=db_session, collection_id=collection.collection_id
-        )
-        is False
-    )
+    assert set(linked) == {model_1.embedding_model_id, model_2.embedding_model_id}


### PR DESCRIPTION
## What has changed and why?

The `collection_embedding_model` table has held multiple models per collection for a while, but the resolver's names and behavior still described the old one-default-per-collection world. This aligns the interface with the link-table semantics.

Splits the two concerns that `set_default` used to fuse:

- `get_or_create` — idempotent link, never touches `is_default`
- `get_all_by_collection_id` — all linked model ids
- `get_by_collection_id` → `get_default_by_collection_id`
- `set_default` — now a pure flag-flip; raises on an unlinked model
- `delete_by_collection_id` removed (no production caller)

Callers and tests migrated. Renamed the misleading `delete_dataset` helper `_delete_default_embedding_spaces` → `_delete_collection_embedding_models` (already deleted all links, not just defaults).

No schema change. First of a 3-PR sequence; follow-ups drop the `embedding_model.collection_id` column.

## How has it been tested?

- `make static-checks` (ruff + mypy) clean
- Resolver suite plus all affected caller suites pass

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @JonasWurst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collections can now link to multiple embedding models while maintaining one designated default.
  * The first linked model is automatically selected as the default, with explicit controls to change it.
  * Embedding-based features consistently use the collection’s configured default model.

* **Bug Fixes**
  * Improved consistency for 2D embeddings, similarity searches, regions, and few-shot classifiers when multiple embedding models are available.
  * Prevented unlinked models from being selected as defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->