### PR TITLE
Report GUI events against the installation ID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,15 @@ Now edit the `.env` file:
 * Optionally change the `EXAMPLES_*` paths to point to data on your machine. You can leave the
 defaults to use the cloned dataset examples data.
 
+### Mark Your Machine as Internal
+
+Lightly staff should mark their machine once, so that internal usage is filtered out of the
+product metrics. `LIGHTLY_STUDIO_INTERNAL=1`, in `.env` or the environment, does the same per run:
+
+```shell
+mkdir -p ~/.cache/lightly-studio && touch ~/.cache/lightly-studio/internal
+```
+
 ### Run Examples
 
 Choose a script in `lightly_studio/src/lightly_studio/examples` directory and run it like this:

--- a/lightly_studio/src/lightly_studio/analytics/cohort.py
+++ b/lightly_studio/src/lightly_studio/analytics/cohort.py
@@ -1,0 +1,93 @@
+"""Cohort a running installation belongs to.
+
+Internal usage has to be separable from real users, otherwise a handful of devs and CI runs
+dominate the product signal while the user base is small.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from enum import Enum
+from importlib import metadata
+from pathlib import Path
+
+from lightly_studio.dataset.env import (
+    LIGHTLY_STUDIO_INTERNAL,
+    LIGHTLY_STUDIO_MODEL_CACHE_DIR,
+)
+
+# Shares the directory with the installation ID, so marking a machine survives recreating the
+# virtualenv. LIGHTLY_STUDIO_INTERNAL alone is forgotten when it matters most, on a fresh
+# container or a new laptop.
+INTERNAL_MARKER_PATH: Path = LIGHTLY_STUDIO_MODEL_CACHE_DIR / "internal"
+
+# Set by every CI provider we run on, GitHub Actions included. A build matrix otherwise looks like
+# one very active user.
+_CI_ENV_VAR = "CI"
+
+
+class UserCohort(str, Enum):
+    """Who is behind the events of one installation.
+
+    Attributes:
+        STAFF: A Lightly dev or staff member, opted in explicitly.
+        CI: An automated build, not a person.
+        SOURCE_BUILD: Installed from a checkout, so staff who did not opt in, or a contributor.
+        USER: Everyone else, a released package on someone else's machine.
+    """
+
+    STAFF = "staff"
+    CI = "ci"
+    SOURCE_BUILD = "source_build"
+    USER = "user"
+
+
+def get_cohort(marker_path: Path = INTERNAL_MARKER_PATH) -> UserCohort:
+    """Get the cohort of this installation.
+
+    Args:
+        marker_path: File whose presence marks the machine as internal.
+
+    Returns:
+        The cohort. `USER` whenever nothing indicates otherwise, so a misdetection loses internal
+        traffic from the internal metrics rather than polluting the product metrics.
+    """
+    # The deliberate signal wins: a marked machine stays internal even when a tool exports CI in
+    # the shell.
+    if LIGHTLY_STUDIO_INTERNAL or marker_path.exists():
+        return UserCohort.STAFF
+    if os.environ.get(_CI_ENV_VAR):
+        return UserCohort.CI
+    if _is_source_build():
+        return UserCohort.SOURCE_BUILD
+    return UserCohort.USER
+
+
+def is_test_run() -> bool:
+    """Whether the current process runs the test suite, whose events are dropped entirely."""
+    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules
+
+
+def _is_source_build() -> bool:
+    """Whether the installed package was built from a local checkout rather than a release.
+
+    A `dir_info` entry in the PEP 610 `direct_url.json` record means the install came from a
+    directory on disk, covering both `pip install -e .` and a plain install from a checkout.
+    """
+    try:
+        direct_url = metadata.distribution("lightly-studio").read_text("direct_url.json")
+    except metadata.PackageNotFoundError:
+        # Running straight from a checkout, without the package installed at all.
+        return True
+
+    if direct_url is None:
+        return False
+    try:
+        record = json.loads(direct_url)
+    except json.JSONDecodeError:
+        return False
+    # A record that is not an object is malformed. `in` would raise on null or a number, and match
+    # the wrong thing on a string or an array.
+    return isinstance(record, dict) and "dir_info" in record

--- a/lightly_studio/src/lightly_studio/analytics/posthog_tracker.py
+++ b/lightly_studio/src/lightly_studio/analytics/posthog_tracker.py
@@ -9,7 +9,7 @@ from importlib import metadata
 
 from posthog import Posthog
 
-from lightly_studio.analytics import install_id
+from lightly_studio.analytics import cohort, install_id
 from lightly_studio.analytics.tracker import Tracker
 
 # One retry rather than the default three. Delivery happens on a background thread, but the flush
@@ -80,10 +80,15 @@ def _silence_delivery_logging() -> None:
         logger.propagate = False
 
 
-def _common_properties() -> dict[str, str]:
+def _common_properties() -> dict[str, object]:
     """Build the properties attached to every event."""
+    user_cohort = cohort.get_cohort().value
     return {
         "lightly_studio_version": metadata.version("lightly-studio"),
         "python_version": platform.python_version(),
         "os": platform.system(),
+        "user_cohort": user_cohort,
+        # Also stored on the person, so a PostHog cohort and the project-wide internal user filter
+        # can select on it without reading event properties.
+        "$set": {"user_cohort": user_cohort},
     }

--- a/lightly_studio/src/lightly_studio/analytics/tracking.py
+++ b/lightly_studio/src/lightly_studio/analytics/tracking.py
@@ -12,6 +12,7 @@ import threading
 from collections.abc import Mapping
 from enum import Enum
 
+from lightly_studio.analytics import cohort
 from lightly_studio.analytics.posthog_tracker import PostHogTracker
 from lightly_studio.analytics.tracker import Tracker
 from lightly_studio.dataset.env import (
@@ -93,6 +94,11 @@ def _get_tracker() -> Tracker:
 def _create_tracker() -> Tracker:
     """Build the tracker matching the current configuration."""
     if not LIGHTLY_STUDIO_ANALYTICS_ENABLED or not LIGHTLY_STUDIO_POSTHOG_KEY:
+        return NoOpTracker()
+
+    # Tracking is on by default, so without this the test suite reports events of its own. They
+    # say nothing about how the app is used, and no cohort would keep them out of the metrics.
+    if cohort.is_test_run():
         return NoOpTracker()
 
     tracker = PostHogTracker(

--- a/lightly_studio/src/lightly_studio/api/analytics_config.py
+++ b/lightly_studio/src/lightly_studio/api/analytics_config.py
@@ -1,0 +1,43 @@
+"""Analytics configuration the GUI reads back from the backend.
+
+The GUI reports to the same PostHog project as the Python package, so deciding here keeps one
+source of truth for whether tracking runs, under which identity, and in which cohort.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from lightly_studio.analytics import cohort, install_id
+from lightly_studio.analytics.cohort import UserCohort
+from lightly_studio.dataset.env import LIGHTLY_STUDIO_ANALYTICS_ENABLED
+
+
+class AnalyticsConfigView(BaseModel):
+    """Analytics configuration of the running app.
+
+    Attributes:
+        enabled: Whether usage tracking is switched on.
+        distinct_id: Anonymous ID the GUI reports against, shared with the Python package so that
+            backend and browser events belong to one person. None while tracking is off.
+        user_cohort: Cohort of this installation, keeping internal usage out of the product
+            metrics. None while tracking is off.
+    """
+
+    enabled: bool
+    distinct_id: str | None
+    user_cohort: UserCohort | None
+
+
+def get_analytics_config() -> AnalyticsConfigView:
+    """Build the analytics configuration for the running app."""
+    if not LIGHTLY_STUDIO_ANALYTICS_ENABLED:
+        # Reading the installation ID writes it to disk on first use, which opting out must not
+        # trigger.
+        return AnalyticsConfigView(enabled=False, distinct_id=None, user_cohort=None)
+
+    return AnalyticsConfigView(
+        enabled=True,
+        distinct_id=str(install_id.get_install_id()),
+        user_cohort=cohort.get_cohort(),
+    )

