### PR TITLE
Align EmbeddingManager default model state

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -190,7 +190,7 @@ class EmbeddingManager:
         # Determine if the model should be set as default.
         # TODO(Michal, 08/2026): Currently there are two places storing the defaults:
         # the `_collection_id_to_default_model_id` dict and the database. The source
-        # of truth should completely move to the database,
+        # of truth should completely move to the database.
         has_no_default_in_db = (
             collection_embedding_model_resolver.get_default_by_collection_id(
                 session=session, collection_id=collection_id

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -165,43 +165,43 @@ class EmbeddingManager:
         if collection is None:
             raise ValueError("Provided collection_id could not be found.")
 
-        embedding_space = embedding_generator.get_embedding_model_input()
-        embedding_model = EmbeddingModelCreate(
-            name=embedding_space.name,
-            parameter_count_in_mb=embedding_space.parameter_count_in_mb,
-            embedding_model_hash=embedding_space.embedding_model_hash,
-            embedding_dimension=embedding_space.embedding_dimension,
+        model_description = embedding_generator.get_embedding_model_input()
+        model_create = EmbeddingModelCreate(
+            name=model_description.name,
+            parameter_count_in_mb=model_description.parameter_count_in_mb,
+            embedding_model_hash=model_description.embedding_model_hash,
+            embedding_dimension=model_description.embedding_dimension,
             collection_id=collection_id,
             dataset_id=collection.dataset_id,
         )
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_model,
+            embedding_model=model_create,
         )
         model_id = db_model.embedding_model_id
 
         self._models[model_id] = embedding_generator
 
-        # Record the model in two places: the in-memory map caches the loaded generator for
-        # this process, and the collection_embedding_model table persists the link for
-        # query-layer callers (collection_embedding_model_resolver.get_default_by_collection_id).
-        if set_as_default or collection_id not in self._collection_id_to_default_model_id:
-            self._collection_id_to_default_model_id[collection_id] = model_id
+        # Register the model with the collection
         collection_embedding_model_resolver.get_or_add_collection_model(
             session=session, collection_id=collection_id, embedding_model_id=model_id
         )
-        # The first model linked to a collection becomes its default; an explicit request
-        # re-points it. "First model auto-defaults" is caller policy, kept out of the resolver.
-        if (
-            set_as_default
-            or collection_embedding_model_resolver.get_default_by_collection_id(
+
+        # Determine if the model should be set as default.
+        # TODO(Michal, 08/2026): Currently there are two places storing the defaults:
+        # the `_collection_id_to_default_model_id` dict and the database. The source
+        # of truth should completely move to the database,
+        has_no_default_in_db = (
+            collection_embedding_model_resolver.get_default_by_collection_id(
                 session=session, collection_id=collection_id
             )
             is None
-        ):
+        )
+        if set_as_default or has_no_default_in_db:
             collection_embedding_model_resolver.set_default(
                 session=session, collection_id=collection_id, embedding_model_id=model_id
             )
+            self._collection_id_to_default_model_id[collection_id] = model_id
 
         return db_model
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -156,7 +156,7 @@ class EmbeddingManager:
             collection_id: The ID of the collection to associate with the model.
                 And to register as default, if requested.
             embedding_generator: The model implementation used for embeddings.
-            set_as_default: Whether to set this model as the default.
+            set_as_default: If True, make this model the collection's default.
 
         Returns:
             The created EmbeddingModel.

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -186,19 +186,17 @@ class EmbeddingManager:
         collection_model_link = collection_embedding_model_resolver.get_or_add_collection_model(
             session=session, collection_id=collection_id, embedding_model_id=model_id
         )
-        if collection_model_link.is_default:
-            self._collection_id_to_default_model_id[collection_id] = model_id
-
-        # Determine if the model should be set as default.
         # TODO(Michal, 08/2026): The default is stored both in the database and in
         # `_collection_id_to_default_model_id`. The database is the source of truth,
         # while the dictionary only tracks models loaded at runtime. Split these
         # responsibilities during the EmbeddingManager refactor.
-        has_no_default_in_db = (
-            collection_embedding_model_resolver.get_default_by_collection_id(
-                session=session, collection_id=collection_id
-            )
-            is None
+        if collection_model_link.is_default:
+            self._collection_id_to_default_model_id[collection_id] = model_id
+            return db_model
+
+        # Determine if the model should be set as default.
+        has_no_default_in_db = not collection_embedding_model_resolver.has_default_by_collection_id(
+            session=session, collection_id=collection_id
         )
         if set_as_default or has_no_default_in_db:
             collection_embedding_model_resolver.set_default(

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -190,11 +190,10 @@ class EmbeddingManager:
             self._collection_id_to_default_model_id[collection_id] = model_id
 
         # Determine if the model should be set as default.
-        # TODO(Michal, 08/2026): Currently there are two places storing the defaults:
-        # the `_collection_id_to_default_model_id` dict and the database. The source
-        # of truth is the database. The dictionary does not 100% match the db, it contains
-        # only models loaded during the runtime. These responsibilities should split after
-        # EmbeddingMagager refactor.
+        # TODO(Michal, 08/2026): The default is stored both in the database and in
+        # `_collection_id_to_default_model_id`. The database is the source of truth,
+        # while the dictionary only tracks models loaded at runtime. Split these
+        # responsibilities during the EmbeddingManager refactor.
         has_no_default_in_db = (
             collection_embedding_model_resolver.get_default_by_collection_id(
                 session=session, collection_id=collection_id

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -182,15 +182,19 @@ class EmbeddingManager:
 
         self._models[model_id] = embedding_generator
 
-        # Register the model with the collection
-        collection_embedding_model_resolver.get_or_add_collection_model(
+        # Register the model with the collection.
+        collection_model_link = collection_embedding_model_resolver.get_or_add_collection_model(
             session=session, collection_id=collection_id, embedding_model_id=model_id
         )
+        if collection_model_link.is_default:
+            self._collection_id_to_default_model_id[collection_id] = model_id
 
         # Determine if the model should be set as default.
         # TODO(Michal, 08/2026): Currently there are two places storing the defaults:
         # the `_collection_id_to_default_model_id` dict and the database. The source
-        # of truth should completely move to the database.
+        # of truth is the database. The dictionary does not 100% match the db, it contains
+        # only models loaded during the runtime. These responsibilities should split after
+        # EmbeddingMagager refactor.
         has_no_default_in_db = (
             collection_embedding_model_resolver.get_default_by_collection_id(
                 session=session, collection_id=collection_id

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from sqlalchemy import exists
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
@@ -90,6 +91,17 @@ def get_default_by_collection_id(session: Session, collection_id: UUID) -> UUID 
     """Return the collection's default embedding model id, or None if it has none."""
     default = _get_default_by_collection_id(session=session, collection_id=collection_id)
     return None if default is None else default.embedding_model_id
+
+
+def has_default_by_collection_id(session: Session, collection_id: UUID) -> bool:
+    """Return whether the collection has a default embedding model."""
+    stmt = select(
+        exists().where(
+            col(CollectionEmbeddingModelTable.collection_id) == collection_id,
+            col(CollectionEmbeddingModelTable.is_default).is_(True),
+        )
+    )
+    return session.exec(stmt).one()
 
 
 def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[UUID]:

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -31,6 +31,7 @@ from lightly_studio.models.embedding_model import (
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
+    collection_embedding_model_resolver,
     collection_resolver,
     embedding_model_resolver,
     sample_embedding_resolver,
@@ -150,6 +151,21 @@ def test_register_multiple_models(
     # Verify both models are associated with the same collection and dataset
     assert all(model.collection_id == collection.collection_id for model in stored_models)
     assert all(model.dataset_id == collection.dataset_id for model in stored_models)
+
+    # Both models are linked to the collection, not only the default one.
+    linked_model_ids = collection_embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert set(linked_model_ids) == {model_id1, model_id2}
+
+    # The DB default is the model registered with set_as_default=True. The second model,
+    # registered with set_as_default=False, must not override the existing default.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == model_id1
+    )
 
 
 def test_embed_text_with_default_model(
@@ -704,9 +720,15 @@ def test_default_model(
         collection_id=collection.collection_id,
         set_as_default=False,
     ).embedding_model_id
-    # The first model is always set as default.
+    # The first model is always set as default, both in memory and in the database.
     assert (
         embedding_manager._collection_id_to_default_model_id[collection.collection_id]
+        == first_model_id
+    )
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
         == first_model_id
     )
 

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -746,6 +746,40 @@ def test_default_model(
     )
 
 
+def test_register_embedding_model__seeds_default_cache_from_db(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A fresh manager caches an existing DB default even when set_as_default is False.
+
+    The default lives in the database. A new manager starts with an empty cache, so
+    re-registering a model that is already the collection's default must seed the cache
+    from the database rather than leave it empty.
+    """
+    # A first manager registers the model and makes it the DB default.
+    first_manager = EmbeddingManager()
+    model_id = first_manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=collection.collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+    # A fresh manager (empty cache) re-registers the same model without asking for default.
+    second_manager = EmbeddingManager()
+    second_manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=collection.collection_id,
+        set_as_default=False,
+    )
+
+    # The existing DB default is mirrored into the fresh manager's cache.
+    assert (
+        second_manager._collection_id_to_default_model_id[collection.collection_id] == model_id
+    )
+
+
 def test_embed_videos(
     db_session: Session,
 ) -> None:

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -168,6 +168,38 @@ def test_register_multiple_models(
     )
 
 
+def test_register_embedding_model__seeds_default_cache_from_db(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A fresh manager caches an existing DB default even when set_as_default is False.
+
+    The default lives in the database. A new manager starts with an empty cache, so
+    re-registering a model that is already the collection's default must seed the cache
+    from the database rather than leave it empty.
+    """
+    # A first manager registers the model and makes it the DB default.
+    first_manager = EmbeddingManager()
+    model_id = first_manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=collection.collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+    # A fresh manager (empty cache) re-registers the same model without asking for default.
+    second_manager = EmbeddingManager()
+    second_manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=collection.collection_id,
+        set_as_default=False,
+    )
+
+    # The existing DB default is mirrored into the fresh manager's cache.
+    assert second_manager._collection_id_to_default_model_id[collection.collection_id] == model_id
+
+
 def test_embed_text_with_default_model(
     db_session: Session,
     collection: CollectionTable,
@@ -743,40 +775,6 @@ def test_default_model(
     assert (
         embedding_manager._collection_id_to_default_model_id[collection.collection_id]
         == second_model_id
-    )
-
-
-def test_register_embedding_model__seeds_default_cache_from_db(
-    db_session: Session,
-    collection: CollectionTable,
-) -> None:
-    """A fresh manager caches an existing DB default even when set_as_default is False.
-
-    The default lives in the database. A new manager starts with an empty cache, so
-    re-registering a model that is already the collection's default must seed the cache
-    from the database rather than leave it empty.
-    """
-    # A first manager registers the model and makes it the DB default.
-    first_manager = EmbeddingManager()
-    model_id = first_manager.register_embedding_model(
-        session=db_session,
-        embedding_generator=RandomEmbeddingGenerator(),
-        collection_id=collection.collection_id,
-        set_as_default=True,
-    ).embedding_model_id
-
-    # A fresh manager (empty cache) re-registers the same model without asking for default.
-    second_manager = EmbeddingManager()
-    second_manager.register_embedding_model(
-        session=db_session,
-        embedding_generator=RandomEmbeddingGenerator(),
-        collection_id=collection.collection_id,
-        set_as_default=False,
-    )
-
-    # The existing DB default is mirrored into the fresh manager's cache.
-    assert (
-        second_manager._collection_id_to_default_model_id[collection.collection_id] == model_id
     )
 
 

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -160,6 +160,25 @@ def test_get_default_by_collection_id__returns_id(db_session: Session) -> None:
     )
 
 
+def test_has_default_by_collection_id__false_when_unset(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+
+    assert not collection_embedding_model_resolver.has_default_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+
+def test_has_default_by_collection_id__true_when_set(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    create_embedding_model(
+        session=db_session, collection_id=collection.collection_id, set_as_default=True
+    )
+
+    assert collection_embedding_model_resolver.has_default_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+
 def test_get_all_by_collection_id__empty(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 


### PR DESCRIPTION
## What has changed and why?

- Keep the in-memory default model aligned with the database default when registering models.
- Use the persisted collection default to decide when the first registered model becomes the default.

## How has it been tested?

- `uv run pytest tests/dataset/test_embedding_manager.py` (41 passed)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Alternative reviewer: @horatiualmasan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding model registration and default selection.
  * Preserved existing collection defaults when adding or registering additional embedding models.
  * Ensured all registered embedding models are correctly linked to their collections.
  * Restored default model settings when starting with an existing database configuration.
  * Persisted newly selected defaults so they remain available across application restarts.
  * Improved consistency between saved embedding model settings and the application’s active configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->