### PR TITLE
Lint and test the release tooling on PRs

### DIFF
--- a/.github/scripts/Makefile
+++ b/.github/scripts/Makefile
@@ -1,0 +1,27 @@
+# CI-internal release tooling. Kept out of the workspace's uv project on purpose
+# (`--no-project`): it must run before, and independently of, the LightlyStudio
+# environment it prepares a release for.
+UV := uv run --no-project
+
+.PHONY: static-checks
+static-checks: format-check lint type-check
+
+.PHONY: format-check
+format-check:
+	$(UV) --with ruff ruff format --check .
+
+.PHONY: lint
+lint:
+	$(UV) --with ruff ruff check .
+
+.PHONY: type-check
+type-check:
+	$(UV) --with mypy mypy prepare_release
+
+.PHONY: format
+format:
+	$(UV) --with ruff ruff format .
+
+.PHONY: test
+test:
+	$(UV) --with pytest pytest -q

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -49,10 +49,8 @@ jobs:
       - name: Lint and test the prepare_release tooling
         working-directory: .github/scripts
         run: |
-          uv run --with ruff --no-project ruff format --check .
-          uv run --with ruff --no-project ruff check .
-          uv run --with mypy --no-project mypy prepare_release
-          uv run --with pytest --no-project pytest -q
+          make static-checks
+          make test
 
       - name: Guard against a git-pinned Labelformat
         run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -26,6 +26,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend || 'true' }}
       docs: ${{ steps.filter.outputs.docs || 'true' }}
       fast_track: ${{ steps.filter.outputs.fast_track || 'true' }}
+      release_tooling: ${{ steps.filter.outputs.release_tooling || 'true' }}
     steps:
       - name: Checkout Code # Needed for merge_group event
         uses: actions/checkout@v6
@@ -61,6 +62,10 @@ jobs:
             fast_track:
               - '.github/workflows/unit_test.yml'
               - 'fast_track/**'
+            # Release tooling: CI-internal, so it has its own toolchain.
+            release_tooling:
+              - '.github/workflows/unit_test.yml'
+              - '.github/scripts/**'
 
   check-python:
     name: Static Checks Python
@@ -299,6 +304,30 @@ jobs:
       - name: Tests
         run: npm run test
 
+  check-release-tooling:
+    name: Static Checks + Tests Release Tooling
+    needs: detect
+    if: needs.detect.outputs.release_tooling == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .github/scripts
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.6"
+          enable-cache: true
+
+      - name: Static checks
+        run: make static-checks
+
+      - name: Tests
+        run: make test
+
   # The single required status check: always runs, so gated jobs can be skipped
   # without stranding the merge queue. Require this in the branch ruleset.
   unit-success:
@@ -312,6 +341,7 @@ jobs:
       - test-frontend
       - check-docs
       - check-fast-track
+      - check-release-tooling
     if: always()
     steps:
       - name: Verify required jobs
@@ -323,6 +353,7 @@ jobs:
           FRONTEND_TESTS: ${{ needs.test-frontend.result }}
           DOCS: ${{ needs.check-docs.result }}
           FAST_TRACK: ${{ needs.check-fast-track.result }}
+          RELEASE_TOOLING: ${{ needs.check-release-tooling.result }}
         run: |
           python3 - <<'PY'
           import os
@@ -341,6 +372,7 @@ jobs:
               "Frontend tests": os.environ["FRONTEND_TESTS"],
               "Build Docs": os.environ["DOCS"],
               "Static Checks + Tests Fast Track": os.environ["FAST_TRACK"],
+              "Static Checks + Tests Release Tooling": os.environ["RELEASE_TOOLING"],
           }
           allowed = {"success", "skipped"}
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -309,12 +309,20 @@ jobs:
     needs: detect
     if: needs.detect.outputs.release_tooling == 'true'
     runs-on: ubuntu-latest
+    # This job runs code the pull request itself supplies - pytest collects the
+    # PR's conftest.py, and `uv run --with` resolves tools from PyPI at job
+    # time. The repository default is a write-scoped token, so pin this job to
+    # read-only and keep the token out of .git/config.
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: .github/scripts
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set Up uv
         uses: astral-sh/setup-uv@v10.0.1


### PR DESCRIPTION
Stack for [LIG-10551](https://linear.app/lightly/issue/LIG-10551/public-repo-gate-releases-on-green-ci-for-the-exact-release-commit), 1 of 3. Standalone — it is useful whether or not the rest lands.

## What has changed and why?

`.github/scripts` (the `prepare_release` tooling behind the Prepare Release
workflow) is only linted, type checked and tested **during an actual release**.
A mistake there surfaces when you are trying to cut a release, which is the
worst moment to find it.

- Adds `.github/scripts/Makefile` with `static-checks` / `test`, matching the
  `lightly_studio` and `lightly_studio_view` convention, so the commands live in
  one place instead of being spelled out per workflow.
- Adds a `Static Checks + Tests Release Tooling` job to `unit_test.yml`, gated on
  a `release_tooling` path filter and wired into `CI Success Check` like the
  other jobs.
- `prepare_release.yml` now calls the Makefile rather than repeating the four
  `uv run` lines.

No behaviour change to the tooling itself.

## How has it been tested?

`make static-checks` and `make test` pass locally (54 tests). The new job runs on
this PR — it should appear as `Static Checks + Tests Release Tooling`, and be
skipped on PRs that touch nothing under `.github/scripts`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly (most recent `.github/workflows` history), alternatively @JonasWurst.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated formatting, lint, type-checking, and test validation for release tooling.
  * Release-tooling checks now run automatically when related files change and are included in required CI validation.

* **Chores**
  * Consolidated release-tooling quality checks into reusable commands for consistent execution across workflows.
  * Improved CI safeguards for release-tooling validation with restricted permissions and secure checkout settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->