### PR TITLE
Add SubpartDiversityStrategy config model and Mundig wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole collection on every click, for annotations on images and on video frames. On PostgreSQL
   with 4M annotations a click went from 6.3s to 1.3s; the neighbour lookup itself went from ~6s
   to 3ms, and the remaining 1.2s is the exact position and total counts.
+- Bump lightly-mundig to 0.1.15; its sampling algorithms are up to 7x faster.
 
 ### Deprecated
 

--- a/lightly_studio/pyproject.toml
+++ b/lightly_studio/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # Mundig releases are published to PyPI: https://pypi.org/project/lightly-mundig/
     # To update, bump the pin below and relock:
     # uv lock --upgrade-package lightly-mundig==$version
-    "lightly-mundig==0.1.14",
+    "lightly-mundig==0.1.15",
     "pyarrow>=17.0.0",
     "av>=10.0.0",
     "requests>=2.32.3",

--- a/lightly_studio/src/lightly_studio/sampling/mundig.py
+++ b/lightly_studio/src/lightly_studio/sampling/mundig.py
@@ -163,6 +163,52 @@ class Mundig:
             strength=strength,
         )
 
+    def add_subpart_diversity(
+        self,
+        embeddings: Iterable[Iterable[Iterable[float]]],
+        strength: float = 1.0,
+        stopping_condition_minimum_distance: float | None = None,
+    ) -> None:
+        """Add subpart diversity-based sampling using per-sample subpart embeddings.
+
+        Each sample may have zero or more subpart embeddings (e.g. annotation crops).
+        Diversity is computed across all subparts rather than whole-sample embeddings.
+
+        Args:
+            embeddings:
+                Ragged per-sample list of subpart embeddings.
+                The outer dimension is over samples. Each inner list contains
+                the embeddings of the subparts (crops) for that sample.
+                Samples with no subparts produce an empty inner list and remain
+                eligible for selection; they simply contribute no embedding signal.
+            strength:
+                The strength of the subpart diversity strategy.
+            stopping_condition_minimum_distance:
+                When a sample would be closer than this distance to the already
+                selected samples, selection stops. ``None`` disables the stopping
+                condition.
+        """
+        # Materialise the ragged input so we can iterate it multiple times.
+        subpart_embeddings_per_sample = [list(subparts) for subparts in embeddings]
+        self._check_consistent_input_size(len(subpart_embeddings_per_sample))
+
+        # Flatten subpart embeddings and build the sample → subpart index mapping.
+        flat_embeddings: list[Iterable[float]] = []
+        sample_to_subpart_indices: list[list[int]] = []
+        offset = 0
+        for subparts in subpart_embeddings_per_sample:
+            sample_to_subpart_indices.append(list(range(offset, offset + len(subparts))))
+            flat_embeddings.extend(subparts)
+            offset += len(subparts)
+
+        embeddings_ndarray = np.array(flat_embeddings, dtype=np.float32)
+        self.mundig.add_subpart_diversifying_strategy(
+            embeddings=embeddings_ndarray,
+            sample_to_subpart_indices=sample_to_subpart_indices,
+            strength=strength,
+            stopping_condition_minimum_distance=stopping_condition_minimum_distance,
+        )
+
     def _check_consistent_input_size(self, n_input_samples_strategy: int) -> None:
         """Assert that input samples count is consistent across strategies.
 

--- a/lightly_studio/src/lightly_studio/sampling/mundig.py
+++ b/lightly_studio/src/lightly_studio/sampling/mundig.py
@@ -201,6 +201,9 @@ class Mundig:
             flat_embeddings.extend(subparts)
             offset += len(subparts)
 
+        if not flat_embeddings:
+            return
+
         embeddings_ndarray = np.array(flat_embeddings, dtype=np.float32)
         self.mundig.add_subpart_diversifying_strategy(
             embeddings=embeddings_ndarray,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal, Union
+from typing import Annotated, Literal, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -102,3 +102,23 @@ class MetadataBalancingStrategy(SamplingStrategy):
     strategy_name: Literal["metadata_balance"] = "metadata_balance"
     metadata_key: str
     target_distribution: MetadataValueToTarget | Literal["uniform"] | Literal["input"]
+
+class SubpartDiversityStrategy(SamplingStrategy):
+    """Sampling strategy based on diversity of annotation subparts (crops)."""
+
+    strategy_name: Literal["subpart_diversity"] = "subpart_diversity"
+    embedding_model_name: str | None = None
+    annotation_source_id: UUID | None = None
+
+
+Strategy = Annotated[
+    Union[
+        AnnotationClassBalancingStrategy,
+        EmbeddingDeduplicationStrategy,
+        EmbeddingDiversityStrategy,
+        EmbeddingSimilarityStrategy,
+        MetadataWeightingStrategy,
+        SubpartDiversityStrategy,
+    ],
+    Field(discriminator="strategy_name"),
+]

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -103,6 +103,7 @@ class MetadataBalancingStrategy(SamplingStrategy):
     metadata_key: str
     target_distribution: MetadataValueToTarget | Literal["uniform"] | Literal["input"]
 
+
 class SubpartDiversityStrategy(SamplingStrategy):
     """Sampling strategy based on diversity of annotation subparts (crops)."""
 

--- a/lightly_studio/tests/sampling/test_mundig.py
+++ b/lightly_studio/tests/sampling/test_mundig.py
@@ -181,6 +181,14 @@ class TestMundig:
         sampled = mundig.run(n_samples=2)
         assert sampled == [0, 2]
 
+    def test_add_subpart_diversity__all_empty_subpart_lists(self) -> None:
+        """Test subpart diversity when every sample has no subparts."""
+        mundig = Mundig()
+        mundig.add_subpart_diversity([[], [], []])
+        mundig.add_weighting([1.0, 3.0, 2.0])
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [1, 2]
+
     def test_mundig_rust_error(self) -> None:
         """Test the error handling for Rust exceptions.
 

