### PR TITLE
Drop two unused environment variables

### DIFF
--- a/lightly_studio/.env.example
+++ b/lightly_studio/.env.example
@@ -1,8 +1,5 @@
 # Copy this file to .env and fill in the required fields.
 
-# License key for LightlyStudio
-LIGHTLY_STUDIO_LICENSE_KEY="your_license_key_here"
-
 # LightlyStudio server
 # LIGHTLY_STUDIO_PROTOCOL=http
 # LIGHTLY_STUDIO_HOST=0.0.0.0
@@ -20,9 +17,6 @@ LIGHTLY_STUDIO_LICENSE_KEY="your_license_key_here"
 # uses, so a local quickstart puts its CLI and browser events side by side. Published wheels
 # find no .env and default to the production project instead.
 LIGHTLY_STUDIO_POSTHOG_KEY=phc_A9K0pMRovzmhFhngbKAZIr2qZdA14eHvsZY6kjNdYWr
-#
-# PostHog instance to report to. Defaults to the EU cloud.
-# LIGHTLY_STUDIO_POSTHOG_HOST=https://eu.i.posthog.com
 #
 # Set to false to switch tracking off entirely, in the Python package and the GUI.
 # LIGHTLY_STUDIO_ANALYTICS_ENABLED=false

--- a/lightly_studio/src/lightly_studio/dataset/env.py
+++ b/lightly_studio/src/lightly_studio/dataset/env.py
@@ -35,10 +35,9 @@ LIGHTLY_STUDIO_POSTHOG_KEY: str = env.str(
     "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_LB62TVP2O3S2goH4KASascsXRT14H7zfxHVfo7d2cLV"
 )
 # The EU instance, matching PUBLIC_POSTHOG_HOST in lightly_studio_view/.env. The two packages read
-# their configuration through different systems, so the value is written once on each side.
-LIGHTLY_STUDIO_POSTHOG_HOST: str = env.str(
-    "LIGHTLY_STUDIO_POSTHOG_HOST", "https://eu.i.posthog.com"
-)
+# their configuration through different systems, so the value is written once on each side. Not an
+# environment variable: the key above is the only part worth pointing elsewhere.
+LIGHTLY_STUDIO_POSTHOG_HOST: str = "https://eu.i.posthog.com"
 
 LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS: int = max(
     1, env.int("LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS", 32)


### PR DESCRIPTION
## What has changed and why?

Removes two environment variables that nobody should be setting.

- `LIGHTLY_STUDIO_LICENSE_KEY` was documented in `.env.example` but has no reader anywhere in
  the repository. It dates back to #173 and was never wired up.
- `LIGHTLY_STUDIO_POSTHOG_HOST` is read, but the only thing it does is point our own write-only
  PostHog project key at a different instance — not something an OSS user has a reason to do.
  The host becomes a plain constant next to the key in `dataset/env.py`.

`LIGHTLY_STUDIO_POSTHOG_KEY` stays an environment variable: pointing a build at the dev vs.
production project, and `""` to drop ingestion without touching the flag, are both real uses.
`LIGHTLY_STUDIO_ANALYTICS_ENABLED=false` remains the documented way to switch tracking off.

## How has it been tested?

- `make test` on `tests/analytics` — 22 passed. `test_tracking.py` patches the module attribute
  rather than the environment variable, so it is unaffected by the change.
- `grep` over the repository (excluding `node_modules`) confirms nothing else reads either
  variable, and no CI or Docker configuration sets the host.
- `make static-checks` reports 16 pre-existing mypy errors in untouched test files, all from
  optional cloud dependencies (`s3fs`, `gcsfs`, `adlfs`) missing locally.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @gabrielfruet, who added the PostHog host in #1914. Alternative: Igor Susmelj for the
call on what tracking configuration belongs in the OSS repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified configuration by removing unused example settings.
  * Standardized PostHog connectivity to use the built-in European host configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->