### PR TITLE
Gate releases on green CI for the exact release commit

### DIFF
--- a/.github/actions/check-release-ci/README.md
+++ b/.github/actions/check-release-ci/README.md
@@ -1,0 +1,69 @@
+# Check release CI
+
+Fails unless every required CI check succeeded on the **exact commit** being
+released. Release workflows call it before tagging, publishing a wheel or
+deploying docs, so a release is never cut from an untested or red commit.
+
+## Why the release PR's own CI is not enough
+
+The version-bump PR runs Unit Test and End2End Test, but a release is published
+from a ref, and that ref is not necessarily the commit those runs tested:
+
+- Squash-merging the release PR produces a **new** commit on `main`. The PR's
+  runs belong to the PR head, not to what was merged.
+- `workflow_dispatch` puts no ordering between "merge" and "publish". A publish
+  can be dispatched while `main`'s runs are still going, or after they failed.
+- `RELEASE.md`'s emergency path releases from a release branch, which may have
+  no runs at all.
+
+The gate closes the gap by asking about the sha rather than about the branch.
+
+## Usage
+
+```yaml
+- uses: lightly-ai/lightly-studio/.github/actions/check-release-ci@main
+  with:
+    ref: v1.2.3            # tag, branch or sha being released
+    github-token: ${{ github.token }}
+```
+
+Cross-repo callers - including the private repo's docs workflow - use the
+action as above. Workflows in this repository can instead call the job wrapper
+`.github/workflows/check_release_ci.yml`, which also exposes the gate as a
+`workflow_dispatch` for manual checks. The runner needs `gh` and `python3`.
+
+Set `skip-ci-check: true` for the documented emergency path. It skips the gate
+entirely and records the override, with the actor's name, in the log and the
+job summary.
+
+## What counts as green
+
+The required checks are named once, in `REQUIRED_CHECKS` in
+[`.github/scripts/prepare_release/ci_gate.py`](../../scripts/prepare_release/ci_gate.py),
+which also carries the reasoning. In short:
+
+- The required names are the two **aggregate jobs**, `CI Success Check` and
+  `End2End Success Check` - not the workflow names `Unit Test` and `End2End
+  Test`, which name no check run and would pass vacuously.
+- Only a completed `success` counts. Missing, still running, `cancelled`,
+  `skipped` and `neutral` all block.
+- One completed green attempt on the sha is enough, because a commit on `main`
+  carries each check twice and `cancel-in-progress: true` routinely cancels the
+  push-to-main attempt. Other attempts are reported next to the green one.
+
+## Verified against
+
+A gate that returns success unconditionally also passes on a green commit, so
+these were checked in this order. Re-run them after changing the gate:
+
+| Case | Commit | Expected | Result |
+| --- | --- | --- | --- |
+| Both required checks failed | `1f9b2156d23ecf5033b1cfe34be06af5d903d83c` | blocks, naming both | blocks, both named and linked |
+| One required check failed | `a311e602b9fadd5c4e950adde7786aa53bc6fa5c` | blocks, naming `CI Success Check` | blocks, named and linked |
+| Every gated unit-test job `skipped`, aggregate green | `da604e0802b9f91adf9ac8cca298623a587c62e1` | passes - the aggregate resolves its own skipped jobs | passes |
+| Green, with a cancelled push attempt | `2ae55628ff29e01065d748128d7a39aa4519f8bf` | passes, flagging the other attempt | passes, flagged |
+| Green | `b2dc2470d5a0055e791944dbd14a4e965ff615bd` | passes | passes |
+
+Still-running and misspelled-requirement commits are covered by
+`.github/scripts/tests/test_ci_gate.py`, which also pins `skipped` as blocking
+when a required check itself reports it.

--- a/.github/actions/check-release-ci/README.md
+++ b/.github/actions/check-release-ci/README.md
@@ -64,6 +64,14 @@ these were checked in this order. Re-run them after changing the gate:
 | Green, with a cancelled push attempt | `2ae55628ff29e01065d748128d7a39aa4519f8bf` | passes, flagging the other attempt | passes, flagged |
 | Green | `b2dc2470d5a0055e791944dbd14a4e965ff615bd` | passes | passes |
 
-Still-running and misspelled-requirement commits are covered by
-`.github/scripts/tests/test_ci_gate.py`, which also pins `skipped` as blocking
-when a required check itself reports it.
+Checks still running was verified live rather than against a fixed sha, since
+any commit goes green afterwards: run against `0b6cfbc8` while its CI was in
+flight, the gate refused it with "is not reported yet; 12 check(s) on this
+commit are still running". An aggregate job gets no check run until the jobs it
+waits on finish, so this case arrives as an absent check rather than a running
+one - which is why it is worth stating separately from a commit that was never
+tested at all.
+
+The still-running and misspelled-requirement cases are also unit tested in
+`.github/scripts/tests/test_ci_gate.py`, which pins `skipped` as blocking when a
+required check itself reports it.

