### PR TITLE
Add the docs build hook and open the theme override directory

### DIFF
--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -5,7 +5,20 @@ site_url: https://docs.lightly.ai/studio
 
 theme:
   name: material
-  language: en
+  # Not `en`. `overrides/partials/languages/custom.html` answers the handful of
+  # strings this theme words differently and lets Material fall back to `en` for
+  # everything else.
+  language: custom
+  # `overrides/` holds six templates. `main.html`, `partials/site_footer.html`
+  # and `partials/languages/custom.html` are additive — they append the site
+  # footer under Material's prev/next pager and reword a string or two.
+  # `partials/header.html`, `partials/nav.html` and `partials/toc.html` are FORKS
+  # of the same-named Material 9.7.5 partials, carrying the section tab strip and
+  # the sidebar scoping it does (see `extra.tabs` below), the release chip, and
+  # the page-action links under the contents list. Upstream regenerates those
+  # files between releases and shadowing them is silent, so re-diff them against
+  # `material/templates/partials/` whenever mkdocs-material is bumped.
+  custom_dir: overrides
   logo: _static/lightly_logo.svg
   favicon: _static/lightly_logo_fav.svg
   palette:
@@ -30,6 +43,11 @@ theme:
 repo_url: https://github.com/lightly-ai/lightly-studio
 repo_name: LightlyStudio
 docs_dir: docs
+
+# Sets `extra.package_version` from the installed package, so the footer does not
+# carry a second copy of the version. See `mkdocs_hooks.py`.
+hooks:
+  - mkdocs_hooks.py
 
 nav:
   - Getting Started:
@@ -193,6 +211,10 @@ plugins:
   - git-revision-date-localized:
       type: date
       fallback_to_build_date: true
+      # This plugin defaults its locale to `theme.language`, which is `custom`
+      # here — a Material convention, not a babel one, so it raises
+      # `UnknownLocaleError` on the first page. Say `en` outright.
+      locale: en
 
 extra:
   homepage: https://lightly.ai/lightly-studio
@@ -207,14 +229,17 @@ extra:
 markdown_extensions:
   - admonition
   - attr_list
-  - codehilite
   - def_list
   - footnotes
   - md_in_html
   - toc:
       permalink: true
   - pymdownx.details
-  - pymdownx.highlight
+  # `pygments_lang_class` puts the fence language on the wrapper as
+  # `language-python`, which is the only hook the header label has to read from.
+  # See `labelCodeBlocks` in _static/custom.js.
+  - pymdownx.highlight:
+      pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences

--- a/lightly_studio/docs/mkdocs_hooks.py
+++ b/lightly_studio/docs/mkdocs_hooks.py
@@ -7,7 +7,7 @@ it is not part of the `lightly_studio` package and nothing else imports it.
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from importlib import metadata
 from typing import Any, NamedTuple
 