--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -21,6 +21,7 @@ from lightly_studio.api.routes import (
     webapp,
 )
 from lightly_studio.api.routes.api import (
+    analytics,
     annotation,
     annotation_label,
     caption,
@@ -149,6 +150,7 @@ api_router.include_router(settings.settings_router)
 api_router.include_router(classifier.classifier_router)
 api_router.include_router(embeddings2d.embeddings2d_router)
 api_router.include_router(features.features_router)
+api_router.include_router(analytics.analytics_router)
 api_router.include_router(evaluation.evaluation_router)
 api_router.include_router(metadata.metadata_router)
 api_router.include_router(sampling.sampling_router)

--- a/lightly_studio/src/lightly_studio/api/features.py
+++ b/lightly_studio/src/lightly_studio/api/features.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_ANALYTICS_ENABLED
 
-# The GUI reads this back to decide whether to start PostHog, so that
-# LIGHTLY_STUDIO_ANALYTICS_ENABLED switches off tracking on both sides.
+# Reports whether usage tracking runs. The GUI decides whether to start PostHog from
+# /analytics/config instead, which also carries the identity to report under.
 ANALYTICS_FEATURE = "analytics"
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
@@ -1,0 +1,18 @@
+"""This module contains the API routes for the analytics configuration."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from lightly_studio.api import analytics_config
+from lightly_studio.api.analytics_config import AnalyticsConfigView
+
+__all__ = ["analytics_router"]
+
+analytics_router = APIRouter()
+
+
+@analytics_router.get("/analytics/config")
+def get_analytics_config() -> AnalyticsConfigView:
+    """Get the analytics configuration the GUI reports under."""
+    return analytics_config.get_analytics_config()

--- a/lightly_studio/src/lightly_studio/dataset/env.py
+++ b/lightly_studio/src/lightly_studio/dataset/env.py
@@ -39,6 +39,10 @@ LIGHTLY_STUDIO_POSTHOG_KEY: str = env.str(
 LIGHTLY_STUDIO_POSTHOG_HOST: str = env.str(
     "LIGHTLY_STUDIO_POSTHOG_HOST", "https://eu.i.posthog.com"
 )
+# Marks this machine as a Lightly dev or staff machine, so internal usage can be filtered out of
+# the product metrics. See lightly_studio/analytics/cohort.py for the alternative marker file,
+# which survives recreating the virtualenv.
+LIGHTLY_STUDIO_INTERNAL: bool = env.bool("LIGHTLY_STUDIO_INTERNAL", False)
 
 LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS: int = max(
     1, env.int("LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS", 32)

--- a/lightly_studio/tests/analytics/test_cohort.py
+++ b/lightly_studio/tests/analytics/test_cohort.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lightly_studio.analytics import cohort
+from lightly_studio.analytics.cohort import UserCohort
+
+
+# Signals are (marker file present, LIGHTLY_STUDIO_INTERNAL, CI variable, installed from source).
+@pytest.mark.parametrize(
+    ("signals", "expected"),
+    [
+        # Either deliberate signal marks the machine, and both win over a CI variable.
+        ((True, False, "true", False), UserCohort.STAFF),
+        ((False, True, "true", False), UserCohort.STAFF),
+        ((False, False, "true", False), UserCohort.CI),
+        # An emptied variable is how CI providers unset it.
+        ((False, False, "", True), UserCohort.SOURCE_BUILD),
+        ((False, False, "", False), UserCohort.USER),
+    ],
+)
+def test_get_cohort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    signals: tuple[bool, bool, str, bool],
+    expected: UserCohort,
+) -> None:
+    marked, internal_env, ci, is_source_build = signals
+    marker_path = tmp_path / "internal"
+    if marked:
+        marker_path.touch()
+    monkeypatch.setenv(cohort._CI_ENV_VAR, ci)
+    mocker.patch.object(cohort, "LIGHTLY_STUDIO_INTERNAL", internal_env)
+    mocker.patch.object(cohort, "_is_source_build", return_value=is_source_build)
+
+    assert cohort.get_cohort(marker_path=marker_path) == expected
+
+
+def test_is_test_run() -> None:
+    assert cohort.is_test_run()
+
+
+@pytest.mark.parametrize(
+    ("direct_url", "expected"),
+    [
+        (json.dumps({"url": "file:///repo", "dir_info": {"editable": True}}), True),
+        # A wheel from PyPI records no direct URL at all.
+        (None, False),
+        (json.dumps({"url": "https://example.com/pkg.whl"}), False),
+        # Malformed records must not raise, nor match the wrong thing.
+        ("null", False),
+        ('"dir_info"', False),
+        ("not json", False),
+    ],
+)
+def test_is_source_build(mocker: MockerFixture, direct_url: str | None, expected: bool) -> None:
+    distribution = mocker.MagicMock()
+    distribution.read_text.return_value = direct_url
+    mocker.patch.object(metadata, "distribution", return_value=distribution)
+
+    assert cohort._is_source_build() == expected
+
+
+def test_is_source_build__without_the_package_installed(mocker: MockerFixture) -> None:
+    mocker.patch.object(metadata, "distribution", side_effect=metadata.PackageNotFoundError)
+
+    assert cohort._is_source_build()

--- a/lightly_studio/tests/analytics/test_posthog_tracker.py
+++ b/lightly_studio/tests/analytics/test_posthog_tracker.py
@@ -5,11 +5,13 @@ from uuid import UUID
 import pytest
 from pytest_mock import MockerFixture
 
-from lightly_studio.analytics import install_id, posthog_tracker
+from lightly_studio.analytics import cohort, install_id, posthog_tracker
+from lightly_studio.analytics.cohort import UserCohort
 from lightly_studio.analytics.posthog_tracker import PostHogTracker
 
 INSTALL_ID = UUID("0199f1a2-b775-76b8-9b09-c2fd260c67c1")
 POSTHOG_HOST = "https://eu.i.posthog.com"
+_BASE_PROPERTIES = ("lightly_studio_version", "python_version", "os")
 
 
 class RecordingHandler(logging.Handler):
@@ -104,8 +106,13 @@ def test_shutdown(mocker: MockerFixture) -> None:
     client.shutdown.assert_called_once_with()
 
 
-def test_common_properties() -> None:
+def test_common_properties(mocker: MockerFixture) -> None:
+    """The cohort goes on the person too, which is what the internal user filter selects on."""
+    mocker.patch.object(cohort, "get_cohort", return_value=UserCohort.CI)
+
     properties = posthog_tracker._common_properties()
 
-    assert set(properties) == {"lightly_studio_version", "python_version", "os"}
+    assert set(properties) == {*_BASE_PROPERTIES, "user_cohort", "$set"}
     assert all(properties.values())
+    assert properties["user_cohort"] == "ci"
+    assert properties["$set"] == {"user_cohort": "ci"}

--- a/lightly_studio/tests/analytics/test_tracking.py
+++ b/lightly_studio/tests/analytics/test_tracking.py
@@ -6,7 +6,7 @@ from collections.abc import Generator, Mapping
 import pytest
 from pytest_mock import MockerFixture
 
-from lightly_studio.analytics import tracking
+from lightly_studio.analytics import cohort, tracking
 
 
 class FakeTracker:
@@ -119,6 +119,7 @@ def test_shutdown__when_the_backend_raises(mocker: MockerFixture) -> None:
 
 
 def test_create_tracker(mocker: MockerFixture) -> None:
+    mocker.patch.object(cohort, "is_test_run", return_value=False)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_test")
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_HOST", "https://posthog.test")
@@ -133,6 +134,7 @@ def test_create_tracker(mocker: MockerFixture) -> None:
 
 def test_create_tracker__flushes_at_exit(mocker: MockerFixture) -> None:
     """Without this hook a short-lived process drops the queued event."""
+    mocker.patch.object(cohort, "is_test_run", return_value=False)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_test")
     mocker.patch.object(tracking, "PostHogTracker")
@@ -153,5 +155,14 @@ def test_create_tracker__when_analytics_are_disabled(mocker: MockerFixture) -> N
 def test_create_tracker__without_a_key(mocker: MockerFixture) -> None:
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "")
+
+    assert isinstance(tracking._create_tracker(), tracking.NoOpTracker)
+
+
+def test_create_tracker__during_a_test_run(mocker: MockerFixture) -> None:
+    """The suite must not report events of its own, tracking being on by default."""
+    mocker.patch.object(cohort, "is_test_run", return_value=True)
+    mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
+    mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_test")
 
     assert isinstance(tracking._create_tracker(), tracking.NoOpTracker)

--- a/lightly_studio/tests/api/test_analytics_config.py
+++ b/lightly_studio/tests/api/test_analytics_config.py
@@ -1,0 +1,33 @@
+from uuid import UUID
+
+from pytest_mock import MockerFixture
+
+from lightly_studio.analytics import cohort, install_id
+from lightly_studio.analytics.cohort import UserCohort
+from lightly_studio.api import analytics_config
+
+
+def test_get_analytics_config(mocker: MockerFixture) -> None:
+    mocker.patch.object(analytics_config, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
+    distinct_id = UUID("00000000-0000-4000-8000-000000000000")
+    mocker.patch.object(install_id, "get_install_id", return_value=distinct_id)
+    mocker.patch.object(cohort, "get_cohort", return_value=UserCohort.STAFF)
+
+    config = analytics_config.get_analytics_config()
+
+    assert config.enabled
+    assert config.distinct_id == str(distinct_id)
+    assert config.user_cohort == UserCohort.STAFF
+
+
+def test_get_analytics_config__with_analytics_disabled(mocker: MockerFixture) -> None:
+    """Opting out must leave no identity behind, on disk or in the response."""
+    mocker.patch.object(analytics_config, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", False)
+    get_install_id = mocker.patch.object(install_id, "get_install_id")
+
+    config = analytics_config.get_analytics_config()
+
+    assert not config.enabled
+    assert config.distinct_id is None
+    assert config.user_cohort is None
+    get_install_id.assert_not_called()

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -20,6 +20,7 @@ export { useAddTagToSample } from '$lib/hooks/useAddTagToSample/useAddTagToSampl
 export { useFileDrop } from '$lib/hooks/useFileDrop/useFileDrop';
 export { useImageUpload } from '$lib/hooks/useImageUpload/useImageUpload';
 export { useFeatureFlags } from '$lib/hooks/useFeatureFlags/useFeatureFlags';
+export { useAnalyticsConfig } from '$lib/hooks/useAnalyticsConfig/useAnalyticsConfig';
 export { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
 export { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
 export { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';

--- a/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.test.ts
@@ -1,0 +1,42 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAnalyticsConfig } from './useAnalyticsConfig';
+
+const mockGetAnalyticsConfig = vi.fn();
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args)
+}));
+
+const config = { enabled: true, distinct_id: 'install-id', user_cohort: 'staff' };
+
+describe('useAnalyticsConfig', () => {
+    beforeEach(() => {
+        mockGetAnalyticsConfig.mockReset();
+    });
+
+    it('should expose the configuration reported by the backend', async () => {
+        mockGetAnalyticsConfig.mockResolvedValue({ data: config });
+
+        const { config: store, ready } = useAnalyticsConfig();
+        await ready;
+
+        expect(get(store)).toEqual(config);
+    });
+
+    it.each([
+        ['the request rejects', () => mockGetAnalyticsConfig.mockRejectedValue(new Error('nope'))],
+        // The client resolves with an error rather than rejecting on an HTTP failure.
+        [
+            'the response carries an error',
+            () => mockGetAnalyticsConfig.mockResolvedValue({ error: {} })
+        ]
+    ])('should leave the configuration empty when %s', async (_name, arrange) => {
+        arrange();
+
+        const { config: store, ready } = useAnalyticsConfig();
+        await ready;
+
+        expect(get(store)).toBeNull();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.ts
@@ -1,0 +1,28 @@
+import { getAnalyticsConfig } from '$lib/api/lightly_studio_local/sdk.gen';
+import { readonly, writable } from 'svelte/store';
+
+type AnalyticsConfig = NonNullable<Awaited<ReturnType<typeof getAnalyticsConfig>>['data']>;
+
+/**
+ * Analytics configuration reported by the backend, so that the browser reports against the same
+ * person as the Python package instead of a second anonymous one.
+ */
+export const useAnalyticsConfig = () => {
+    const config = writable<AnalyticsConfig | null>(null);
+    // Handed back as `ready` so a caller that has to act on the answer can await it instead of
+    // reading the store before the request lands. A failed request leaves the config empty, which
+    // callers treat as tracking being off, so neither a rejection nor the `error` the client
+    // resolves with on an HTTP failure is reported.
+    const ready = getAnalyticsConfig()
+        .then((response) => {
+            if (response.data) {
+                config.set(response.data);
+            }
+        })
+        .catch(() => {});
+
+    return {
+        config: readonly(config),
+        ready
+    };
+};

--- a/lightly_studio_view/src/lib/hooks/usePostHog.test.ts
+++ b/lightly_studio_view/src/lib/hooks/usePostHog.test.ts
@@ -17,30 +17,37 @@ vi.mock('$lib/version.json', () => ({
 const mockInit = vi.fn();
 const mockCapture = vi.fn();
 const mockRegister = vi.fn();
+const mockIdentify = vi.fn();
 
 vi.mock('posthog-js', () => ({
     default: {
         init: (...args: unknown[]) => mockInit(...args),
         capture: (...args: unknown[]) => mockCapture(...args),
-        register: (...args: unknown[]) => mockRegister(...args)
+        register: (...args: unknown[]) => mockRegister(...args),
+        identify: (...args: unknown[]) => mockIdentify(...args)
     }
 }));
 
 // Mocked at the module registry rather than spied on, so it survives the vi.resetModules() the
 // tests below need to get an uninitialized hook.
-const mockGetFeatures = vi.fn();
+const mockGetAnalyticsConfig = vi.fn();
 
 vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
-    getFeatures: (...args: unknown[]) => mockGetFeatures(...args)
+    getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args)
 }));
+
+const enabledConfig = {
+    data: { enabled: true, distinct_id: 'install-id', user_cohort: 'user' }
+};
 
 describe('usePostHog', () => {
     beforeEach(() => {
         mockInit.mockClear();
         mockCapture.mockClear();
         mockRegister.mockClear();
-        mockGetFeatures.mockReset();
-        mockGetFeatures.mockResolvedValue({ data: ['analytics'] });
+        mockIdentify.mockClear();
+        mockGetAnalyticsConfig.mockReset();
+        mockGetAnalyticsConfig.mockResolvedValue(enabledConfig);
     });
 
     it('should initialize PostHog with correct configuration', async () => {
@@ -73,16 +80,28 @@ describe('usePostHog', () => {
         expect(mockInit).toHaveBeenCalledTimes(1);
     });
 
+    it('should identify with the installation id and cohort reported by the backend', async () => {
+        mockGetAnalyticsConfig.mockResolvedValue({
+            data: { enabled: true, distinct_id: 'install-id', user_cohort: 'staff' }
+        });
+
+        await (await freshPostHog()).init();
+
+        expect(mockIdentify).toHaveBeenCalledWith('install-id', { user_cohort: 'staff' });
+    });
+
     it('should not initialize when the backend reports analytics as off', async () => {
-        mockGetFeatures.mockResolvedValue({ data: [] });
+        mockGetAnalyticsConfig.mockResolvedValue({
+            data: { enabled: false, distinct_id: null, user_cohort: null }
+        });
 
         await (await freshPostHog()).init();
 
         expect(mockInit).not.toHaveBeenCalled();
     });
 
-    it('should not initialize when the features request fails', async () => {
-        mockGetFeatures.mockRejectedValue(new Error('API Error'));
+    it('should not initialize when the config request fails', async () => {
+        mockGetAnalyticsConfig.mockRejectedValue(new Error('API Error'));
 
         await (await freshPostHog()).init();
 

--- a/lightly_studio_view/src/lib/hooks/usePostHog.ts
+++ b/lightly_studio_view/src/lib/hooks/usePostHog.ts
@@ -8,12 +8,8 @@ import {
 import { version } from '$lib/version.json';
 // Imported by its own path: $lib/hooks re-exports usePostHog, so going through the barrel would
 // make the two modules import each other.
-import { useFeatureFlags } from '$lib/hooks/useFeatureFlags/useFeatureFlags';
+import { useAnalyticsConfig } from '$lib/hooks/useAnalyticsConfig/useAnalyticsConfig';
 import { get } from 'svelte/store';
-
-// The backend reports this only while LIGHTLY_STUDIO_ANALYTICS_ENABLED is set, so one variable
-// opts out of tracking in both the Python package and here.
-const ANALYTICS_FEATURE = 'analytics';
 
 let initialized = false;
 
@@ -38,11 +34,13 @@ export const usePostHog = () => {
     const init = async () => {
         if (!browser || initialized) return;
 
-        // A failed request leaves the flags empty, so a backend that cannot be reached is never
-        // tracked against.
-        const { featureFlags, ready } = useFeatureFlags();
+        // A failed request leaves the config empty, so a backend that cannot be reached is never
+        // tracked against. LIGHTLY_STUDIO_ANALYTICS_ENABLED decides there, so one variable opts
+        // out of tracking in both the Python package and here.
+        const { config, ready } = useAnalyticsConfig();
         await ready;
-        if (!get(featureFlags).includes(ANALYTICS_FEATURE)) return;
+        const analyticsConfig = get(config);
+        if (!analyticsConfig?.enabled) return;
         // Re-check: concurrent callers both get past the guard above before this resolves.
         if (initialized) return;
 
@@ -62,6 +60,14 @@ export const usePostHog = () => {
             capture_exceptions: true
         });
         posthog.register({ app_version: version });
+
+        // Report against the installation ID the Python package uses, so backend and browser
+        // events belong to one person rather than two, with the cohort on that person.
+        if (analyticsConfig.distinct_id) {
+            posthog.identify(analyticsConfig.distinct_id, {
+                user_cohort: analyticsConfig.user_cohort
+            });
+        }
 
         initialized = true;
     };


### PR DESCRIPTION
## What has changed and why?

Stacked on #2104, which adds the cohort. Second of three for [LIG-10435](https://linear.app/lightly/issue/LIG-10435/figure-out-track-devs-and-staff-separately-from-real-users).

`posthog.identify` was never called, and with `person_profiles: 'identified_only'` the browser had no person profile at all. Browser events therefore used a different distinct ID than the Python package, so one install counted as two people, and the cohort from #2104 could not reach the GUI.

New `GET /api/analytics/config` returns `{enabled, distinct_id, user_cohort}`, and the GUI reads it instead of the feature-flag list. It reports against the installation ID the Python package uses, so backend and browser events belong to one person and the cohort lands on that person from both sides. The endpoint deliberately does not read the installation ID while analytics are off, since reading it writes it to disk.

Known gap: Playwright e2e runs a real backend and a real browser, so the pytest guard from #2104 does not catch it. On CI the `ci` cohort covers it; run locally it reports as `staff` or `source_build`. Filterable, but not dropped.

## How has it been tested?

New tests for the endpoint with analytics on and off, for the hook, and for the `identify` call.

- `cd lightly_studio && make static-checks && make test` — 2162 passed, 41 skipped; `mypy` clean on the touched files. Same four pre-existing collection failures as #2104, excluded and untouched.
- `cd lightly_studio_view && make static-checks && npm run test:unit -- --run` — passing, `svelte-check` 0 errors 0 warnings.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @gabrielfruet, as for #2104. Alternative: @IgorSusmelj.