--- a/.github/actions/check-release-ci/action.yml
+++ b/.github/actions/check-release-ci/action.yml
@@ -1,0 +1,102 @@
+name: Check release CI
+description: >-
+  Fails unless every required CI check succeeded on the exact commit being
+  released, so a release is never cut from an untested or red commit.
+
+# Usable cross-repo, including from the private repo's release workflows:
+#
+#   - uses: lightly-ai/lightly-studio/.github/actions/check-release-ci@main
+#     with:
+#       ref: v1.2.3
+#       github-token: ${{ github.token }}
+#
+# GitHub checks out this whole repository for the action, so the tooling in
+# `.github/scripts` comes along with it. The runner needs `gh` and `python3`,
+# both present on GitHub-hosted runners.
+
+inputs:
+  ref:
+    description: Tag, branch or sha being released. Resolved to a commit sha.
+    required: true
+  repository:
+    description: >-
+      Repository whose check runs are inspected. Defaults to this repository,
+      which is where the required checks run.
+    required: false
+    default: lightly-ai/lightly-studio
+  skip-ci-check:
+    description: >-
+      Emergency override for the documented path where a fix is released from
+      a release branch rather than main. "true" skips the gate entirely and
+      records who overrode it in the log and the job summary.
+    required: false
+    default: "false"
+  github-token:
+    description: Token with read access to the repository's contents and checks.
+    required: true
+
+outputs:
+  sha:
+    description: The commit sha that `ref` resolved to.
+    value: ${{ steps.resolve.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve the release commit
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        REF: ${{ inputs.ref }}
+      run: |
+        set -euo pipefail
+        sha="$(gh api "repos/${REPOSITORY}/commits/${REF}" --jq .sha)"
+        echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+        echo "Release ref '${REF}' resolves to ${sha}."
+
+    - name: Record the override
+      if: inputs.skip-ci-check == 'true'
+      shell: bash
+      env:
+        SHA: ${{ steps.resolve.outputs.sha }}
+      run: |
+        set -euo pipefail
+        echo "::warning::Release CI gate skipped for ${SHA} by ${GITHUB_ACTOR} (skip-ci-check=true)."
+        {
+          echo "### Release CI gate for \`${SHA}\`"
+          echo
+          echo "⚠️ **Skipped** via \`skip-ci-check\`, requested by @${GITHUB_ACTOR}."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Fetch the commit's check runs
+      if: inputs.skip-ci-check != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        SHA: ${{ steps.resolve.outputs.sha }}
+      # `--slurp` keeps the paginated pages as a JSON array instead of
+      # concatenating them into invalid JSON; the gate flattens it.
+      run: |
+        set -euo pipefail
+        gh api --paginate --slurp \
+          "repos/${REPOSITORY}/commits/${SHA}/check-runs?per_page=100" \
+          > "${RUNNER_TEMP}/check-runs.json"
+
+    - name: Verify the required checks
+      if: inputs.skip-ci-check != 'true'
+      shell: bash
+      env:
+        SHA: ${{ steps.resolve.outputs.sha }}
+        # The gate lives with the rest of the release tooling so it is linted,
+        # type checked and unit tested by `.github/scripts/Makefile`, rather
+        # than being inlined here where nothing could test it.
+        PYTHONPATH: ${{ github.action_path }}/../../scripts
+      run: |
+        set -euo pipefail
+        python3 -m prepare_release check-ci \
+          --check-runs "${RUNNER_TEMP}/check-runs.json" \
+          --sha "${SHA}" \
+          --summary "${GITHUB_STEP_SUMMARY}"

--- a/.github/scripts/Makefile
+++ b/.github/scripts/Makefile
@@ -1,0 +1,27 @@
+# CI-internal release tooling. Kept out of the workspace's uv project on purpose
+# (`--no-project`): it must run before, and independently of, the LightlyStudio
+# environment it prepares a release for.
+UV := uv run --no-project
+
+.PHONY: static-checks
+static-checks: format-check lint type-check
+
+.PHONY: format-check
+format-check:
+	$(UV) --with ruff ruff format --check .
+
+.PHONY: lint
+lint:
+	$(UV) --with ruff ruff check .
+
+.PHONY: type-check
+type-check:
+	$(UV) --with mypy mypy prepare_release
+
+.PHONY: format
+format:
+	$(UV) --with ruff ruff format .
+
+.PHONY: test
+test:
+	$(UV) --with pytest pytest -q

--- a/.github/scripts/prepare_release/ci_gate.py
+++ b/.github/scripts/prepare_release/ci_gate.py
@@ -1,0 +1,203 @@
+"""Release gate: the required CI checks must be green on the release commit.
+
+Backs the "Check release CI" composite action
+(`.github/actions/check-release-ci/action.yml`), which resolves a ref to a
+sha, fetches that commit's check runs and hands them to the `check-ci`
+subcommand. Nothing here touches the network, so every rule below is
+covered by offline unit tests.
+
+Three decisions are worth spelling out, because getting any of them wrong
+turns this into a gate that waves everything through - which is worse than
+no gate, since it also removes the manual checking it replaced:
+
+- **The required names are job names, not workflow names.** GitHub names a
+  check run after the job that produced it, so "Unit Test" and "End2End
+  Test" - the workflow names - match nothing and would pass vacuously.
+- **Only `success` passes.** A missing check, a still-running one,
+  `cancelled`, `skipped` and `neutral` all block. `cancel-in-progress:
+  true` in both test workflows makes `cancelled` routine, and
+  unit_test.yml's path filters make `skipped` real; neither is evidence
+  that anything was tested.
+- **One completed green attempt is enough.** A commit on `main` carries the
+  same check twice: once from the merge-queue run and once from the
+  push-to-main run. `cancel-in-progress: true` routinely cancels the latter
+  when the next merge lands, and a cancelled aggregate job reports
+  `failure`, so "the newest attempt wins" would block nearly every commit -
+  and a gate that blocks everything gets overridden by habit, which is the
+  same loss of vigilance by another route. A completed `success` means this
+  exact tree was tested green; any other attempts are reported alongside it
+  so a genuine flake stays visible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Sequence
+from typing import Any
+
+from prepare_release.errors import PrepareReleaseError
+
+# The single aggregate job of each test workflow, and the checks required by
+# the branch ruleset. Both run with `if: always()`, so they are reported for
+# every commit and never come back `skipped`: the per-job `skipped` results
+# that unit_test.yml's path filters produce are resolved inside "CI Success
+# Check" itself. Requiring the aggregates rather than the individual jobs is
+# therefore what keeps path-filtered commits from stranding the gate.
+# This tuple is the single place the required checks are named; workflows
+# pass no list of their own.
+REQUIRED_CHECKS: tuple[str, ...] = ("CI Success Check", "End2End Success Check")
+
+_COMPLETED = "completed"
+_SUCCESS = "success"
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckRun:
+    """One check run GitHub reports for a commit.
+
+    Attributes:
+        name: Name of the job that produced the run.
+        status: `queued`, `in_progress` or `completed`.
+        conclusion: `success`, `failure`, `cancelled`, `skipped`, ...; empty
+            while the run is not completed.
+        url: Link to the run on GitHub.
+        started_at: ISO 8601 start timestamp, used to find the latest attempt.
+        run_id: Check run id, tie-breaker for attempts started in the same second.
+    """
+
+    name: str
+    status: str
+    conclusion: str
+    url: str
+    started_at: str
+    run_id: int
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckVerdict:
+    """The gate's reading of one required check.
+
+    Attributes:
+        name: The required check name.
+        passed: Whether the check is green on the commit.
+        detail: Why, phrased to follow the check name in a sentence.
+        url: Link to the run that decided it, empty when there is none.
+    """
+
+    name: str
+    passed: bool
+    detail: str
+    url: str
+
+
+def parse_check_runs(payload: Any) -> list[CheckRun]:
+    """Flattens the JSON of `gh api repos/.../commits/<sha>/check-runs`.
+
+    Args:
+        payload: Either one API response object, or the list of page objects
+            that `gh api --paginate --slurp` produces.
+
+    Returns:
+        Every check run in the payload, in the order the API returned them.
+
+    Raises:
+        PrepareReleaseError: The payload is not a check-runs response, e.g.
+            because the API call errored and its output was captured anyway.
+    """
+    pages = payload if isinstance(payload, list) else [payload]
+    if not all(isinstance(page, dict) and "check_runs" in page for page in pages):
+        raise PrepareReleaseError(
+            "Not a check-runs API response; the gate cannot tell a red commit from an "
+            "unreadable one, so it refuses to pass."
+        )
+    return [
+        CheckRun(
+            name=run["name"],
+            status=run["status"],
+            conclusion=run["conclusion"] or "",
+            url=run.get("html_url") or "",
+            started_at=run.get("started_at") or "",
+            run_id=run["id"],
+        )
+        for page in pages
+        for run in page["check_runs"]
+    ]
+
+
+def evaluate_check_runs(
+    check_runs: Sequence[CheckRun], required: Sequence[str] = REQUIRED_CHECKS
+) -> list[CheckVerdict]:
+    """Judges each required check against the runs reported for one commit.
+
+    Args:
+        check_runs: Every check run on the commit, from `parse_check_runs`.
+        required: Names that must be green; defaults to `REQUIRED_CHECKS`.
+
+    Returns:
+        One verdict per required name, in the order given.
+    """
+    return [
+        _verdict(name=name, runs=[run for run in check_runs if run.name == name])
+        for name in required
+    ]
+
+
+def render_report(verdicts: Sequence[CheckVerdict], sha: str) -> str:
+    """Renders the verdicts as a markdown table for the job summary."""
+    lines = [
+        f"### Release CI gate for `{sha}`",
+        "",
+        "| Required check | Result |",
+        "| --- | --- |",
+    ]
+    for verdict in verdicts:
+        mark = "✅" if verdict.passed else "❌"
+        detail = f"[{verdict.detail}]({verdict.url})" if verdict.url else verdict.detail
+        lines.append(f"| {verdict.name} | {mark} {detail} |")
+    return "\n".join(lines) + "\n"
+
+
+def _verdict(name: str, runs: Sequence[CheckRun]) -> CheckVerdict:
+    """Judges one required check from every attempt reported under its name."""
+    if not runs:
+        return CheckVerdict(
+            name=name, passed=False, detail="was never reported on this commit", url=""
+        )
+
+    successes = [run for run in runs if run.status == _COMPLETED and run.conclusion == _SUCCESS]
+    if successes:
+        latest = max(successes, key=_attempt_order)
+        return CheckVerdict(
+            name=name,
+            passed=True,
+            detail=_succeeded_detail(len(runs) - len(successes)),
+            url=latest.url,
+        )
+
+    latest = max(runs, key=_attempt_order)
+    if latest.status != _COMPLETED:
+        detail = f"is still {latest.status.replace('_', ' ')}"
+    else:
+        detail = f"concluded {latest.conclusion or 'without a conclusion'}"
+    return CheckVerdict(
+        name=name, passed=False, detail=_of_attempts(detail, len(runs)), url=latest.url
+    )
+
+
+def _attempt_order(run: CheckRun) -> tuple[str, int]:
+    """Orders attempts by start time, with the run id as a tie-breaker."""
+    return (run.started_at, run.run_id)
+
+
+def _succeeded_detail(not_green: int) -> str:
+    """Describes a green check, flagging any sibling attempt that was not green."""
+    if not_green == 0:
+        return "succeeded"
+    return f"succeeded, but {not_green} other attempt(s) did not"
+
+
+def _of_attempts(detail: str, attempts: int) -> str:
+    """Appends the attempt count when more than one attempt was reported."""
+    if attempts == 1:
+        return detail
+    return f"{detail} (newest of {attempts} attempts, none green)"

--- a/.github/scripts/prepare_release/ci_gate.py
+++ b/.github/scripts/prepare_release/ci_gate.py
@@ -136,8 +136,13 @@ def evaluate_check_runs(
     Returns:
         One verdict per required name, in the order given.
     """
+    in_flight = sum(1 for run in check_runs if run.status != _COMPLETED)
     return [
-        _verdict(name=name, runs=[run for run in check_runs if run.name == name])
+        _verdict(
+            name=name,
+            runs=[run for run in check_runs if run.name == name],
+            in_flight=in_flight,
+        )
         for name in required
     ]
 
@@ -157,12 +162,25 @@ def render_report(verdicts: Sequence[CheckVerdict], sha: str) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _verdict(name: str, runs: Sequence[CheckRun]) -> CheckVerdict:
-    """Judges one required check from every attempt reported under its name."""
+def _verdict(name: str, runs: Sequence[CheckRun], in_flight: int) -> CheckVerdict:
+    """Judges one required check from every attempt reported under its name.
+
+    Args:
+        name: The required check name.
+        runs: Every attempt reported under that name; may be empty.
+        in_flight: How many of the commit's check runs have not completed.
+            An aggregate job only gets a check run once the jobs it waits on
+            are done, so a commit whose CI is mid-flight has no run under this
+            name yet - which must not read as "CI never ran".
+
+    Returns:
+        The verdict for this check.
+    """
     if not runs:
-        return CheckVerdict(
-            name=name, passed=False, detail="was never reported on this commit", url=""
-        )
+        detail = "was never reported on this commit"
+        if in_flight:
+            detail = f"is not reported yet; {in_flight} check(s) on this commit are still running"
+        return CheckVerdict(name=name, passed=False, detail=detail, url="")
 
     successes = [run for run in runs if run.status == _COMPLETED and run.conclusion == _SUCCESS]
     if successes:

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -15,16 +15,18 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
-from prepare_release import changelog, lock, pr_body, version
+from prepare_release import changelog, ci_gate, lock, pr_body, version
 from prepare_release.errors import PrepareReleaseError
 
 CHECK_LABELFORMAT_PIN = "check-labelformat-pin"
 PROMOTE_CHANGELOG = "promote-changelog"
 ASSERT_LOCK_DIFF = "assert-lock-diff"
 RENDER_PR_BODY = "render-pr-body"
+CHECK_CI = "check-ci"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,6 +58,25 @@ def main(argv: list[str] | None = None) -> int:
     pr_body_parser.add_argument("--version", required=True)
     pr_body_parser.add_argument("--output", type=Path, required=True)
 
+    check_ci = subparsers.add_parser(
+        CHECK_CI, help="fail unless the required CI checks are green on a commit"
+    )
+    check_ci.add_argument(
+        "--check-runs",
+        type=Path,
+        required=True,
+        help="JSON of `gh api repos/<repo>/commits/<sha>/check-runs`",
+    )
+    check_ci.add_argument("--sha", required=True, help="the commit the runs belong to")
+    check_ci.add_argument(
+        "--required",
+        action="append",
+        help="check name that must be green; repeatable, defaults to ci_gate.REQUIRED_CHECKS",
+    )
+    check_ci.add_argument(
+        "--summary", type=Path, help="file the markdown report is appended to, e.g. the job summary"
+    )
+
     args = parser.parse_args(argv)
 
     try:
@@ -71,6 +92,7 @@ def _dispatch(args: argparse.Namespace) -> int:
         PROMOTE_CHANGELOG: _cmd_promote_changelog,
         ASSERT_LOCK_DIFF: _cmd_assert_lock_diff,
         RENDER_PR_BODY: _cmd_render_pr_body,
+        CHECK_CI: _cmd_check_ci,
     }
     handlers[args.command](args)
     return 0
@@ -105,6 +127,27 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
     )
     body = pr_body.render_pr_body(section_body=section_body)
     args.output.write_text(body)
+
+
+def _cmd_check_ci(args: argparse.Namespace) -> None:
+    verdicts = ci_gate.evaluate_check_runs(
+        check_runs=ci_gate.parse_check_runs(json.loads(args.check_runs.read_text())),
+        required=args.required or ci_gate.REQUIRED_CHECKS,
+    )
+    report = ci_gate.render_report(verdicts=verdicts, sha=args.sha)
+    print(report)
+    if args.summary is not None:
+        with args.summary.open("a") as summary:
+            summary.write(report)
+
+    failed = [verdict for verdict in verdicts if not verdict.passed]
+    for verdict in failed:
+        print(f"::error::Required check '{verdict.name}' {verdict.detail}. {verdict.url}".rstrip())
+    if failed:
+        raise PrepareReleaseError(
+            f"{len(failed)} of {len(verdicts)} required checks are not green on {args.sha}; "
+            "not releasing this commit."
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_ci_gate.py
+++ b/.github/scripts/tests/test_ci_gate.py
@@ -263,3 +263,16 @@ class TestCheckCiCommand:
 def test_parse_check_runs__unreadable_payload_is_refused():
     with pytest.raises(PrepareReleaseError):
         ci_gate.parse_check_runs({"message": "No commit found for SHA"})
+
+
+# An aggregate job gets no check run until the jobs it waits on are done, so a
+# commit whose CI is mid-flight has no run under the required name yet.
+def test_evaluate_check_runs__missing_check_while_ci_is_running():
+    runs = ci_gate.parse_check_runs(
+        {"check_runs": [_api_run("Backend (3.9, DuckDB)", status="in_progress", conclusion=None)]}
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "1 check(s) on this commit are still running" in verdicts[0].detail

--- a/.github/scripts/tests/test_ci_gate.py
+++ b/.github/scripts/tests/test_ci_gate.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prepare_release import ci_gate, cli
+from prepare_release.errors import PrepareReleaseError
+
+
+def _api_run(
+    name: str,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    started_at: str = "2026-08-21T10:00:00Z",
+    run_id: int = 1,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "started_at": started_at,
+        "html_url": f"https://github.com/lightly-ai/lightly-studio/runs/{run_id}",
+    }
+
+
+def test_parse_check_runs__single_page():
+    runs = ci_gate.parse_check_runs({"check_runs": [_api_run("CI Success Check")]})
+
+    assert runs == [
+        ci_gate.CheckRun(
+            name="CI Success Check",
+            status="completed",
+            conclusion="success",
+            url="https://github.com/lightly-ai/lightly-studio/runs/1",
+            started_at="2026-08-21T10:00:00Z",
+            run_id=1,
+        )
+    ]
+
+
+def test_parse_check_runs__slurped_pages():
+    payload = [
+        {"check_runs": [_api_run("CI Success Check", run_id=1)]},
+        {"check_runs": [_api_run("End2End Success Check", run_id=2)]},
+    ]
+
+    runs = ci_gate.parse_check_runs(payload)
+
+    assert [run.name for run in runs] == ["CI Success Check", "End2End Success Check"]
+
+
+def test_parse_check_runs__running_run_has_no_conclusion():
+    payload = {"check_runs": [_api_run("CI Success Check", status="in_progress", conclusion=None)]}
+
+    runs = ci_gate.parse_check_runs(payload)
+
+    assert runs[0].conclusion == ""
+
+
+def test_evaluate_check_runs__all_green():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check", run_id=1),
+                _api_run("End2End Success Check", run_id=2),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs)
+
+    assert [verdict.passed for verdict in verdicts] == [True, True]
+
+
+def test_evaluate_check_runs__failed_check_is_named():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check", run_id=1),
+                _api_run("End2End Success Check", conclusion="failure", run_id=2),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs)
+
+    assert verdicts[0].passed
+    assert not verdicts[1].passed
+    assert verdicts[1].name == "End2End Success Check"
+    assert "failure" in verdicts[1].detail
+    assert verdicts[1].url == "https://github.com/lightly-ai/lightly-studio/runs/2"
+
+
+@pytest.mark.parametrize("status", ["queued", "in_progress"])
+def test_evaluate_check_runs__still_running_does_not_pass(status: str):
+    runs = ci_gate.parse_check_runs(
+        {"check_runs": [_api_run("CI Success Check", status=status, conclusion=None)]}
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "still" in verdicts[0].detail
+
+
+# `cancel-in-progress: true` and unit_test.yml's path filters make these two real
+# outcomes rather than hypotheticals. Neither means anything was tested.
+@pytest.mark.parametrize("conclusion", ["cancelled", "skipped", "neutral", "timed_out"])
+def test_evaluate_check_runs__non_success_conclusion_does_not_pass(conclusion: str):
+    runs = ci_gate.parse_check_runs(
+        {"check_runs": [_api_run("CI Success Check", conclusion=conclusion)]}
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert conclusion in verdicts[0].detail
+
+
+def test_evaluate_check_runs__missing_check_does_not_pass():
+    verdicts = ci_gate.evaluate_check_runs([], required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "never reported" in verdicts[0].detail
+
+
+def test_evaluate_check_runs__misspelled_requirement_does_not_pass_vacuously():
+    runs = ci_gate.parse_check_runs({"check_runs": [_api_run("CI Success Check")]})
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["Unit Test"])
+
+    assert not verdicts[0].passed
+
+
+# Every commit on main carries this check twice - once from the merge-queue run
+# and once from the push-to-main run, the latter routinely cancelled by
+# `cancel-in-progress: true` and therefore reported as `failure`. The green
+# attempt tested this exact tree, so it decides; the red one stays visible.
+def test_evaluate_check_runs__one_green_attempt_passes():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check", started_at="2026-08-21T09:00:00Z", run_id=1),
+                _api_run(
+                    "CI Success Check",
+                    conclusion="failure",
+                    started_at="2026-08-21T11:00:00Z",
+                    run_id=2,
+                ),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert verdicts[0].passed
+    assert "1 other attempt(s) did not" in verdicts[0].detail
+    assert verdicts[0].url == "https://github.com/lightly-ai/lightly-studio/runs/1"
+
+
+def test_evaluate_check_runs__no_green_attempt_reports_the_newest():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run(
+                    "CI Success Check",
+                    conclusion="failure",
+                    started_at="2026-08-21T09:00:00Z",
+                    run_id=1,
+                ),
+                _api_run(
+                    "CI Success Check",
+                    status="in_progress",
+                    conclusion=None,
+                    started_at="2026-08-21T11:00:00Z",
+                    run_id=2,
+                ),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "still in progress" in verdicts[0].detail
+    assert "none green" in verdicts[0].detail
+
+
+def test_render_report():
+    verdicts = [
+        ci_gate.CheckVerdict(name="CI Success Check", passed=True, detail="succeeded", url="url-1"),
+        ci_gate.CheckVerdict(
+            name="End2End Success Check", passed=False, detail="concluded failure", url="url-2"
+        ),
+    ]
+
+    report = ci_gate.render_report(verdicts=verdicts, sha="0123abc")
+
+    assert "0123abc" in report
+    assert "| CI Success Check | ✅ [succeeded](url-1) |" in report
+    assert "| End2End Success Check | ❌ [concluded failure](url-2) |" in report
+
+
+class TestCheckCiCommand:
+    def test_check_ci__green_commit_exits_zero(self, tmp_path: Path):
+        check_runs = tmp_path / "check-runs.json"
+        check_runs.write_text(
+            json.dumps(
+                {
+                    "check_runs": [
+                        _api_run("CI Success Check", run_id=1),
+                        _api_run("End2End Success Check", run_id=2),
+                    ]
+                }
+            )
+        )
+        summary = tmp_path / "summary.md"
+
+        exit_code = cli.main(
+            [
+                "check-ci",
+                "--check-runs",
+                str(check_runs),
+                "--sha",
+                "0123abc",
+                "--summary",
+                str(summary),
+            ]
+        )
+
+        assert exit_code == 0
+        assert "0123abc" in summary.read_text()
+
+    def test_check_ci__red_commit_exits_one(self, tmp_path: Path):
+        check_runs = tmp_path / "check-runs.json"
+        check_runs.write_text(
+            json.dumps(
+                {
+                    "check_runs": [
+                        _api_run("CI Success Check", run_id=1),
+                        _api_run("End2End Success Check", conclusion="failure", run_id=2),
+                    ]
+                }
+            )
+        )
+
+        exit_code = cli.main(["check-ci", "--check-runs", str(check_runs), "--sha", "0123abc"])
+
+        assert exit_code == 1
+
+    def test_check_ci__commit_without_any_checks_exits_one(self, tmp_path: Path):
+        check_runs = tmp_path / "check-runs.json"
+        check_runs.write_text(json.dumps({"check_runs": []}))
+
+        exit_code = cli.main(["check-ci", "--check-runs", str(check_runs), "--sha", "0123abc"])
+
+        assert exit_code == 1
+
+
+def test_parse_check_runs__unreadable_payload_is_refused():
+    with pytest.raises(PrepareReleaseError):
+        ci_gate.parse_check_runs({"message": "No commit found for SHA"})

--- a/.github/workflows/check_release_ci.yml
+++ b/.github/workflows/check_release_ci.yml
@@ -1,0 +1,57 @@
+name: Check Release CI
+
+# Job-level wrapper around `.github/actions/check-release-ci`, for manual
+# verification and for release workflows in this repository. Callers in other
+# repositories should use the composite action directly - a reusable workflow
+# runs in the caller's context, so its local `./.github/actions` path is not
+# guaranteed to resolve there.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Tag, branch or sha to check.
+        type: string
+        required: true
+      skip_ci_check:
+        description: >-
+          Emergency override. Skips the gate and records who overrode it.
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      ref:
+        description: Tag, branch or sha to check.
+        type: string
+        required: true
+      skip_ci_check:
+        description: Emergency override; skips the gate and records the override.
+        type: boolean
+        default: false
+    outputs:
+      sha:
+        description: The commit sha that `ref` resolved to.
+        value: ${{ jobs.check-release-ci.outputs.sha }}
+
+permissions:
+  contents: read
+  checks: read
+
+jobs:
+  check-release-ci:
+    name: Check Release CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.gate.outputs.sha }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Check the release commit's CI
+        id: gate
+        uses: ./.github/actions/check-release-ci
+        with:
+          ref: ${{ inputs.ref }}
+          skip-ci-check: ${{ inputs.skip_ci_check }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -49,10 +49,8 @@ jobs:
       - name: Lint and test the prepare_release tooling
         working-directory: .github/scripts
         run: |
-          uv run --with ruff --no-project ruff format --check .
-          uv run --with ruff --no-project ruff check .
-          uv run --with mypy --no-project mypy prepare_release
-          uv run --with pytest --no-project pytest -q
+          make static-checks
+          make test
 
       - name: Guard against a git-pinned Labelformat
         run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -26,6 +26,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend || 'true' }}
       docs: ${{ steps.filter.outputs.docs || 'true' }}
       fast_track: ${{ steps.filter.outputs.fast_track || 'true' }}
+      release_tooling: ${{ steps.filter.outputs.release_tooling || 'true' }}
     steps:
       - name: Checkout Code # Needed for merge_group event
         uses: actions/checkout@v6
@@ -61,6 +62,11 @@ jobs:
             fast_track:
               - '.github/workflows/unit_test.yml'
               - 'fast_track/**'
+            # Release tooling and the CI gate that reads this workflow's checks.
+            release_tooling:
+              - '.github/workflows/unit_test.yml'
+              - '.github/actions/check-release-ci/**'
+              - '.github/scripts/**'
 
   check-python:
     name: Static Checks Python
@@ -299,6 +305,59 @@ jobs:
       - name: Tests
         run: npm run test
 
+  check-release-tooling:
+    name: Static Checks + Tests Release Tooling
+    needs: detect
+    if: needs.detect.outputs.release_tooling == 'true'
+    runs-on: ubuntu-latest
+    # The gate self-test below reads another commit's check runs.
+    permissions:
+      contents: read
+      checks: read
+    defaults:
+      run:
+        working-directory: .github/scripts
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.6"
+          enable-cache: true
+
+      - name: Static checks
+        run: make static-checks
+
+      - name: Tests
+        run: make test
+
+      # A gate that returns success unconditionally also passes a green commit,
+      # so the known-red commit is checked first. These two shas are the
+      # recorded acceptance cases from
+      # `.github/actions/check-release-ci/README.md`; if either stops resolving
+      # because its branch was pruned, replace it there and here together.
+      - name: Release gate must block a known-red commit
+        id: known-red
+        continue-on-error: true
+        uses: ./.github/actions/check-release-ci
+        with:
+          ref: 1f9b2156d23ecf5033b1cfe34be06af5d903d83c
+          github-token: ${{ github.token }}
+
+      - name: Assert the known-red commit was blocked
+        if: steps.known-red.outcome != 'failure'
+        run: |
+          echo "::error::The release gate passed a commit whose required checks failed."
+          exit 1
+
+      - name: Release gate must pass a known-green commit
+        uses: ./.github/actions/check-release-ci
+        with:
+          ref: b2dc2470d5a0055e791944dbd14a4e965ff615bd
+          github-token: ${{ github.token }}
+
   # The single required status check: always runs, so gated jobs can be skipped
   # without stranding the merge queue. Require this in the branch ruleset.
   unit-success:
@@ -312,6 +371,7 @@ jobs:
       - test-frontend
       - check-docs
       - check-fast-track
+      - check-release-tooling
     if: always()
     steps:
       - name: Verify required jobs
@@ -323,6 +383,7 @@ jobs:
           FRONTEND_TESTS: ${{ needs.test-frontend.result }}
           DOCS: ${{ needs.check-docs.result }}
           FAST_TRACK: ${{ needs.check-fast-track.result }}
+          RELEASE_TOOLING: ${{ needs.check-release-tooling.result }}
         run: |
           python3 - <<'PY'
           import os
@@ -341,6 +402,7 @@ jobs:
               "Frontend tests": os.environ["FRONTEND_TESTS"],
               "Build Docs": os.environ["DOCS"],
               "Static Checks + Tests Fast Track": os.environ["FAST_TRACK"],
+              "Static Checks + Tests Release Tooling": os.environ["RELEASE_TOOLING"],
           }
           allowed = {"success", "skipped"}
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -346,11 +346,18 @@ jobs:
           ref: 1f9b2156d23ecf5033b1cfe34be06af5d903d83c
           github-token: ${{ github.token }}
 
