### PR TITLE
Flatten the docs nav into task-named sections

### DIFF
--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -212,12 +212,6 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
 }
 
 
-/* Bold the active top-level menu item in the header navigation tabs */
-.md-tabs__item--active .md-tabs__link {
-  font-weight: 700;
-}
-
-
 /* ===== Multi-row tab overrides ===== */
 
 /* Enable wrapping; remove theme's inset box-shadow and scroll behavior */

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -56,11 +56,12 @@ docs_dir: docs
 hooks:
   - mkdocs_hooks.py
 
-# Six sections, named for what the reader is doing rather than for the kind of
-# artifact each page is: get set up, run the loop, learn the vocabulary, plug
-# something in, look something up. The theme-overrides PR promotes two of the six
-# to header tabs via `extra.tabs`; on this branch, with no tab strip, all six
-# render in the sidebar.
+# Seven sections. The five in the sidebar are named for what the reader is doing
+# rather than for the kind of artifact each page is: get set up, run the loop,
+# learn the vocabulary, plug something in, look something up. The theme-overrides
+# PR gives Tutorials and Enterprise each their own header tab via `extra.tabs` and
+# groups those five under a default Docs tab; on this branch, with no tab strip,
+# all seven render in the sidebar.
 #
 # Workflows is the product pipeline, in the order a user runs it: ingest, curate,
 # annotate, evaluate, export. One caption per stage, so the section reads top to

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -58,8 +58,9 @@ hooks:
 
 # Six sections, named for what the reader is doing rather than for the kind of
 # artifact each page is: get set up, run the loop, learn the vocabulary, plug
-# something in, look something up. Two of the six are their own header tab (see
-# `extra.tabs`), so the sidebar shows four at a time.
+# something in, look something up. The theme-overrides PR promotes two of the six
+# to header tabs via `extra.tabs`; on this branch, with no tab strip, all six
+# render in the sidebar.
 #
 # Workflows is the product pipeline, in the order a user runs it: ingest, curate,
 # annotate, evaluate, export. One caption per stage, so the section reads top to

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -1,4 +1,6 @@
-site_name: LightlyStudio Docs
+# The header renders this as the wordmark, so it is the product name alone —
+# "Docs" is what the whole site is.
+site_name: LightlyStudio
 site_description: LightlyStudio Documentation
 site_url: https://docs.lightly.ai/studio
 
@@ -26,19 +28,24 @@ theme:
       primary: teal
       accent: teal
   features:
-    - navigation.tabs
+    # Navigation lives entirely in the left sidebar: every section is a group
+    # caption with its pages listed under it, no top-level tab row.
     - navigation.sections
+    - navigation.expand
+    # Deliberately not `navigation.indexes`. It folds a section's index page
+    # into the section's own caption, and MkDocs picks that page for any
+    # `index.md` under the section, wherever it sits in `nav:` — which took
+    # `about_us/index.md` out of the sidebar and left the Resources caption
+    # pointing at it. Captions are labels here, pages are items, and every
+    # index page below is titled so it can be one.
     - navigation.path
     - navigation.top
-    - content.action.edit
-    - toc.follow
     - navigation.instant
-    - navigation.expand
-    - search.highlight
-    - navigation.tabs.sticky
-    - navigation.indexes
-    - content.tabs.link
+    - content.action.edit
     - content.code.copy
+    - content.tabs.link
+    - toc.follow
+    - search.highlight
 
 repo_url: https://github.com/lightly-ai/lightly-studio
 repo_name: LightlyStudio
@@ -49,36 +56,60 @@ docs_dir: docs
 hooks:
   - mkdocs_hooks.py
 
