### PR TITLE
Give the docs a section tab strip, page actions and a site footer

### DIFF
--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -1067,6 +1067,50 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
   padding-left: 1.5rem;
 }
 
+/* -- Page actions ----------------------------------------------------------
+
+   Edit / report / ask, under the contents list. From
+   `overrides/partials/toc.html`; the edit link is the one Material would
+   otherwise draw as a bare pencil icon floating over the first paragraph.
+   ------------------------------------------------------------------------- */
+
+.ls-actions {
+  border-top: 1px solid var(--ls-line-hair);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 1rem 0 0;
+  padding: 0.8rem 0 0 0.5rem;
+}
+
+.ls-actions__link {
+  color: var(--ls-body);
+  font-size: 0.625rem;
+  line-height: 1.4;
+  text-decoration: none;
+  transition: color 0.12s;
+}
+
+.ls-actions__link:hover,
+.ls-actions__link:focus-visible {
+  color: var(--ls-accent);
+}
+
+/* The pencil the actions list replaces. */
+.md-content__button.md-icon[rel="edit"] {
+  display: none;
+}
+
+/* Below the TOC breakpoint the actions ride along inside the collapsed
+   contents drawer, which is the wrong place for them — they are page-level, not
+   part of the heading list. */
+@media screen and (max-width: 59.984375em) {
+  .ls-actions {
+    display: none;
+  }
+}
+
+/* ==========================================================================
 
 /* ==========================================================================
    Legacy rules carried from the previous theme, removed as each region is

--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -458,6 +458,135 @@ body {
   padding: 0.05rem 0.25rem;
 }
 
+/* -- Section tabs ----------------------------------------------------------
+
+   Docs / Tutorials / Enterprise, inline in the header row. Each scopes the
+   sidebar to the `nav:` sections it claims; the markup comes from
+   `overrides/partials/section_tabs.html` and the mapping from `extra.tabs` in
+   mkdocs.yml. Still one row of chrome: this is not Material's `navigation.tabs`
+   strip, which is a second row under the header.
+
+   Two copies, and exactly one is displayed at any width. Below 76.25em the
+   sidebar these tabs scope is a slide-in drawer, so the strip has to be in the
+   drawer as well — a header-only strip would leave a phone reader stuck in
+   whichever section they arrived in. `display: none` rather than a transparent
+   or zero-size copy, so the hidden one is out of the accessibility tree and the
+   tab order too.
+
+   The active tab is marked twice over. The ink text carries it and the accent
+   rule underneath repeats it, because the header is translucent: with a
+   near-black code panel scrolled under it the accent falls below 3:1 against
+   what is effectively behind it. That is fine for a decoration and not enough
+   to be the only signal. Weight stays 500 on all three — bolding the active one
+   would change its width and shift the whole strip sideways on every
+   navigation.
+   ------------------------------------------------------------------------- */
+
+.ls-tabs__list {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ls-tabs__link {
+  /* Transparent until active, so both states are the same height and the row
+     does not jump as the reader moves between tabs. */
+  border-bottom: 2px solid transparent;
+  color: var(--ls-body);
+  font-size: 0.675rem;
+  font-weight: 500;
+  padding-bottom: 0.15rem;
+  text-decoration: none;
+  transition: border-color 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+
+.ls-tabs__link:hover {
+  color: var(--ls-ink);
+}
+
+.ls-tabs__link--active,
+.ls-tabs__link--active:hover {
+  border-bottom-color: var(--ls-accent);
+  color: var(--ls-ink);
+}
+
+/* The accent ring at a 0.2rem offset is Material's own focus treatment for
+   `.md-tabs__link` and `.md-header__button`, written with the real pseudo-class
+   rather than its polyfill class. An outline and not just a color change: a
+   color on its own is not a focus indicator. */
+.ls-tabs__link:focus-visible {
+  border-radius: var(--ls-radius-sm);
+  color: var(--ls-ink);
+  outline: 2px solid var(--ls-accent);
+  outline-offset: 0.2rem;
+}
+
+/* Three equal segments across the drawer, and a neutral pill for the active one
+   — the accent rule belongs to the header row, where the strip is the only
+   horizontal thing; in the drawer it would sit a few pixels from the sidebar's
+   own active pill and read as a second, competing marker. */
+.ls-tabs--drawer .ls-tabs__list {
+  gap: 0.25rem;
+  padding: 0.4rem 0.5rem 0.7rem;
+}
+
+.ls-tabs--drawer .ls-tabs__item {
+  flex: 1 1 0;
+}
+
+.ls-tabs--drawer .ls-tabs__link {
+  border-bottom: 0;
+  border-radius: var(--ls-radius-sm);
+  display: block;
+  font-size: 0.66rem;
+  padding: 0.3rem 0.35rem;
+  text-align: center;
+}
+
+.ls-tabs--drawer .ls-tabs__link--active,
+.ls-tabs--drawer .ls-tabs__link--active:hover {
+  background-color: var(--ls-surface-mut);
+  color: var(--ls-ink);
+}
+
+/* The drawer's scrollwrap clips at its edge, so the ring goes inside the pill
+   rather than around it. */
+.ls-tabs--drawer .ls-tabs__link:focus-visible {
+  outline-offset: -2px;
+}
+
+.ls-tabs--header {
+  display: none;
+}
+
+/* The drawer breakpoint. Above it the sidebar is a column and the strip belongs
+   in the header; below it the sidebar is the drawer and so is the strip. */
+@media screen and (min-width: 76.25em) {
+  .ls-tabs--header {
+    align-items: center;
+    display: flex;
+    /* The strip is what takes the slack once it exists, so the search field
+       stays pinned to the right edge. */
+    margin-inline-end: auto;
+    height: var(--ls-header-height);
+  }
+
+  .ls-tabs--drawer {
+    display: none;
+  }
+
+  /* The chip hands the slack over to the strip and settles for a plain gap —
+     wide enough that "v1.0.5" reads as belonging to the wordmark behind it
+     rather than to "Docs" in front of it. */
+  .ls-version {
+    margin-inline-end: 1.4rem;
+  }
+}
+
 /* -- Search ---------------------------------------------------------------- */
 
 .md-search__form {
@@ -1003,43 +1132,10 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
     border-color: #091c1e !important; /* Match border color */
 }
 
-/* Custom menu bar color */
-:root {
-    --md-primary-fg-color: #091c1e;
-    --md-primary-fg-color--light: #0f2c30;
-    --md-primary-fg-color--dark: #051315;
-    --md-accent-fg-color: #13a6e6;
-    --md-accent-fg-color--transparent: #13a6e61a;
-    --lightly-nav-active-color: #0a6f99;
-}
-
-/* Override Material theme primary colors */
-[data-md-color-scheme="default"] {
-    --md-primary-fg-color: #091c1e;
-    --md-primary-fg-color--light: #0f2c30;
-    --md-primary-fg-color--dark: #051315;
-    --md-accent-fg-color: #13a6e6;
-    --md-accent-fg-color--transparent: #13a6e61a;
-}
-
-[data-md-color-scheme="slate"] {
-    --md-primary-fg-color: #091c1e;
-    --md-primary-fg-color--light: #0f2c30;
-    --md-primary-fg-color--dark: #051315;
-    --md-accent-fg-color: #13a6e6;
-    --md-accent-fg-color--transparent: #13a6e61a;
-}
-
 /* Hide Material for MkDocs footer */
 .md-footer-meta {
     display: none !important;
 }
-
-/* Bold the active top-level menu item in the header navigation tabs */
-.md-tabs__item--active .md-tabs__link {
-  font-weight: 700;
-}
-
 
 /* ===== Multi-row tab overrides ===== */
 

--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -1111,6 +1111,180 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
 }
 
 /* ==========================================================================
+   8. Footer
+
+   Two bands. Material's `.md-footer` carries the prev/next pager; `.ls-footer`
+   below it carries the brand, the link columns and the legal line, and comes
+   from `overrides/partials/site_footer.html`.
+   ========================================================================== */
+
+.md-footer {
+  background-color: var(--ls-surface);
+  border-top: 1px solid var(--ls-line-hair);
+}
+
+.md-footer__inner {
+  gap: 0.6rem;
+  margin: 1.6rem auto;
+  opacity: 1;
+  padding: 0 1.3rem;
+}
+
+.md-footer__link {
+  border: 1px solid var(--ls-line);
+  border-radius: var(--ls-radius);
+  flex: none;
+  margin: 0;
+  opacity: 1;
+  padding: 0.7rem 0.9rem;
+  transition: border-color 0.15s;
+  width: calc(50% - 0.3rem);
+}
+
+.md-footer__link:hover {
+  border-color: var(--ls-ink);
+  opacity: 1;
+}
+
+.md-footer__direction {
+  color: var(--ls-muted);
+  font-size: 0.575rem;
+  opacity: 1;
+}
+
+.md-footer__title {
+  font-size: 0.725rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
+}
+
+.md-footer__title .md-ellipsis {
+  color: var(--ls-ink);
+  font-family: var(--ls-font-display);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* The prev/next cards carry the direction already. */
+.md-footer__button {
+  display: none;
+}
+
+/* The copyright it would print is rendered by `.ls-footer__legal` instead, next
+   to the version, and the "Made with Material for MkDocs" line goes with it. */
+.md-footer-meta {
+  display: none !important;
+}
+
+/* -- Site footer ----------------------------------------------------------- */
+
+.ls-footer {
+  background-color: var(--ls-surface-mut);
+  border-top: 1px solid var(--ls-line);
+}
+
+.ls-footer__inner {
+  padding: 1.4rem 1.3rem 1.2rem;
+}
+
+/* The brand block and the columns share one row and wrap together, so a narrow
+   viewport stacks them in reading order rather than reflowing into a grid. */
+.ls-footer__top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.6rem 2rem;
+  justify-content: space-between;
+  margin-bottom: 1.2rem;
+}
+
+.ls-footer__brand {
+  max-width: 14rem;
+}
+
+.ls-footer__lockup {
+  align-items: center;
+  display: flex;
+  gap: 0.45rem;
+  margin-bottom: 0.4rem;
+}
+
+/* Same size as the header mark, so the two lockups read as one wordmark. */
+.ls-footer__mark {
+  height: 1.1rem;
+  width: auto;
+}
+
+.ls-footer__wordmark {
+  color: var(--ls-ink);
+  font-family: var(--ls-font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.ls-footer__tagline {
+  color: var(--ls-muted);
+  font-size: 0.62rem;
+  line-height: 1.55;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.ls-footer__column {
+  min-width: 6.5rem;
+}
+
+/* Same reason as the search placeholder: the footer band is the muted surface,
+   where the faint grey drops under 4.5:1. */
+.ls-footer__heading {
+  color: var(--ls-muted);
+  font-family: var(--ls-font-mono);
+  font-size: 0.52rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.55rem;
+  text-transform: uppercase;
+}
+
+.ls-footer__links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ls-footer__link {
+  color: var(--ls-body);
+  font-size: 0.62rem;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.ls-footer__link:hover,
+.ls-footer__link:focus-visible {
+  color: var(--ls-accent);
+}
+
+.ls-footer__legal {
+  align-items: center;
+  border-top: 1px solid var(--ls-line-hair);
+  color: var(--ls-faint);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.6rem;
+  gap: 0.4rem 1rem;
+  justify-content: space-between;
+  padding-top: 0.8rem;
+}
+
+.ls-footer__version {
+  font-family: var(--ls-font-mono);
+}
+
+/* ==========================================================================
 
 /* ==========================================================================
    Legacy rules carried from the previous theme, removed as each region is
@@ -1174,11 +1348,6 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
     box-shadow: 0 2px 8px rgba(9, 28, 30, 0.2) !important; /* Subtle shadow */
     background-color: #091c1e !important; /* Use header dark color on hover */
     border-color: #091c1e !important; /* Match border color */
-}
-
-/* Hide Material for MkDocs footer */
-.md-footer-meta {
-    display: none !important;
 }
 
 /* ===== Multi-row tab overrides ===== */

--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -1096,6 +1096,14 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
   color: var(--ls-accent);
 }
 
+/* An outline, not just the color shift above: a colour change on its own is not
+   a focus indicator (same treatment as `.ls-tabs__link`). */
+.ls-actions__link:focus-visible {
+  border-radius: var(--ls-radius-sm);
+  outline: 2px solid var(--ls-accent);
+  outline-offset: 2px;
+}
+
 /* The pencil the actions list replaces. */
 .md-content__button.md-icon[rel="edit"] {
   display: none;
@@ -1268,6 +1276,14 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
   color: var(--ls-accent);
 }
 
+/* An outline, not just the color shift above: a colour change on its own is not
+   a focus indicator (same treatment as `.ls-tabs__link`). */
+.ls-footer__link:focus-visible {
+  border-radius: var(--ls-radius-sm);
+  outline: 2px solid var(--ls-accent);
+  outline-offset: 2px;
+}
+
 .ls-footer__legal {
   align-items: center;
   border-top: 1px solid var(--ls-line-hair);
@@ -1283,8 +1299,6 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
 .ls-footer__version {
   font-family: var(--ls-font-mono);
 }
-
-/* ==========================================================================
 
 /* ==========================================================================
    Legacy rules carried from the previous theme, removed as each region is

--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -1069,21 +1069,38 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
 
 /* -- Page actions ----------------------------------------------------------
 
-   Edit / report / ask, under the contents list. From
-   `overrides/partials/toc.html`; the edit link is the one Material would
-   otherwise draw as a bare pencil icon floating over the first paragraph.
+   Edit / report / ask, from `overrides/partials/page_actions.html`. The edit
+   link is the one Material would otherwise draw as a bare pencil icon floating
+   over the first paragraph.
+
+   Two copies, and exactly one is displayed at any width: a column under the
+   contents list where that list is a sidebar, a row under the article where it
+   has collapsed into a drawer. Page-level links do not belong inside a heading
+   list the reader has to open.
    ------------------------------------------------------------------------- */
 
 .ls-actions {
   border-top: 1px solid var(--ls-line-hair);
   display: flex;
+  flex-wrap: wrap;
+}
+
+.ls-actions--aside {
   flex-direction: column;
   gap: 0.4rem;
   margin: 1rem 0 0;
   padding: 0.8rem 0 0 0.5rem;
 }
 
-.ls-actions__link {
+.ls-actions--page {
+  gap: 0.4rem 1.2rem;
+  margin: 2.4rem 0 0;
+  padding: 0.8rem 0 0;
+}
+
+/* The article copy sits inside `.md-typeset`, whose `.md-typeset a` outranks a
+   bare `.ls-actions__link`. Scoping each link rule to the block wins it back. */
+.ls-actions .ls-actions__link {
   color: var(--ls-body);
   font-size: 0.625rem;
   line-height: 1.4;
@@ -1091,14 +1108,19 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
   transition: color 0.12s;
 }
 
-.ls-actions__link:hover,
-.ls-actions__link:focus-visible {
+/* The article copy is read at body distance, not sidebar distance. */
+.ls-actions--page .ls-actions__link {
+  font-size: 0.7rem;
+}
+
+.ls-actions .ls-actions__link:hover,
+.ls-actions .ls-actions__link:focus-visible {
   color: var(--ls-accent);
 }
 
 /* An outline, not just the color shift above: a colour change on its own is not
    a focus indicator (same treatment as `.ls-tabs__link`). */
-.ls-actions__link:focus-visible {
+.ls-actions .ls-actions__link:focus-visible {
   border-radius: var(--ls-radius-sm);
   outline: 2px solid var(--ls-accent);
   outline-offset: 2px;
@@ -1109,11 +1131,14 @@ input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
   display: none;
 }
 
-/* Below the TOC breakpoint the actions ride along inside the collapsed
-   contents drawer, which is the wrong place for them — they are page-level, not
-   part of the heading list. */
 @media screen and (max-width: 59.984375em) {
-  .ls-actions {
+  .ls-actions--aside {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 60em) {
+  .ls-actions--page {
     display: none;
   }
 }

--- a/lightly_studio/docs/docs/_static/custom.js
+++ b/lightly_studio/docs/docs/_static/custom.js
@@ -34,4 +34,29 @@ function addSearchShortcutHint() {
     searchForm.appendChild(hint);
 }
 
+// Instant navigation replaces `[data-md-component=container]`, which the header
+// sits outside of — so the header copy of the section tabs still marks whichever
+// tab was active when the page was first loaded. The drawer copy is inside that
+// region and is re-rendered per page, so it is the one telling the truth; copy
+// its state across after every navigation.
+function syncSectionTabs() {
+    const source = document.querySelector('.ls-tabs--drawer .ls-tabs__link--active');
+    const activeTab = source ? source.dataset.lsTab : null;
+
+    document.querySelectorAll('.ls-tabs--header .ls-tabs__link').forEach(function (link) {
+        const isActive = link.dataset.lsTab === activeTab;
+        link.classList.toggle('ls-tabs__link--active', isActive);
+        if (isActive) {
+            link.setAttribute('aria-current', source.getAttribute('aria-current') || 'true');
+        } else {
+            link.removeAttribute('aria-current');
+        }
+    });
+}
+
 document.addEventListener('DOMContentLoaded', addSearchShortcutHint);
+
+// `navigation.instant` swaps the article without a page load, so the header copy
+// of the strip has to be re-synced per navigation. `document$` is Material's
+// observable for exactly that.
+document$.subscribe(syncSectionTabs);

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -302,6 +302,13 @@ extra:
     - name: Enterprise
       sections:
         - Enterprise
+  # Links under the contents list, after the "Edit this page" one that
+  # `page.edit_url` provides. Same `href` rule as the footer columns below.
+  page_actions:
+    - label: Report an issue
+      href: https://github.com/lightly-ai/lightly-studio/issues/new
+    - label: Ask in Discord
+      href: https://discord.com/invite/xvNJW94
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/lightly-ai/lightly-studio

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -277,6 +277,31 @@ plugins:
 
 extra:
   homepage: https://lightly.ai/lightly-studio
+  # The header tab strip. Each tab claims top-level `nav:` sections and scopes
+  # the sidebar to them, so a reader in Tutorials sees the tutorials and nothing
+  # else. `nav:` itself is untouched: the mapping is by section title, and a
+  # section no tab claims joins the one marked `default` rather than falling out
+  # of the site. Where each tab lands is derived from `nav:` at build time, not
+  # written down here, so it follows a section that moves.
+  #
+  # `mkdocs_hooks.py` resolves this into `extra.tab_links` and
+  # `extra.tab_sections`, and warns — fatally, under `--strict` — when a tab
+  # claims a section `nav:` no longer has.
+  tabs:
+    - name: Docs
+      default: true
+      sections:
+        - Get Started
+        - Workflows
+        - Core Concepts
+        - Ecosystem
+        - Resources
+    - name: Tutorials
+      sections:
+        - Tutorials
+    - name: Enterprise
+      sections:
+        - Enterprise
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/lightly-ai/lightly-studio

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -71,6 +71,7 @@ theme:
     - content.tabs.link
     - toc.follow
     - search.highlight
+    - search.suggest
 
 repo_url: https://github.com/lightly-ai/lightly-studio
 repo_name: LightlyStudio

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -64,6 +64,7 @@ theme:
     # index page below is titled so it can be one.
     - navigation.path
     - navigation.top
+    - navigation.footer
     - navigation.instant
     - content.action.edit
     - content.code.copy
@@ -74,6 +75,9 @@ theme:
 repo_url: https://github.com/lightly-ai/lightly-studio
 repo_name: LightlyStudio
 docs_dir: docs
+
+# Read by the footer. Material's own `.md-footer-meta` bar stays hidden.
+copyright: "© 2026 Lightly · Apache 2.0"
 
 # Sets `extra.package_version` from the installed package, so the footer does not
 # carry a second copy of the version. See `mkdocs_hooks.py`.
@@ -309,6 +313,39 @@ extra:
       href: https://github.com/lightly-ai/lightly-studio/issues/new
     - label: Ask in Discord
       href: https://discord.com/invite/xvNJW94
+  # Footer link columns. An `href` with a scheme is used as written; anything
+  # else is a path relative to the site root.
+  footer:
+    tagline: Open-source curation and annotation for vision datasets.
+    columns:
+      - name: Community
+        links:
+          - label: GitHub
+            href: https://github.com/lightly-ai/lightly-studio
+          - label: Discord
+            href: https://discord.com/invite/xvNJW94
+          - label: Release notes
+            href: https://github.com/lightly-ai/lightly-studio/releases
+          - label: Contact support
+            href: https://www.lightly.ai/contact
+      - name: Docs
+        links:
+          - label: Get Started
+            href: .
+          - label: Workflows
+            href: dataset_setup/image_dataset/
+          - label: Tutorials
+            href: tutorials/
+          - label: Python API reference
+            href: api/dataset/
+      - name: Product
+        links:
+          - label: LightlyStudio
+            href: https://www.lightly.ai/lightly-studio
+          - label: Enterprise
+            href: enterprise/
+          - label: About us
+            href: about_us/
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/lightly-ai/lightly-studio

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -77,10 +77,11 @@ repo_url: https://github.com/lightly-ai/lightly-studio
 repo_name: LightlyStudio
 docs_dir: docs
 
-# The default branch is `main`. Without this, MkDocs derives `edit/master/docs/`
-# for a GitHub `repo_url`, and the "Edit this page" link (see `overrides/partials/toc.html`)
-# points at a `master` branch that does not exist and 404s.
-edit_uri: edit/main/docs/
+# The default branch is `main`, and the path is relative to the repository root,
+# not to this file. Without both, MkDocs derives `edit/master/docs/` for a GitHub
+# `repo_url`, and the "Edit this page" link (see `overrides/partials/toc.html`)
+# points at a branch and a path that do not exist, and 404s.
+edit_uri: edit/main/lightly_studio/docs/docs/
 
 # Read by the footer. Material's own `.md-footer-meta` bar stays hidden.
 copyright: "© 2026 Lightly · Apache 2.0"

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -77,6 +77,11 @@ repo_url: https://github.com/lightly-ai/lightly-studio
 repo_name: LightlyStudio
 docs_dir: docs
 
+# The default branch is `main`. Without this, MkDocs derives `edit/master/docs/`
+# for a GitHub `repo_url`, and the "Edit this page" link (see `overrides/partials/toc.html`)
+# points at a `master` branch that does not exist and 404s.
+edit_uri: edit/main/docs/
+
 # Read by the footer. Material's own `.md-footer-meta` bar stays hidden.
 copyright: "© 2026 Lightly · Apache 2.0"
 

--- a/lightly_studio/docs/overrides/main.html
+++ b/lightly_studio/docs/overrides/main.html
@@ -2,8 +2,18 @@
   Material's own footer is kept for the prev/next pager; the site footer is
   appended under it. Overriding the block rather than replacing
   `partials/footer.html` means the pager stays whatever upstream ships.
+
+  The page actions are appended to the article for the same reason: `content` is
+  the only hook Material gives inside `.md-content__inner`.
 -#}
 {% extends "base.html" %}
+
+{% import "partials/page_actions.html" as page_actions with context %}
+
+{% block content %}
+  {{ super() }}
+  {{ page_actions.page_actions("page") }}
+{% endblock %}
 
 {% block footer %}
   {{ super() }}

--- a/lightly_studio/docs/overrides/main.html
+++ b/lightly_studio/docs/overrides/main.html
@@ -1,0 +1,11 @@
+{#-
+  Material's own footer is kept for the prev/next pager; the site footer is
+  appended under it. Overriding the block rather than replacing
+  `partials/footer.html` means the pager stays whatever upstream ships.
+-#}
+{% extends "base.html" %}
+
+{% block footer %}
+  {{ super() }}
+  {% include "partials/site_footer.html" %}
+{% endblock %}

--- a/lightly_studio/docs/overrides/partials/header.html
+++ b/lightly_studio/docs/overrides/partials/header.html
@@ -6,6 +6,7 @@
   file inside it anyway, so the file is what gets owned. Re-diff it against
   upstream when bumping mkdocs-material.
 -#}
+{% import "partials/section_tabs.html" as section_tabs with context %}
 {% set class = "md-header" %}
 {% if "navigation.tabs.sticky" in features %}
   {% set class = class ~ " md-header--shadow md-header--lifted" %}
@@ -46,6 +47,10 @@
     {% if config.extra.package_version %}
       <span class="ls-version">v{{ config.extra.package_version }}</span>
     {% endif %}
+    {#- ADDED: the header copy of the section tabs. It goes after the title
+        rather than inside it, because the second `.md-header__topic` above is
+        what instant navigation swaps and `custom.js` reads the first one. -#}
+    {{ section_tabs.strip("header") }}
     {% if config.theme.palette %}
       {% if not config.theme.palette is mapping %}
         {% include "partials/palette.html" %}

--- a/lightly_studio/docs/overrides/partials/links.html
+++ b/lightly_studio/docs/overrides/partials/links.html
@@ -1,0 +1,17 @@
+{#-
+  smart_link(href, label, link_class): one anchor whose href is used as written
+  when it carries a URL scheme (https:, mailto:, tel:, ...) and rewritten as a
+  site-relative path otherwise. A scheme shows up as a colon in the first path
+  segment; a site-relative path never has one, so `mailto:` and `tel:` links are
+  classified as external rather than run through `url` and mangled into a broken
+  relative path.
+
+  Shared by `toc.html` (page actions) and `site_footer.html` (footer columns).
+-#}
+{% macro smart_link(href, label, link_class) -%}
+  {%- if ":" in href.split("/")[0] -%}
+    <a class="{{ link_class }}" href="{{ href }}">{{ label }}</a>
+  {%- else -%}
+    <a class="{{ link_class }}" href="{{ href | url }}">{{ label }}</a>
+  {%- endif -%}
+{%- endmacro %}

--- a/lightly_studio/docs/overrides/partials/nav.html
+++ b/lightly_studio/docs/overrides/partials/nav.html
@@ -1,0 +1,30 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% import "partials/nav-item.html" as item with context %}
+{% set class = "md-nav md-nav--primary" %}
+{% if "navigation.tabs" in features %}
+  {% set class = class ~ " md-nav--lifted" %}
+{% endif %}
+{% if "toc.integrate" in features %}
+  {% set class = class ~ " md-nav--integrated" %}
+{% endif %}
+<nav class="{{ class }}" aria-label="{{ lang.t('nav') }}" data-md-level="0">
+  <label class="md-nav__title" for="__drawer">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-nav__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    {{ config.site_name }}
+  </label>
+  {% if config.repo_url %}
+    <div class="md-nav__source">
+      {% include "partials/source.html" %}
+    </div>
+  {% endif %}
+  <ul class="md-nav__list" data-md-scrollfix>
+    {% for nav_item in nav.items %}
+      {% set path = "__nav_" ~ loop.index %}
+      {{ item.render(nav_item, path, 1) }}
+    {% endfor %}
+  </ul>
+</nav>

--- a/lightly_studio/docs/overrides/partials/nav.html
+++ b/lightly_studio/docs/overrides/partials/nav.html
@@ -1,7 +1,13 @@
 {#-
-  This file was automatically generated - do not edit
+  A copy of Material 9.7.5's `partials/nav.html` with two changes, both marked
+  below: the top-level loop skips the sections the active tab does not claim,
+  and the drawer copy of the tab strip goes above the list. No template block
+  isolates that loop, so scoping the sidebar means owning this file;
+  `partials/nav-item.html`, which does the actual rendering, stays upstream.
+  Re-diff against upstream when bumping mkdocs-material.
 -#}
 {% import "partials/nav-item.html" as item with context %}
+{% import "partials/section_tabs.html" as section_tabs with context %}
 {% set class = "md-nav md-nav--primary" %}
 {% if "navigation.tabs" in features %}
   {% set class = class ~ " md-nav--lifted" %}
@@ -21,10 +27,23 @@
       {% include "partials/source.html" %}
     </div>
   {% endif %}
+  {#- ADDED: the drawer copy of the section tabs. Between the title and the list
+      so the list keeps scrolling underneath it, and inside
+      `[data-md-component=container]`, which instant navigation replaces — so
+      this copy is the one that stays correct, and `custom.js` syncs the header
+      copy from it. -#}
+  {{ section_tabs.strip("drawer") }}
+  {#- CHANGED: `ls_nav_sections` holds the top-level sections the active tab
+      claims (see `mkdocs_hooks.py`); it is unset on 404.html, where the whole
+      nav shows. The loop still runs over every section so that `__nav_N` names
+      the same one whichever tab is open. -#}
+  {% set visible_sections = ls_nav_sections if ls_nav_sections is defined else none %}
   <ul class="md-nav__list" data-md-scrollfix>
     {% for nav_item in nav.items %}
       {% set path = "__nav_" ~ loop.index %}
-      {{ item.render(nav_item, path, 1) }}
+      {% if visible_sections is none or nav_item.title in visible_sections %}
+        {{ item.render(nav_item, path, 1) }}
+      {% endif %}
     {% endfor %}
   </ul>
 </nav>

--- a/lightly_studio/docs/overrides/partials/page_actions.html
+++ b/lightly_studio/docs/overrides/partials/page_actions.html
@@ -1,0 +1,31 @@
+{#-
+  page_actions(modifier): the edit link plus whatever `extra.page_actions`
+  declares in mkdocs.yml. `page.edit_url` only exists once `repo_url` and
+  `edit_uri` resolve for the page, so the list can come out shorter.
+
+  Rendered twice, once from `toc.html` beside the article and once from
+  `main.html` under it, and `custom.css` shows exactly one at any width. Two
+  copies rather than one moved element because the contents list collapses into
+  a drawer below 60em, and page-level links do not belong inside a heading list.
+
+  `modifier` is the BEM modifier for the copy: `aside` or `page`.
+-#}
+{#- `lang` is imported here rather than inherited: `base.html` imports it into
+    its own namespace, which a block overridden in `main.html` does not see. -#}
+{% import "partials/language.html" as lang with context %}
+{% import "partials/links.html" as links with context %}
+{% macro page_actions(modifier) -%}
+  {%- set actions = config.extra.page_actions or [] -%}
+  {%- if page.edit_url or actions -%}
+    <div class="ls-actions ls-actions--{{ modifier }}">
+      {%- if page.edit_url %}
+        <a class="ls-actions__link" href="{{ page.edit_url }}" rel="edit">
+          {{ lang.t("action.edit") }}
+        </a>
+      {%- endif %}
+      {%- for action in actions %}
+        {{ links.smart_link(action.href, action.label, "ls-actions__link") }}
+      {%- endfor %}
+    </div>
+  {%- endif -%}
+{%- endmacro %}

--- a/lightly_studio/docs/overrides/partials/section_tabs.html
+++ b/lightly_studio/docs/overrides/partials/section_tabs.html
@@ -1,0 +1,43 @@
+{#-
+  The section tab strip: Docs / Tutorials / Enterprise.
+
+  One macro, rendered twice. `header` is the design — inline in the header row,
+  next to the wordmark. `drawer` exists because below 76.25em the sidebar these
+  tabs scope is a slide-in drawer, and a header-only strip would leave a phone
+  reader stuck in whichever section they arrived in. `custom.css` shows exactly
+  one of the two at any width.
+
+  Links in a `nav`, not `role="tablist"`. Activating one loads a page rather
+  than swapping a panel in place, so the ARIA tabs pattern describes the wrong
+  widget: it would take two of the three links out of the tab order, bind the
+  arrow keys, and have a screen reader announce "selected" for something that is
+  about to navigate. Material's own tab row is the same markup for the same
+  reason.
+
+  `extra.tab_links` and `ls_active_tab` are set by `mkdocs_hooks.py`. Neither
+  exists on 404.html, which MkDocs builds without a page, so the strip draws
+  there with nothing marked.
+-#}
+
+{% macro strip(variant) %}
+  {% set active = ls_active_tab if ls_active_tab is defined else none %}
+  <nav class="ls-tabs ls-tabs--{{ variant }}" aria-label="Sections">
+    <ul class="ls-tabs__list">
+      {% for tab in config.extra.tab_links or [] %}
+        {% set is_active = tab.name == active %}
+        <li class="ls-tabs__item">
+          {#- `aria-current` says what is true. The tab is always the current
+              item of the three; it is only the current *page* on the one page
+              it actually links to. Claiming `page` anywhere else tells a screen
+              reader the link leads nowhere. -#}
+          <a
+            class="ls-tabs__link{{ ' ls-tabs__link--active' if is_active }}"
+            href="{{ tab.url | url }}"
+            data-ls-tab="{{ tab.name }}"
+            {%- if is_active %} aria-current="{{ 'page' if page and page.url == tab.url else 'true' }}"{% endif %}
+          >{{ tab.name }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
+{% endmacro %}

--- a/lightly_studio/docs/overrides/partials/section_tabs.html
+++ b/lightly_studio/docs/overrides/partials/section_tabs.html
@@ -7,12 +7,15 @@
   reader stuck in whichever section they arrived in. `custom.css` shows exactly
   one of the two at any width.
 
-  Links in a `nav`, not `role="tablist"`. Activating one loads a page rather
-  than swapping a panel in place, so the ARIA tabs pattern describes the wrong
-  widget: it would take two of the three links out of the tab order, bind the
-  arrow keys, and have a screen reader announce "selected" for something that is
-  about to navigate. Material's own tab row is the same markup for the same
-  reason.
+  Plain links in a `div`, not `role="tablist"`. Activating one loads a page
+  rather than swapping a panel in place, so the ARIA tabs pattern describes the
+  wrong widget: it would take two of the three links out of the tab order, bind
+  the arrow keys, and have a screen reader announce "selected" for something that
+  is about to navigate.
+
+  A `div` and not a `nav`: the strip already renders inside the header's `nav`
+  and, in the drawer variant, inside the sidebar's, so a `nav` here would only
+  nest a third landmark inside those two for a screen reader to step through.
 
   `extra.tab_links` and `ls_active_tab` are set by `mkdocs_hooks.py`. Neither
   exists on 404.html, which MkDocs builds without a page, so the strip draws
@@ -21,7 +24,7 @@
 
 {% macro strip(variant) %}
   {% set active = ls_active_tab if ls_active_tab is defined else none %}
-  <nav class="ls-tabs ls-tabs--{{ variant }}" aria-label="Sections">
+  <div class="ls-tabs ls-tabs--{{ variant }}">
     <ul class="ls-tabs__list">
       {% for tab in config.extra.tab_links or [] %}
         {% set is_active = tab.name == active %}
@@ -39,5 +42,5 @@
         </li>
       {% endfor %}
     </ul>
-  </nav>
+  </div>
 {% endmacro %}

--- a/lightly_studio/docs/overrides/partials/site_footer.html
+++ b/lightly_studio/docs/overrides/partials/site_footer.html
@@ -4,6 +4,7 @@
   because Material's `.md-footer` already owns the page's `contentinfo` landmark
   and a second one would leave screen readers with two footers to choose from.
 -#}
+{% import "partials/links.html" as links with context %}
 {% set footer = config.extra.footer or {} %}
 <div class="ls-footer">
   <div class="ls-footer__inner md-grid">
@@ -24,15 +25,7 @@
           <h2 class="ls-footer__heading">{{ column.name }}</h2>
           <ul class="ls-footer__links">
             {% for link in column.links %}
-              <li>
-                {#- An `href` with a scheme is passed through; anything else is a
-                    site-relative path that `url` rewrites for the current page. -#}
-                {% if "://" in link.href %}
-                  <a class="ls-footer__link" href="{{ link.href }}">{{ link.label }}</a>
-                {% else %}
-                  <a class="ls-footer__link" href="{{ link.href | url }}">{{ link.label }}</a>
-                {% endif %}
-              </li>
+              <li>{{ links.smart_link(link.href, link.label, "ls-footer__link") }}</li>
             {% endfor %}
           </ul>
         </nav>

--- a/lightly_studio/docs/overrides/partials/site_footer.html
+++ b/lightly_studio/docs/overrides/partials/site_footer.html
@@ -1,0 +1,50 @@
+{#-
+  Site footer: brand lockup, the link columns declared under `extra.footer` in
+  mkdocs.yml, and a legal line. A `div` rather than a second `footer` element,
+  because Material's `.md-footer` already owns the page's `contentinfo` landmark
+  and a second one would leave screen readers with two footers to choose from.
+-#}
+{% set footer = config.extra.footer or {} %}
+<div class="ls-footer">
+  <div class="ls-footer__inner md-grid">
+    <div class="ls-footer__top">
+      <div class="ls-footer__brand">
+        <div class="ls-footer__lockup">
+          {% if config.theme.logo %}
+            <img class="ls-footer__mark" src="{{ config.theme.logo | url }}" alt="">
+          {% endif %}
+          <span class="ls-footer__wordmark">{{ config.site_name }}</span>
+        </div>
+        {% if footer.tagline %}
+          <p class="ls-footer__tagline">{{ footer.tagline }}</p>
+        {% endif %}
+      </div>
+      {% for column in footer.columns or [] %}
+        <nav class="ls-footer__column" aria-label="{{ column.name }}">
+          <h2 class="ls-footer__heading">{{ column.name }}</h2>
+          <ul class="ls-footer__links">
+            {% for link in column.links %}
+              <li>
+                {#- An `href` with a scheme is passed through; anything else is a
+                    site-relative path that `url` rewrites for the current page. -#}
+                {% if "://" in link.href %}
+                  <a class="ls-footer__link" href="{{ link.href }}">{{ link.label }}</a>
+                {% else %}
+                  <a class="ls-footer__link" href="{{ link.href | url }}">{{ link.label }}</a>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      {% endfor %}
+    </div>
+    <div class="ls-footer__legal">
+      {% if config.copyright %}
+        <span>{{ config.copyright }}</span>
+      {% endif %}
+      {% if config.extra.package_version %}
+        <span class="ls-footer__version">v{{ config.extra.package_version }}</span>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/lightly_studio/docs/overrides/partials/toc.html
+++ b/lightly_studio/docs/overrides/partials/toc.html
@@ -1,0 +1,25 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% set title = lang.t("toc") %}
+{% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
+  {% set title = config.mdx_configs.toc.title %}
+{% endif %}
+<nav class="md-nav md-nav--secondary" aria-label="{{ title | e }}">
+  {% set toc = page.toc %}
+  {% set first = toc | first %}
+  {% if first and first.level == 1 %}
+    {% set toc = first.children %}
+  {% endif %}
+  {% if toc %}
+    <label class="md-nav__title" for="__toc">
+      <span class="md-nav__icon md-icon"></span>
+      {{ title }}
+    </label>
+    <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
+      {% for toc_item in toc %}
+        {% include "partials/toc-item.html" %}
+      {% endfor %}
+    </ul>
+  {% endif %}
+</nav>

--- a/lightly_studio/docs/overrides/partials/toc.html
+++ b/lightly_studio/docs/overrides/partials/toc.html
@@ -8,6 +8,7 @@
   as an editing control for the page rather than a link to its source.
   `custom.css` hides that copy.
 -#}
+{% import "partials/links.html" as links with context %}
 {% set title = lang.t("toc") %}
 {% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
   {% set title = config.mdx_configs.toc.title %}
@@ -42,11 +43,7 @@
         </a>
       {% endif %}
       {% for action in actions %}
-        {% if "://" in action.href %}
-          <a class="ls-actions__link" href="{{ action.href }}">{{ action.label }}</a>
-        {% else %}
-          <a class="ls-actions__link" href="{{ action.href | url }}">{{ action.label }}</a>
-        {% endif %}
+        {{ links.smart_link(action.href, action.label, "ls-actions__link") }}
       {% endfor %}
     </div>
   {% endif %}

--- a/lightly_studio/docs/overrides/partials/toc.html
+++ b/lightly_studio/docs/overrides/partials/toc.html
@@ -1,5 +1,12 @@
 {#-
-  This file was automatically generated - do not edit
+  A copy of Material 9.7.5's `partials/toc.html`, with a page-actions list added
+  under the heading list and nothing else changed. The one insertion is marked
+  below. Re-diff it against upstream when bumping mkdocs-material.
+
+  The actions are what Material otherwise renders as `partials/actions.html`: a
+  bare pencil icon floating over the first paragraph of the article, which reads
+  as an editing control for the page rather than a link to its source.
+  `custom.css` hides that copy.
 -#}
 {% set title = lang.t("toc") %}
 {% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
@@ -21,5 +28,26 @@
         {% include "partials/toc-item.html" %}
       {% endfor %}
     </ul>
+  {% endif %}
+  {#- ADDED: page actions. `actions` is a list of {label, href} declared under
+      `extra.page_actions` in mkdocs.yml; the edit link is prepended from
+      `page.edit_url`, which only exists once `repo_url` and `edit_uri` resolve
+      for this page. -#}
+  {% set actions = config.extra.page_actions or [] %}
+  {% if page.edit_url or actions %}
+    <div class="ls-actions">
+      {% if page.edit_url %}
+        <a class="ls-actions__link" href="{{ page.edit_url }}" rel="edit">
+          {{ lang.t("action.edit") }}
+        </a>
+      {% endif %}
+      {% for action in actions %}
+        {% if "://" in action.href %}
+          <a class="ls-actions__link" href="{{ action.href }}">{{ action.label }}</a>
+        {% else %}
+          <a class="ls-actions__link" href="{{ action.href | url }}">{{ action.label }}</a>
+        {% endif %}
+      {% endfor %}
+    </div>
   {% endif %}
 </nav>

--- a/lightly_studio/docs/overrides/partials/toc.html
+++ b/lightly_studio/docs/overrides/partials/toc.html
@@ -8,7 +8,7 @@
   as an editing control for the page rather than a link to its source.
   `custom.css` hides that copy.
 -#}
-{% import "partials/links.html" as links with context %}
+{% import "partials/page_actions.html" as page_actions with context %}
 {% set title = lang.t("toc") %}
 {% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
   {% set title = config.mdx_configs.toc.title %}
@@ -30,21 +30,8 @@
       {% endfor %}
     </ul>
   {% endif %}
-  {#- ADDED: page actions. `actions` is a list of {label, href} declared under
-      `extra.page_actions` in mkdocs.yml; the edit link is prepended from
-      `page.edit_url`, which only exists once `repo_url` and `edit_uri` resolve
-      for this page. -#}
-  {% set actions = config.extra.page_actions or [] %}
-  {% if page.edit_url or actions %}
-    <div class="ls-actions">
-      {% if page.edit_url %}
-        <a class="ls-actions__link" href="{{ page.edit_url }}" rel="edit">
-          {{ lang.t("action.edit") }}
-        </a>
-      {% endif %}
-      {% for action in actions %}
-        {{ links.smart_link(action.href, action.label, "ls-actions__link") }}
-      {% endfor %}
-    </div>
-  {% endif %}
+  {#- ADDED: page actions, the copy that sits beside the article. The one under
+      it comes from `main.html`; `partials/page_actions.html` says why there are
+      two. -#}
+  {{ page_actions.page_actions("aside") }}
 </nav>


### PR DESCRIPTION
## What has changed and why?

Three pieces of chrome: a Docs / Tutorials / Enterprise tab strip in the header, a page-actions list under the contents, and a site footer. The actions list replaces the pencil Material floats over the first paragraph, which reads as an editing control, not a source link.

The strip also scopes the sidebar, so a reader in Tutorials sees only the tutorials. Where a tab lands comes from `nav:` at build time, so it follows a section that moves. Cost of that: renaming a top-level nav section now breaks `make docs`, because a tab claiming a section that is gone warns, and the build is strict.

Over the size target at ~650 lines, mostly CSS. The first commit copies Material 9.7.5's `nav.html` and `toc.html` verbatim, so the four after it show only our changes. Read it commit by commit.

## How has it been tested?

`mkdocs build --clean --strict`, what `make docs` runs in CI. In a browser: the strip sits in the header above 76.25em, in the drawer below, never both.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Next: 06-article, the article body.


---

**Stack** — [LIG-10506](https://linear.app/lightly/issue/LIG-10506/interface-redesign), merge bottom-up:

1. #2114 — Docs build hook and overrides directory
2. #2115 — Flatten the nav
3. #2116 — Token layer and palette
4. #2117 — Shell, header and sidebars
5. **#2118** ← you are here — Section tabs, page actions, footer
6. #2119 — Article body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Docs, Tutorials, and Enterprise section tabs with responsive header and navigation behavior.
  - Added configurable page actions, including edit-page links and related navigation links.
  - Added a branded, multi-column site footer with legal and version information.
  - Added search suggestions, footer navigation, and direct page-edit links.
- **Style**
  - Introduced responsive styling for tabs, page actions, navigation, and footer components.
- **Documentation**
  - Improved documentation layout and navigation consistency across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->