+      # `continue-on-error` reports the step's conclusion as success whatever
+      # happens, so the real result is in `outcome`. Echo it: a reviewer must be
+      # able to see that the gate blocked, not infer it from a skipped step.
       - name: Assert the known-red commit was blocked
-        if: steps.known-red.outcome != 'failure'
+        env:
+          OUTCOME: ${{ steps.known-red.outcome }}
         run: |
-          echo "::error::The release gate passed a commit whose required checks failed."
-          exit 1
+          echo "Release gate outcome on the known-red commit: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
+            echo "::error::The release gate passed a commit whose required checks failed."
+            exit 1
+          fi
 
       - name: Release gate must pass a known-green commit
         uses: ./.github/actions/check-release-ci


### PR DESCRIPTION
Closes [LIG-10551](https://linear.app/lightly/issue/LIG-10551/public-repo-gate-releases-on-green-ci-for-the-exact-release-commit).

## What has changed and why?

Nothing in the release process checks that CI passed on the commit being
released. This adds a gate that does, given a tag, branch or sha.

**Why the release PR's own CI is not enough.** The version-bump PR runs Unit
Test and End2End Test, but a release is published from a ref, and that ref is
not necessarily the commit those runs tested:

- Squash-merging the release PR produces a **new** commit on `main`; the PR's
  runs belong to the PR head, not to what was merged.
- Publishing is a separate `workflow_dispatch` with no ordering against `main`'s
  runs. It can be dispatched while they are still going, or after they failed.
- The emergency path in `RELEASE.md` releases from a release branch, which may
  have no runs at all.

The gate asks about the sha rather than about the branch.

### Contents

- `.github/actions/check-release-ci/` - composite action, callable cross-repo so
  the private docs workflow can use it without duplicating the logic. Inputs:
  `ref`, `repository`, `skip-ci-check`, `github-token`; output: `sha`. The
  `README.md` there explains usage and records the acceptance commits.
- `.github/workflows/check_release_ci.yml` - job wrapper around the action, plus
  a `workflow_dispatch` for checking a ref by hand.
- `prepare_release check-ci` (`ci_gate.py`) - the rules, as a pure function with
  offline unit tests. `REQUIRED_CHECKS` is the single place the required checks
  are named.
- `unit_test.yml` - a `Static Checks + Tests Release Tooling` job so
  `.github/scripts` is linted, type checked and tested on PRs rather than only
  during a release, and a self-test of the gate (see below).
- `.github/scripts/Makefile` - `static-checks` / `test`, so `unit_test.yml` and
  `prepare_release.yml` do not each spell out the commands.

### Decisions, and the trap they avoid

The dangerous outcome here is a gate that silently passes everything, because
once it exists people stop checking by hand.

- **The required names are the aggregate jobs**, `CI Success Check` and `End2End
  Success Check` - not the workflow names `Unit Test` and `End2End Test`, which
  name no check run at all and would match nothing and pass vacuously.
- **Only a completed `success` counts.** Missing, still running, `cancelled`,
  `skipped` and `neutral` all block. Requiring the aggregates also settles the
  `skipped` question at the right level: both run with `if: always()`, so the
  per-job skips that `unit_test.yml`'s path filters produce are resolved inside
  `CI Success Check` itself. `da604e08` on `main` is a real example - every
  gated unit-test job `skipped`, aggregate green.
- **One completed green attempt on the sha is enough.** Every commit on `main`
  carries each check twice, from the merge-queue run and the push-to-main run,
  and `cancel-in-progress: true` routinely cancels the second - a cancelled
  aggregate job reports `failure`. "Newest attempt wins" would therefore block
  nearly every commit, and a gate that blocks everything gets overridden by
  habit, which loses the same vigilance by another route. Other attempts are
  reported next to the green one, so a genuine flake stays visible.

`skip-ci-check: true` skips the gate for the documented emergency path and
records the override, with the actor's name, in the log and the job summary.

## How has it been tested?

Unit tests cover the rules offline. Beyond that, the gate was run against real
commits, known-red first - a gate that returns success unconditionally also
passes a green commit, so checking a green one proves nothing on its own:

| Case | Commit | Result |
| --- | --- | --- |
| Both required checks failed | `1f9b2156` | blocks, both named and linked |
| One required check failed | `a311e602` | blocks, `CI Success Check` named and linked |
| Every gated unit-test job `skipped`, aggregate green | `da604e08` | passes |
| Green, with a cancelled push attempt | `2ae55628` | passes, other attempt flagged |
| Green | `b2dc2470` | passes |

Still-running and misspelled-requirement cases are unit tested; a commit whose
checks are still running is refused, not passed.

The first and last rows are pinned as a **self-test in CI**: whenever the gate
changes, `Static Checks + Tests Release Tooling` runs the action against the
known-red commit and fails the build unless the gate blocked it, then runs it
against the known-green commit. The shas are recorded in the action's
`README.md`.

Not yet exercised: `workflow_dispatch` on `check_release_ci.yml`, which GitHub
only offers once the workflow is on the default branch. I will dispatch it right
after merge as the final confirmation; the action itself is exercised on this PR
by the self-test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release validation that confirms required CI checks passed on the exact commit being released.
  * Added reusable and manually triggered workflows for checking release readiness.
  * Added clear reports and error details when checks are missing, incomplete, or unsuccessful.
  * Added an emergency override for bypassing CI validation when necessary.

* **Bug Fixes**
  * Prevents releases from proceeding when required checks have not completed successfully.

* **Tests**
  * Added automated coverage for successful, failed, missing, and in-progress CI results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->