+# Six sections, named for what the reader is doing rather than for the kind of
+# artifact each page is: get set up, run the loop, learn the vocabulary, plug
+# something in, look something up. Two of the six are their own header tab (see
+# `extra.tabs`), so the sidebar shows four at a time.
+#
+# Workflows is the product pipeline, in the order a user runs it: ingest, curate,
+# annotate, evaluate, export. One caption per stage, so the section reads top to
+# bottom as the loop rather than as an alphabetical feature list. A page belongs
+# to the stage it serves, which is why the dataset pages sit under Data Ingest
+# rather than under Get Started.
+#
+# Core Concepts sits after Workflows, not inside Get Started. Tags and Metadata
+# are reached for mid-task — tracking curation progress, driving filters — not on
+# a first read, so a get-set-up caption did not describe them. The order is
+# FiftyOne's, whose nav this one otherwise follows: land, get running, see the
+# pipeline, then go deeper.
+#
+# Every other section keeps a single grouping level, and only where a run of
+# pages needs one — Data Ingest and the rest of the stages, and Python API. The
+# tree before last put a grouping level under every section ("Data Types",
+# "Setup Options", "Concepts", "Tools", "More"), which cost a whole visual
+# register to say things the section caption above it already said.
+#
+# No page moved on disk, so no URL changed and nothing needs a redirect.
 nav:
-  - Getting Started:
-    - index.md
-  - 🏢 Enterprise:
-    - Enterprise:
-      - enterprise/index.md
-      - Collaboration and Permissions: enterprise/collaboration.md
-      - Connect from Python: enterprise/connect.md
-      - Security and Architecture: enterprise/security.md
-      - On-Premise Deployment: enterprise/on-premise.md
-      - Local Storage: enterprise/local_storage.md
-    - Cloud Storage:
-      - enterprise/cloud_storage/index.md
-      - AWS S3: enterprise/cloud_storage/aws.md
-      - Google Cloud Storage: enterprise/cloud_storage/gcs.md
-      - Azure Blob Storage: enterprise/cloud_storage/azure.md
-  - Tutorials:
-    - tutorials/index.md
-    - "Tutorial 1: Curate a Traffic CCTV Dataset for YOLO Training": tutorials/yolo-traffic-cctv-object-detection.md
-    - "Tutorial 2: Evaluate YOLO26 on Your Dataset with LightlyStudio": tutorials/yolo26-model-evaluation.md
-  - Dataset Setup:
-    - Data Types:
+  - Get Started:
+    - Welcome: index.md
+    - Run LightlyStudio from a Notebook: dataset_setup/notebooks.md
+    - Reuse Datasets: dataset_setup/reuse_datasets.md
+  - Workflows:
+    - Data Ingest:
       - Image Dataset: dataset_setup/image_dataset.md
       - Video Dataset: dataset_setup/video_dataset.md
-    - Setup Options:
-      - Run LightlyStudio from a Notebook: dataset_setup/notebooks.md
-      - Cloud Storage: dataset_setup/cloud_storage.md
-      - Reuse Datasets: dataset_setup/reuse_datasets.md
-  - Python API:
-    - API Reference:
+    - Curate:
+      - Search and Filter: concepts_and_tools/search_and_filter.md
+      - Lightly Query Language: concepts_and_tools/lightly_query_language.md
+      - Dataset Distributions: concepts_and_tools/dataset_distributions.md
+      - Sampling: concepts_and_tools/sampling.md
+    - Annotate:
+      - Annotations: concepts_and_tools/annotations.md
+      - Captions: concepts_and_tools/captions.md
+    - Evaluate:
+      - Model Evaluation: concepts_and_tools/evaluation.md
+    - Export and Train:
+      - Export: concepts_and_tools/export.md
+  - Core Concepts:
+    - Tags: concepts_and_tools/tags.md
+    - Metadata: concepts_and_tools/metadata.md
+    - Embeddings: concepts_and_tools/embeddings.md
+  - Ecosystem:
+    - Plugins: concepts_and_tools/plugins.md
+    - Cloud Storage: dataset_setup/cloud_storage.md
+  - Resources:
+    - Python API:
       - Dataset: api/dataset.md
       - Sample: api/sample.md
       - DatasetQuery: api/dataset_query.md
@@ -87,24 +118,23 @@ nav:
       - Plugin: api/plugin.md
       - Annotation: api/annotation.md
       - Model Evaluation: api/evaluation.md