@@ -76,9 +76,11 @@ def on_nav(
     `extra.tab_sections`, which maps each tab to the section titles the sidebar
     shows while that tab is active.
 
-    Warns — and so, under `mkdocs build --strict`, fails the build — when a tab
-    claims a section the nav does not have. Without that check, renaming a
-    section on the content branch would silently unscope it.
+    Malformed `extra.tabs` is warned about, not acted on: `_validated_tab_specs`
+    drops a tab missing a `name` or `sections`, and warns about a tab claiming a
+    section the nav lacks, two tabs sharing a name, and a count of `default` tabs
+    other than one. Every warning fails the build under `mkdocs build --strict`,
+    so a bad edit stops the docs instead of shipping a broken or unscoped strip.
 
     Args:
         nav: The navigation tree MkDocs has just built.
@@ -88,42 +90,14 @@ def on_nav(
     Returns:
         The same navigation tree, unmodified.
     """
-    specs = config.extra.get("tabs") or []
-    sections = {item.title: item for item in nav.items}
-    claimed = {title for spec in specs for title in spec["sections"]}
-
-    links: list[Tab] = []
-    tab_sections: dict[str, frozenset[str]] = {}
-    for spec in specs:
-        name = spec["name"]
-        missing = [title for title in spec["sections"] if title not in sections]
-        if missing:
-            log.warning(
-                f"Tab {name!r} claims nav sections that do not exist: "
-                f"{', '.join(repr(title) for title in missing)}. Update "
-                f"`extra.tabs` in mkdocs.yml to match `nav:`."
-            )
-
-        owned = [title for title in spec["sections"] if title in sections]
-        if spec.get("default"):
-            owned += [title for title in sections if title not in claimed]
-
-        # The first section the tab claims that actually holds a page.
-        candidates = (_landing_url(sections[title]) for title in owned)
-        url = next((candidate for candidate in candidates if candidate is not None), None)
-        if url is None:
-            log.warning(f"Tab {name!r} has no page to link to and was dropped.")
-            continue
-
-        links.append(Tab(name=name, url=url))
-        tab_sections[name] = frozenset(owned)
-
-    if specs and not any(spec.get("default") for spec in specs):
-        log.warning(
-            "No tab in `extra.tabs` is marked `default: true`, so a nav section "
-            "no tab claims would be reachable from no tab at all."
-        )
-
+    sections: dict[str, StructureItem] = {
+        item.title: item for item in nav.items if item.title is not None
+    }
+    specs = _validated_tab_specs(
+        specs=config.extra.get("tabs") or [],
+        section_titles=set(sections),
+    )
+    links, tab_sections = _resolve_tabs(specs=specs, sections=sections)
     config.extra["tab_links"] = links
     config.extra["tab_sections"] = tab_sections
     return nav
@@ -158,6 +132,136 @@ def on_page_context(
     context["ls_active_tab"] = active
     context["ls_nav_sections"] = tab_sections[active] if active is not None else None
     return context
+
+
+def _validated_tab_specs(
+    *, specs: Sequence[Mapping[str, Any]], section_titles: set[str]
+) -> list[Mapping[str, Any]]:
+    """Warns on every malformed tab and returns only the well-formed ones.
+
+    Each warning fails the build under `mkdocs build --strict`. A tab missing a
+    `name` or `sections` is dropped so the rest of the strip still resolves;
+    every other problem is warned about but left in, since the tab is otherwise
+    usable.
+
+    Args:
+        specs: The raw `extra.tabs` entries, straight from the YAML.
+        section_titles: The titles of the top-level `nav:` sections.
+
+    Returns:
+        The subset of `specs` that carry both a `name` and a `sections` key, in
+        their original order.
+    """
+    well_formed: list[Mapping[str, Any]] = []
+    for spec in specs:
+        if "name" not in spec or "sections" not in spec:
+            log.warning(
+                f"Dropping a tab in `extra.tabs` that is missing a `name` or "
+                f"`sections` key: {spec!r}."
+            )
+            continue
+        _warn_on_missing_sections(spec=spec, section_titles=section_titles)
+        well_formed.append(spec)
+
+    names = [spec["name"] for spec in well_formed]
+    for name in sorted({n for n in names if names.count(n) > 1}):
+        log.warning(
+            f"Two or more tabs in `extra.tabs` are named {name!r}. Tab names "
+            f"must be unique; the sidebar scoping keys on them."
+        )
+
+    defaults = [spec["name"] for spec in well_formed if spec.get("default")]
+    if well_formed and len(defaults) != 1:
+        log.warning(
+            f"`extra.tabs` must mark exactly one tab `default: true`, found "
+            f"{len(defaults)}: {', '.join(repr(name) for name in defaults)}. The "
+            f"default tab is where nav sections no tab claims are shown."
+        )
+    return well_formed
+
+
+def _warn_on_missing_sections(*, spec: Mapping[str, Any], section_titles: set[str]) -> None:
+    """Warns when a tab claims a `nav:` section that does not exist.
+
+    Args:
+        spec: One well-formed `extra.tabs` entry.
+        section_titles: The titles of the top-level `nav:` sections.
+    """
+    missing = [title for title in spec["sections"] if title not in section_titles]
+    if missing:
+        log.warning(
+            f"Tab {spec['name']!r} claims nav sections that do not exist: "
+            f"{', '.join(repr(title) for title in missing)}. Update "
+            f"`extra.tabs` in mkdocs.yml to match `nav:`."
+        )
+
+
+def _resolve_tabs(
+    *, specs: Sequence[Mapping[str, Any]], sections: Mapping[str, StructureItem]
+) -> tuple[list[Tab], dict[str, frozenset[str]]]:
+    """Builds the tab strip and each tab's sidebar scope from validated specs.
+
+    A tab lands on the first page under the sections it claims. The `default` tab
+    also takes every section no other *surviving* tab claims, so a section stays
+    reachable even when the only tab that named it is dropped for want of a page.
+
+    Args:
+        specs: The well-formed `extra.tabs` entries, in strip order.
+        sections: The top-level `nav:` sections, keyed by title.
+
+    Returns:
+        The strip as a list of `Tab`, and the map from tab name to the frozenset
+        of section titles its sidebar shows.
+    """
+    explicit = {
+        spec["name"]: [title for title in spec["sections"] if title in sections] for spec in specs
+    }
+    landing = {
+        name: _first_landing_url(owned=owned, sections=sections) for name, owned in explicit.items()
+    }
+    # A dropped tab (no landing page) must not keep its sections out of the
+    # default tab, so only tabs that survive count as claiming a section.
+    claimed = {
+        title
+        for spec in specs
+        if landing[spec["name"]] is not None
+        for title in explicit[spec["name"]]
+    }
+
+    links: list[Tab] = []
+    tab_sections: dict[str, frozenset[str]] = {}
+    for spec in specs:
+        name = spec["name"]
+        owned = list(explicit[name])
+        if spec.get("default"):
+            owned += [title for title in sections if title not in claimed and title not in owned]
+        url = landing[name] or _first_landing_url(owned=owned, sections=sections)
+        if url is None:
+            log.warning(f"Tab {name!r} has no page to link to and was dropped.")
+            continue
+        links.append(Tab(name=name, url=url))
+        tab_sections[name] = frozenset(owned)
+    return links, tab_sections
+
+
+def _first_landing_url(
+    *, owned: Iterable[str], sections: Mapping[str, StructureItem]
+) -> str | None:
+    """Returns the landing URL of the first section in `owned` that holds a page.
+
+    Args:
+        owned: Section titles, in the order the tab claims them.
+        sections: The top-level `nav:` sections, keyed by title.
+
+    Returns:
+        A URL relative to the site root, or None when no owned section holds a
+        page.
+    """
+    for title in owned:
+        url = _landing_url(sections[title])
+        if url is not None:
+            return url
+    return None
 
 
 def _landing_url(item: StructureItem) -> str | None:

--- a/lightly_studio/docs/mkdocs_hooks.py
+++ b/lightly_studio/docs/mkdocs_hooks.py
@@ -1,0 +1,205 @@
+"""Build-time hooks for the LightlyStudio docs.
+
+Registered from `mkdocs.yml` under `hooks:`. MkDocs imports this file by path, so
+it is not part of the `lightly_studio` package and nothing else imports it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Mapping, MutableMapping
+from importlib import metadata
+from typing import Any, NamedTuple
+
+from mkdocs import plugins
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure import StructureItem
+from mkdocs.structure.files import Files
+from mkdocs.structure.nav import Navigation, Section
+from mkdocs.structure.pages import Page
+
+log = plugins.get_plugin_logger(__name__)
+
+
+class Tab(NamedTuple):
+    """One tab of the header strip, resolved against the nav tree.
+
+    Attributes:
+        name: The label the strip prints.
+        url: Where the tab lands, as a URL relative to the site root.
+    """
+
+    name: str
+    url: str
+
+
+def on_config(config: MkDocsConfig) -> MkDocsConfig:
+    """Publishes the installed LightlyStudio version to the page templates.
+
+    The footer prints it as the version the docs were built from, which keeps
+    `pyproject.toml` the only place the version is written down. Building from a
+    tree where the package is not installed leaves the key unset, and the footer
+    then omits the version rather than printing a stale one.
+
+    The key is `package_version` rather than `version`, which Material reserves
+    for its mike-backed version selector.
+
+    Args:
+        config: The configuration MkDocs has just loaded.
+
+    Returns:
+        The same configuration, with `extra.package_version` set when the
+        package is installed.
+    """
+    with contextlib.suppress(metadata.PackageNotFoundError):
+        config.extra["package_version"] = metadata.version("lightly-studio")
+    return config
+
+
+def on_nav(
+    nav: Navigation,
+    *,
+    config: MkDocsConfig,
+    files: Files,  # noqa: ARG001
+) -> Navigation:
+    """Resolves the header tab strip against the nav tree.
+
+    Each tab authored under `extra.tabs` claims a set of top-level `nav:` section
+    titles, and lands on the first page beneath the first section it claims.
+    Deriving that landing page from the nav rather than writing a URL down keeps
+    the strip pointing somewhere real when the content branch moves a section.
+
+    Sections no tab claims are added to the tab marked `default`, so a section
+    added later is reachable from somewhere instead of falling out of every tab.
+
+    Writes two keys the templates read: `extra.tab_links`, the strip itself, and
+    `extra.tab_sections`, which maps each tab to the section titles the sidebar
+    shows while that tab is active.
+
+    Warns — and so, under `mkdocs build --strict`, fails the build — when a tab
+    claims a section the nav does not have. Without that check, renaming a
+    section on the content branch would silently unscope it.
+
+    Args:
+        nav: The navigation tree MkDocs has just built.
+        config: The site configuration, read for `extra.tabs` and written to.
+        files: The files collected for this build. Unused.
+
+    Returns:
+        The same navigation tree, unmodified.
+    """
+    specs = config.extra.get("tabs") or []
+    sections = {item.title: item for item in nav.items}
+    claimed = {title for spec in specs for title in spec["sections"]}
+
+    links: list[Tab] = []
+    tab_sections: dict[str, frozenset[str]] = {}
+    for spec in specs:
+        name = spec["name"]
+        missing = [title for title in spec["sections"] if title not in sections]
+        if missing:
+            log.warning(
+                f"Tab {name!r} claims nav sections that do not exist: "
+                f"{', '.join(repr(title) for title in missing)}. Update "
+                f"`extra.tabs` in mkdocs.yml to match `nav:`."
+            )
+
+        owned = [title for title in spec["sections"] if title in sections]
+        if spec.get("default"):
+            owned += [title for title in sections if title not in claimed]
+
+        # The first section the tab claims that actually holds a page.
+        candidates = (_landing_url(sections[title]) for title in owned)
+        url = next((candidate for candidate in candidates if candidate is not None), None)
+        if url is None:
+            log.warning(f"Tab {name!r} has no page to link to and was dropped.")
+            continue
+
+        links.append(Tab(name=name, url=url))
+        tab_sections[name] = frozenset(owned)
+
+    if specs and not any(spec.get("default") for spec in specs):
+        log.warning(
+            "No tab in `extra.tabs` is marked `default: true`, so a nav section "
+            "no tab claims would be reachable from no tab at all."
+        )
+
+    config.extra["tab_links"] = links
+    config.extra["tab_sections"] = tab_sections
+    return nav
+
+
+def on_page_context(
+    context: MutableMapping[str, Any],
+    *,
+    page: Page,
+    config: MkDocsConfig,
+    nav: Navigation,  # noqa: ARG001
+) -> MutableMapping[str, Any]:
+    """Tells the templates which tab this page belongs to.
+
+    `ls_active_tab` marks the tab in the strip; `ls_nav_sections` is the set of
+    top-level section titles the sidebar renders, which is what scopes it. Both
+    are unset on templates MkDocs builds without a page — 404.html — where the
+    strip draws with nothing marked and the sidebar shows every section, since a
+    reader who is lost should see all the routes rather than one tab's.
+
+    Args:
+        context: The template context MkDocs has just built for the page.
+        page: The page being rendered.
+        config: The site configuration, read for what `on_nav` resolved.
+        nav: The navigation tree. Unused.
+
+    Returns:
+        The same context, with the two keys above added.
+    """
+    tab_sections: Mapping[str, frozenset[str]] = config.extra.get("tab_sections") or {}
+    active = _active_tab_name(page=page, tab_sections=tab_sections)
+    context["ls_active_tab"] = active
+    context["ls_nav_sections"] = tab_sections[active] if active is not None else None
+    return context
+
+
+def _landing_url(item: StructureItem) -> str | None:
+    """Returns the URL of the first page under `item`, depth first.
+
+    Args:
+        item: A nav section, page or link.
+
+    Returns:
+        A URL relative to the site root, or None when the item holds no page —
+        an external link, or a section of nothing but links. Narrowing by type
+        rather than by `is_page`, which is a plain attribute the type checker
+        cannot read as a guard.
+    """
+    if isinstance(item, Page):
+        # A local `uv run mypy .` resolves the default groups only, so mkdocs is
+        # absent and every symbol from it is `Any`; the annotation is what keeps
+        # `--warn-return-any` quiet there. See the `mkdocs.*` override in
+        # `pyproject.toml`. CI installs all groups and types this properly.
+        page_url: str = item.url
+        return page_url
+    if isinstance(item, Section):
+        for child in item.children:
+            url = _landing_url(child)
+            if url is not None:
+                return url
+    return None
+
+
+def _active_tab_name(page: Page, tab_sections: Mapping[str, frozenset[str]]) -> str | None:
+    """Returns the name of the tab whose sections contain `page`.
+
+    Args:
+        page: The page being rendered.
+        tab_sections: Section titles per tab, as resolved by `on_nav`.
+
+    Returns:
+        The tab name, or None for a page that sits at the top level of `nav:`
+        and so belongs to no section.
+    """
+    ancestors = list(page.ancestors)
+    if not ancestors:
+        return None
+    root = ancestors[-1].title
+    return next((name for name, titles in tab_sections.items() if root in titles), None)

--- a/lightly_studio/docs/overrides/partials/languages/custom.html
+++ b/lightly_studio/docs/overrides/partials/languages/custom.html
@@ -1,0 +1,10 @@
+{#-
+  Translation overrides, selected by `theme.language: custom` in mkdocs.yml.
+  Material resolves a key through this file first and falls back to
+  `partials/languages/en.html` for anything it does not answer, so only the
+  strings that differ belong here — see `partials/language.html`.
+-#}
+{% macro t(key) %}{{ {
+  "search.placeholder": "Search the docs",
+  "toc": "On this page",
+}[key] }}{% endmacro %}

--- a/lightly_studio/pyproject.toml
+++ b/lightly_studio/pyproject.toml
@@ -113,6 +113,13 @@ exclude = [
 ]
 plugins = ["pydantic.mypy"]
 
+# Only `docs/mkdocs_hooks.py` imports this. CI installs the `docs` group
+# (`make install-optional-deps` is `uv sync --all-groups`), so this is for a
+# plain local `uv run mypy .`, which resolves the default groups only.
+[[tool.mypy.overrides]]
+module = "mkdocs.*"
+ignore_missing_imports = true
+
 [[tool.mypy.overrides]]
 module = "fsspec.*"
 ignore_missing_imports = true


### PR DESCRIPTION
## What has changed and why?

First of six PRs redesigning the docs theme. This one is build-side: it registers a hook file, `docs/mkdocs_hooks.py`, and opens `overrides/` as the theme's custom_dir.

Almost nothing renders differently yet. `on_config` publishes a package version no template reads. `on_nav` resolves a header tab strip out of `extra.tabs`, a key that does not exist until PR 5. What is live: a language partial rewords the search placeholder and the contents heading, and highlighting drops `codehilite` for `pygments_lang_class`, which stamps the fence language onto the code block wrapper.

Selecting `theme.language: custom` is a Material convention babel knows nothing about, so `git-revision-date-localized` needs its locale pinned to `en` or it raises `UnknownLocaleError` on the first page. The `mkdocs.*` mypy override keeps a plain local `uv run mypy .` quiet, since that does not resolve the docs group.

Comments in `mkdocs.yml` describe the finished stack, so a few names they point at land in later PRs.

At 253 lines it is over the 200-line target, but 205 of those are the new hook file, mostly docstrings for behavior the later PRs switch on.

## How has it been tested?

`make docs` in `lightly_studio/docs`, which runs `mkdocs build --clean --strict`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Next: flattening the nav into task-named sections.


---

**Stack** — [LIG-10506](https://linear.app/lightly/issue/LIG-10506/interface-redesign), merge bottom-up:

1. **#2114** ← you are here — Docs build hook and overrides directory
2. #2115 — Flatten the nav
3. #2116 — Token layer and palette
4. #2117 — Shell, header and sidebars
5. #2118 — Section tabs, page actions, footer
6. #2119 — Article body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved documentation navigation with validated, tab-aware sections and clearer handling of incomplete or duplicate navigation settings.
  * Added clear labels for documentation search and table of contents.
  * Standardized revision dates to English and improved code-block language labeling.
  * Enhanced documentation configuration for more reliable builds and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->