--- a/lightly_studio/tests/sampling/test_mundig.py
+++ b/lightly_studio/tests/sampling/test_mundig.py
@@ -146,6 +146,41 @@ class TestMundig:
             # `target` only has 1 class
             mundig.add_class_balancing(class_distributions=class_distributions, target=[0.5])
 
+    def test_add_subpart_diversity__single_subpart_per_sample(self) -> None:
+        """Test subpart diversity with exactly one subpart per sample."""
+        mundig = Mundig()
+        mundig.add_subpart_diversity([[[1.0]], [[3.0]], [[5.0]]])
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [0, 2]
+
+    def test_add_subpart_diversity__multiple_subparts_per_sample(self) -> None:
+        """Test subpart diversity with varying numbers of subparts per sample."""
+        mundig = Mundig()
+        # Samples 0 and 1 cluster at opposite ends; sample 2 is in the middle.
+        # Selecting 2 samples should pick one from each cluster end.
+        mundig.add_subpart_diversity(
+            [
+                [[1.0, 0.0], [0.9, 0.1]],  # 2 subparts near [1, 0]
+                [[0.0, 1.0], [0.1, 0.9]],  # 2 subparts near [0, 1]
+                [[0.5, 0.5]],  # 1 subpart in the middle
+            ]
+        )
+        sampled = mundig.run(n_samples=2)
+        assert set(sampled) == {0, 1}
+
+    def test_add_subpart_diversity__empty_subpart_list(self) -> None:
+        """Test subpart diversity when at least one sample has no subparts."""
+        mundig = Mundig()
+        mundig.add_subpart_diversity(
+            [
+                [[1.0]],  # 1 subpart
+                [],  # 0 subparts — still eligible for selection
+                [[5.0]],  # 1 subpart
+            ]
+        )
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [0, 2]
+
     def test_mundig_rust_error(self) -> None:
         """Test the error handling for Rust exceptions.
 

--- a/lightly_studio/tests/sampling/test_sampling_config.py
+++ b/lightly_studio/tests/sampling/test_sampling_config.py
@@ -5,12 +5,22 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from lightly_studio.sampling.sampling_config import (
     EmbeddingDiversityStrategy,
     SamplingConfig,
+    Strategy,
 )
+
+
+class _StrategyWrapper(BaseModel):
+    strategy: Strategy
+
+
+def test_subpart_diversity_strategy__unknown_strategy_name_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _StrategyWrapper.model_validate({"strategy": {"strategy_name": "unknown_subpart"}})
 
 
 class TestSamplingConfig:

--- a/lightly_studio/tests/sampling/test_sampling_config.py
+++ b/lightly_studio/tests/sampling/test_sampling_config.py
@@ -18,7 +18,7 @@ class _StrategyWrapper(BaseModel):
     strategy: Strategy
 
 
-def test_subpart_diversity_strategy__unknown_strategy_name_rejected() -> None:
+def test_strategy__unknown_strategy_name_rejected() -> None:
     with pytest.raises(ValidationError):
         _StrategyWrapper.model_validate({"strategy": {"strategy_name": "unknown_subpart"}})
 

--- a/lightly_studio/uv.lock
+++ b/lightly_studio/uv.lock
@@ -3132,13 +3132,13 @@ wheels = [
 
 [[package]]
 name = "lightly-mundig"
-version = "0.1.14"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/64/e470dcfd7f994419f160461b9c3fb4d1dd2d1ceab215ce4ef68fa2c2581c/lightly_mundig-0.1.14-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:67bd634b021b9a810b8360b51c90e64738f724e89600986ed4e7566fd0501267", size = 538138, upload-time = "2026-08-13T11:51:00.198Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ce/89ea9f51128249afbaa0d430ca40a9d35a0759341a4c15bd3e54d94f7340/lightly_mundig-0.1.14-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0438b96611d8407e8c08cfb901a988369b2d14496b7978dec02d7e517a6aad7", size = 512424, upload-time = "2026-08-13T11:52:42.342Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/4b/c20499d2bf9e1f55516ce64485d191b3448ae6dab4e1269a68620fa8eb09/lightly_mundig-0.1.14-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26dd67d68e6a90a44e03c994380cf4fa4a872ce0d28aea2794dca2f008ea4ddb", size = 3867562, upload-time = "2026-08-13T11:57:58.524Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/56/58ed79ec2f95d966eb46a7f0f0506676e6ed54fd68099aff5b1d379d6f5a/lightly_mundig-0.1.14-cp39-abi3-win_amd64.whl", hash = "sha256:24ac782527ad0e24fee4e3a9b72c861ded3716ca6799a2c691b06e2727485672", size = 5969363, upload-time = "2026-08-13T12:19:32.749Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d3/702cef37adc1d3fde431e8161457356b192141bd0f2ee8f4e662dd74399f/lightly_mundig-0.1.15-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c804faa7425b75b2f26f3dd20beeb3d937f0db9364d9faa9c2489de8786c9b07", size = 542273, upload-time = "2026-08-25T14:02:18.021Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0f/236f6dee22f39615ba1b45727f8b3a01e5f7a294ae0a4f4dd82cfad90c10/lightly_mundig-0.1.15-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:791848274520a32de8c7aa8b3f316894ff61db3844b2f8c0f710d1306df698da", size = 524128, upload-time = "2026-08-25T14:03:35.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/cf/14d3cf43ae659a82651ed7ab8ef1681d05ff053e80de455febce3c31f726/lightly_mundig-0.1.15-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30cde5be69ebf23461357dc375b44a21b254e1d3ae13450891825ccf16a537e1", size = 3968872, upload-time = "2026-08-25T14:09:05.838Z" },
+    { url = "https://files.pythonhosted.org/packages/44/80/e86ab8cd239ed501673a0dab0550449cf68bd50765a6f2037a4416fd3b0d/lightly_mundig-0.1.15-cp39-abi3-win_amd64.whl", hash = "sha256:8eeae3e4bfa135b7ec32d127d1a10803df5e1d7946b4830f9efd4f952c06952e", size = 5987911, upload-time = "2026-08-25T14:13:20.274Z" },
 ]
 
 [[package]]
@@ -3261,7 +3261,7 @@ requires-dist = [
     { name = "gcsfs", marker = "extra == 'cloud-storage'", specifier = ">=2023.1.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "labelformat", specifier = ">=0.1.17" },
-    { name = "lightly-mundig", specifier = "==0.1.14" },
+    { name = "lightly-mundig", specifier = "==0.1.15" },
     { name = "open-clip-torch", specifier = ">=2.20.0" },
     { name = "opencv-python-headless", specifier = ">=4.11.0.86" },
     { name = "pandas", specifier = ">=2.2.3,<3.0" },


### PR DESCRIPTION
## What has changed and why?

Introduces the building blocks for subpart diversity sampling.

- `SubpartDiversityStrategy` model added to the `Strategy` union in `sampling_config.py`
- `Mundig.add_subpart_diversity()` wraps `lightly_mundig.Selection.add_subpart_diversifying_strategy`.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>