-  - Concepts & Tools:
-    - Concepts:
-      - Annotations: concepts_and_tools/annotations.md
-      - Tags: concepts_and_tools/tags.md
-      - Captions: concepts_and_tools/captions.md
-      - Metadata: concepts_and_tools/metadata.md
-      - Embeddings: concepts_and_tools/embeddings.md
-    - Tools:
-      - Search and Filter: concepts_and_tools/search_and_filter.md
-      - Dataset Distributions: concepts_and_tools/dataset_distributions.md
-      - Export: concepts_and_tools/export.md
-      - Sampling: concepts_and_tools/sampling.md
-      - Plugins: concepts_and_tools/plugins.md
-      - Model Evaluation: concepts_and_tools/evaluation.md
-    - More:
-      - Lightly Query Language: concepts_and_tools/lightly_query_language.md
-  - About Us:
-    - about_us/index.md
+    - About Us: about_us/index.md
+  - Tutorials:
+    - All Tutorials: tutorials/index.md
+    - "Tutorial 1: Curate a Traffic CCTV Dataset for YOLO Training": tutorials/yolo-traffic-cctv-object-detection.md
+    - "Tutorial 2: Evaluate YOLO26 on Your Dataset with LightlyStudio": tutorials/yolo26-model-evaluation.md
+  - Enterprise:
+    - Overview: enterprise/index.md
+    - Collaboration and Permissions: enterprise/collaboration.md
+    - Connect from Python: enterprise/connect.md
+    - Security and Architecture: enterprise/security.md
+    - On-Premise Deployment: enterprise/on-premise.md
+    - Local Storage: enterprise/local_storage.md
+    - Cloud Storage:
+      - Overview: enterprise/cloud_storage/index.md
+      - AWS S3: enterprise/cloud_storage/aws.md
+      - Google Cloud Storage: enterprise/cloud_storage/gcs.md
+      - Azure Blob Storage: enterprise/cloud_storage/azure.md
 
 # Promote link/nav checks from INFO to WARNING so that `mkdocs build --strict`
 # turns them into build errors (see the Makefile `docs` target).
@@ -134,8 +164,42 @@ plugins:
         intelligent data sampling, annotation management, embedding-based search, model evaluation,
         and cloud storage integration — accessible through a Python API or web interface.
       sections:
-        Getting Started:
+        Get Started:
           - index.md
+          - dataset_setup/notebooks.md
+          - dataset_setup/reuse_datasets.md
+        Workflows:
+          - dataset_setup/image_dataset.md
+          - dataset_setup/video_dataset.md
+          - concepts_and_tools/search_and_filter.md
+          - concepts_and_tools/lightly_query_language.md
+          - concepts_and_tools/dataset_distributions.md
+          - concepts_and_tools/sampling.md
+          - concepts_and_tools/annotations.md
+          - concepts_and_tools/captions.md
+          - concepts_and_tools/evaluation.md
+          - concepts_and_tools/export.md
+        Core Concepts:
+          - concepts_and_tools/tags.md
+          - concepts_and_tools/metadata.md
+          - concepts_and_tools/embeddings.md
+        Ecosystem:
+          - concepts_and_tools/plugins.md
+          - dataset_setup/cloud_storage.md
+        Resources:
+          - api/dataset.md
+          - api/sample.md
+          - api/dataset_query.md
+          - api/sampling.md
+          - api/embeddings.md
+          - api/plugin.md
+          - api/annotation.md
+          - api/evaluation.md
+          - about_us/index.md
+        Tutorials:
+          - tutorials/index.md
+          - tutorials/yolo-traffic-cctv-object-detection.md
+          - tutorials/yolo26-model-evaluation.md
         Enterprise:
           - enterprise/index.md
           - enterprise/collaboration.md
@@ -147,40 +211,6 @@ plugins:
           - enterprise/cloud_storage/aws.md
           - enterprise/cloud_storage/gcs.md
           - enterprise/cloud_storage/azure.md
-        Tutorials:
-          - tutorials/index.md
-          - tutorials/yolo-traffic-cctv-object-detection.md
-          - tutorials/yolo26-model-evaluation.md
-        Dataset Setup:
-          - dataset_setup/image_dataset.md
-          - dataset_setup/video_dataset.md
-          - dataset_setup/notebooks.md
-          - dataset_setup/cloud_storage.md
-          - dataset_setup/reuse_datasets.md
-        Python API:
-          - api/dataset.md
-          - api/sample.md
-          - api/dataset_query.md
-          - api/sampling.md
-          - api/embeddings.md
-          - api/plugin.md
-          - api/annotation.md
-          - api/evaluation.md
-        Concepts & Tools:
-          - concepts_and_tools/annotations.md
-          - concepts_and_tools/tags.md
-          - concepts_and_tools/captions.md
-          - concepts_and_tools/metadata.md
-          - concepts_and_tools/embeddings.md
-          - concepts_and_tools/search_and_filter.md
-          - concepts_and_tools/dataset_distributions.md
-          - concepts_and_tools/export.md
-          - concepts_and_tools/sampling.md
-          - concepts_and_tools/plugins.md
-          - concepts_and_tools/evaluation.md
-          - concepts_and_tools/lightly_query_language.md
-        About Us:
-          - about_us/index.md
   - mkdocstrings:
       handlers:
         python:

--- a/lightly_studio/docs/mkdocs_hooks.py
+++ b/lightly_studio/docs/mkdocs_hooks.py
@@ -100,6 +100,8 @@ def on_nav(
     links, tab_sections = _resolve_tabs(specs=specs, sections=sections)
     config.extra["tab_links"] = links
     config.extra["tab_sections"] = tab_sections
+
+    _warn_on_llmstxt_drift(nav=nav, config=config)
     return nav
 
 
@@ -307,3 +309,40 @@ def _active_tab_name(page: Page, tab_sections: Mapping[str, frozenset[str]]) -> 
         return None
     root = ancestors[-1].title
     return next((name for name, titles in tab_sections.items() if root in titles), None)
+
+
+def _warn_on_llmstxt_drift(*, nav: Navigation, config: MkDocsConfig) -> None:
+    """Warns when `llmstxt.sections` and `nav:` list different pages.
+
+    The two are hand-maintained copies of the same page set. The llmstxt plugin
+    silently drops any page missing from its `sections`, and `mkdocs build
+    --strict` stays green, so the page vanishes from llms.txt with no signal.
+    This turns that drift into a warning — a build error under `--strict`.
+
+    Skipped when `sections` uses glob patterns, which a set comparison cannot
+    resolve against resolved page paths.
+
+    Args:
+        nav: The navigation tree MkDocs has just built.
+        config: The site configuration, read for the llmstxt plugin's sections.
+    """
+    plugin = config.plugins.get("llmstxt")
+    if plugin is None:
+        return
+    sections = plugin.config.get("sections") or {}
+    listed = {
+        item if isinstance(item, str) else next(iter(item))
+        for pages in sections.values()
+        for item in pages
+    }
+    if any("*" in path for path in listed):
+        return
+    in_nav = {page.file.src_uri for page in nav.pages}
+    only_nav = sorted(in_nav - listed)
+    only_llms = sorted(listed - in_nav)
+    if only_nav or only_llms:
+        log.warning(
+            "`llmstxt.sections` and `nav:` list different pages. Only in `nav:`: "
+            f"{only_nav}. Only in `llmstxt.sections`: {only_llms}. Update "
+            "`sections` in mkdocs.yml to match."
+        )

--- a/lightly_studio/docs/overrides/partials/path.html
+++ b/lightly_studio/docs/overrides/partials/path.html
@@ -1,0 +1,23 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% import "partials/path-item.html" as item with context %}
+{% if page.meta and page.meta.hide %}
+  {% set hidden = "hidden" if "path" in page.meta.hide %}
+{% endif %}
+{% set depth = page.ancestors | length %}
+{% if nav.homepage %}
+  {% set depth = depth + 1 %}
+{% endif %}
+{% if depth > 1 %}
+  <nav class="md-path" aria-label="{{ lang.t('nav') }}" {{ hidden }}>
+    <ol class="md-path__list">
+      {% if nav.homepage %}
+        {{ item.render(nav.homepage) }}
+      {% endif %}
+      {% for nav_item in page.ancestors | reverse %}
+        {{ item.render(nav_item) }}
+      {% endfor %}
+    </ol>
+  </nav>
+{% endif %}

--- a/lightly_studio/docs/overrides/partials/path.html
+++ b/lightly_studio/docs/overrides/partials/path.html
@@ -1,5 +1,17 @@
 {#-
-  This file was automatically generated - do not edit
+  A copy of Material 9.7.5's `partials/path.html` with two changes, both marked
+  below. Re-diff it against upstream when bumping mkdocs-material.
+
+  1. The trail renders whenever the page has an ancestor. Upstream counts the
+     home page as a crumb and needs two, so a page one level under a section
+     — which is most pages here since the nav flattened — got no trail at all.
+     `nav.homepage` is unset in this site anyway: `index.md` sits inside the
+     Get Started section rather than at the top level of `nav:`, which is what
+     MkDocs requires before it will call a page the home page.
+
+  2. The current page is the last crumb, as in the design mock. Upstream stops
+     at the parent, which leaves the trail naming everything except where the
+     reader actually is. It is a `span`, not a link to itself.
 -#}
 {% import "partials/path-item.html" as item with context %}
 {% if page.meta and page.meta.hide %}
@@ -9,7 +21,8 @@
 {% if nav.homepage %}
   {% set depth = depth + 1 %}
 {% endif %}
-{% if depth > 1 %}
+{#- CHANGED: was `depth > 1`. -#}
+{% if depth > 0 %}
   <nav class="md-path" aria-label="{{ lang.t('nav') }}" {{ hidden }}>
     <ol class="md-path__list">
       {% if nav.homepage %}
@@ -18,6 +31,10 @@
       {% for nav_item in page.ancestors | reverse %}
         {{ item.render(nav_item) }}
       {% endfor %}
+      {#- ADDED: the current page. -#}
+      <li class="md-path__item md-path__item--current">
+        <span class="md-ellipsis">{{ page.title }}</span>
+      </li>
     </ol>
   </nav>
 {% endif %}

--- a/lightly_studio/docs/overrides/partials/path.html
+++ b/lightly_studio/docs/overrides/partials/path.html
@@ -33,7 +33,7 @@
       {% endfor %}
       {#- ADDED: the current page. -#}
       <li class="md-path__item md-path__item--current">
-        <span class="md-ellipsis">{{ page.title }}</span>
+        <span class="md-ellipsis" aria-current="page">{{ page.title }}</span>
       </li>
     </ol>
   </nav>


### PR DESCRIPTION
## What has changed and why?

The nav grouped pages by artifact type ("Concepts & Tools", "Dataset Setup"), most under a second grouping level. Now seven top-level sections named for what the reader is doing, and Workflows runs in pipeline order: ingest, curate, annotate, evaluate, export. Sub-grouping stays only where a run of pages needs it. No page moved on disk, so no URL changed.

`navigation.tabs` comes off; the header strip replacing it lands in PR 5. `navigation.indexes` comes off because it folds a section's index page into the caption for any `index.md` below that section, which had pulled About Us off the sidebar. `llmstxt.sections` is regrouped to match; nothing cross-checks it against `nav:`.

~250 lines, over the target: 40 are commit 1, a byte-identical copy of Material 9.7.5's `partials/path.html`, so commit 2 shows only the two edits to it. 34 more are mkdocs.yml comments on the grouping.

## How has it been tested?

`make docs` is green under `--strict`. Serve and open a page one level under a section: the breadcrumb should render there and end on the current page.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Next: 03-tokens-palette.


---

**Stack** — [LIG-10506](https://linear.app/lightly/issue/LIG-10506/interface-redesign), merge bottom-up:

1. #2114 — Docs build hook and overrides directory
2. **#2115** ← you are here — Flatten the nav
3. #2116 — Token layer and palette
4. #2117 — Shell, header and sidebars
5. #2118 — Section tabs, page actions, footer
6. #2119 — Article body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the documentation navigation into clearer sections, including Get Started, Workflows, Core Concepts, Resources, Tutorials, and Enterprise.
  * Updated site branding to “LightlyStudio” and improved page metadata and code formatting.
  * Added breadcrumbs for easier navigation, including the current page with accessibility support.
  * Simplified header navigation styling by using the theme’s default active-tab appearance.
  * Added checks to identify inconsistencies between navigation and generated documentation indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->