### PR TITLE
Add the release CI gate rule

### DIFF
--- a/.github/scripts/prepare_release/ci_gate.py
+++ b/.github/scripts/prepare_release/ci_gate.py
@@ -1,0 +1,180 @@
+"""Release gate: the required CI checks must be green on the release commit.
+
+Backs the "Check release CI" composite action, which resolves a ref to a sha,
+fetches that commit's check runs and hands them to the `check-ci` subcommand.
+Nothing here touches the network, so every rule below is unit tested offline.
+
+A gate that waves everything through is worse than no gate, because it also
+replaces the manual checking it removed. Hence the three rules: the required
+names come from the branch ruleset rather than a copy kept here, which would
+drift from it silently; only a completed `success` passes; and one green
+attempt is enough, because `cancel-in-progress: true` cancels the
+push-to-main attempt of nearly every commit on `main`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Sequence
+from typing import Any
+
+from prepare_release.errors import PrepareReleaseError
+
+_REQUIRED_STATUS_CHECKS = "required_status_checks"
+_COMPLETED = "completed"
+_SUCCESS = "success"
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckRun:
+    """One check run GitHub reports for a commit, named after the job that produced it.
+
+    Attributes:
+        conclusion: Empty while the run has not completed.
+    """
+
+    name: str
+    status: str
+    conclusion: str
+    url: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckVerdict:
+    """The gate's reading of one required check.
+
+    Attributes:
+        detail: Why, phrased to follow the check name in a sentence.
+        url: The run that decided it, empty when there is none.
+    """
+
+    name: str
+    passed: bool
+    detail: str
+    url: str
+
+
+def parse_required_checks(payload: Any) -> list[str]:
+    """Reads the required check names out of `gh api repos/.../rules/branches/<branch>`.
+
+    The branch ruleset is where the team already agreed which checks must pass
+    before anything reaches `main`, so the gate asks it rather than keeping a
+    second list. Note that check runs are named after jobs, so a hand-written
+    list of the workflow names would match nothing and pass everything.
+
+    Raises:
+        PrepareReleaseError: The payload is not a rules response, or it names no
+            required checks. Requiring nothing would pass every commit, so it is
+            refused rather than obeyed.
+    """
+    if not isinstance(payload, list):
+        raise PrepareReleaseError(
+            "Not a branch-rules API response; the gate cannot tell which checks are "
+            "required, so it refuses to pass."
+        )
+    contexts = [
+        check["context"]
+        for rule in payload
+        if isinstance(rule, dict) and rule.get("type") == _REQUIRED_STATUS_CHECKS
+        for check in rule.get("parameters", {}).get(_REQUIRED_STATUS_CHECKS, [])
+    ]
+    if not contexts:
+        raise PrepareReleaseError(
+            "The branch ruleset names no required status checks. Requiring nothing "
+            "would pass every commit, so the gate refuses instead. Fix the ruleset "
+            "before releasing."
+        )
+    return contexts
+
+
+def parse_check_runs(payload: Any) -> list[CheckRun]:
+    """Flattens the JSON of `gh api repos/.../commits/<sha>/check-runs`.
+
+    Args:
+        payload: One API response object, or the list of pages that
+            `gh api --paginate --slurp` produces.
+
+    Raises:
+        PrepareReleaseError: The payload is not a check-runs response, so the
+            gate cannot tell a red commit from an unreadable one.
+    """
+    pages = payload if isinstance(payload, list) else [payload]
+    if not all(isinstance(page, dict) and "check_runs" in page for page in pages):
+        raise PrepareReleaseError(
+            "Not a check-runs API response; the gate cannot tell a red commit from an "
+            "unreadable one, so it refuses to pass."
+        )
+    return [
+        CheckRun(
+            name=run["name"],
+            status=run["status"],
+            conclusion=run["conclusion"] or "",
+            url=run.get("html_url") or "",
+        )
+        for page in pages
+        for run in page["check_runs"]
+    ]
+
+
+def evaluate_check_runs(
+    check_runs: Sequence[CheckRun], required: Sequence[str]
+) -> list[CheckVerdict]:
+    """Judges each required check against the runs reported for one commit."""
+    ci_running = any(run.status != _COMPLETED for run in check_runs)
+    return [
+        _verdict(
+            name=name,
+            runs=[run for run in check_runs if run.name == name],
+            ci_running=ci_running,
+        )
+        for name in required
+    ]
+
+
+def render_report(verdicts: Sequence[CheckVerdict], sha: str) -> str:
+    """Renders the verdicts as a markdown table for the job summary."""
+    lines = [
+        f"### Release CI gate for `{sha}`",
+        "",
+        "| Required check | Result |",
+        "| --- | --- |",
+    ]
+    for verdict in verdicts:
+        mark = "✅" if verdict.passed else "❌"
+        detail = f"[{verdict.detail}]({verdict.url})" if verdict.url else verdict.detail
+        lines.append(f"| {verdict.name} | {mark} {detail} |")
+    return "\n".join(lines) + "\n"
+
+
+def _verdict(name: str, runs: Sequence[CheckRun], ci_running: bool) -> CheckVerdict:
+    """Judges one required check from every attempt reported under its name.
+
+    An aggregate job only gets a check run once the jobs it waits on are done,
+    so a commit whose CI is still running (`ci_running`) has no run under this
+    name yet - which must not read as "CI never ran".
+    """
+    if not runs:
+        detail = "was never reported on this commit"
+        if ci_running:
+            detail = "is not reported yet; CI on this commit is still running"
+        return CheckVerdict(name=name, passed=False, detail=detail, url="")
+
+    green = [run for run in runs if run.status == _COMPLETED and run.conclusion == _SUCCESS]
+    if green:
+        not_green = len(runs) - len(green)
+        detail = "succeeded"
+        if not_green:
+            detail = f"succeeded, but {not_green} other attempt(s) did not"
+        return CheckVerdict(name=name, passed=True, detail=detail, url=green[0].url)
+
+    outcomes = ", ".join(_outcome(run) for run in runs)
+    return CheckVerdict(
+        name=name, passed=False, detail=f"did not succeed: {outcomes}", url=runs[0].url
+    )
+
+
+def _outcome(run: CheckRun) -> str:
+    """Names what one attempt did: its conclusion, or its status while it has none."""
+    if run.status != _COMPLETED:
+        return f"still {run.status.replace('_', ' ')}"
+    return run.conclusion or "completed without a conclusion"

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -15,16 +15,18 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
-from prepare_release import changelog, lock, pr_body, version
+from prepare_release import changelog, ci_gate, lock, pr_body, version
 from prepare_release.errors import PrepareReleaseError
 
 CHECK_LABELFORMAT_PIN = "check-labelformat-pin"
 PROMOTE_CHANGELOG = "promote-changelog"
 ASSERT_LOCK_DIFF = "assert-lock-diff"
 RENDER_PR_BODY = "render-pr-body"
+CHECK_CI = "check-ci"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,6 +58,26 @@ def main(argv: list[str] | None = None) -> int:
     pr_body_parser.add_argument("--version", required=True)
     pr_body_parser.add_argument("--output", type=Path, required=True)
 
+    check_ci = subparsers.add_parser(
+        CHECK_CI, help="fail unless the required CI checks are green on a commit"
+    )
+    check_ci.add_argument(
+        "--check-runs",
+        type=Path,
+        required=True,
+        help="JSON of `gh api repos/<repo>/commits/<sha>/check-runs`",
+    )
+    check_ci.add_argument("--sha", required=True, help="the commit the runs belong to")
+    check_ci.add_argument(
+        "--branch-rules",
+        type=Path,
+        required=True,
+        help="JSON of `gh api repos/<repo>/rules/branches/<branch>`, naming the required checks",
+    )
+    check_ci.add_argument(
+        "--summary", type=Path, help="file the markdown report is appended to, e.g. the job summary"
+    )
+
     args = parser.parse_args(argv)
 
     try:
@@ -71,6 +93,7 @@ def _dispatch(args: argparse.Namespace) -> int:
         PROMOTE_CHANGELOG: _cmd_promote_changelog,
         ASSERT_LOCK_DIFF: _cmd_assert_lock_diff,
         RENDER_PR_BODY: _cmd_render_pr_body,
+        CHECK_CI: _cmd_check_ci,
     }
     handlers[args.command](args)
     return 0
@@ -105,6 +128,29 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
     )
     body = pr_body.render_pr_body(section_body=section_body, version=args.version)
     args.output.write_text(body)
+
+
+def _cmd_check_ci(args: argparse.Namespace) -> None:
+    required = ci_gate.parse_required_checks(json.loads(args.branch_rules.read_text()))
+    print(f"Required checks, per the branch ruleset: {', '.join(required)}")
+    verdicts = ci_gate.evaluate_check_runs(
+        check_runs=ci_gate.parse_check_runs(json.loads(args.check_runs.read_text())),
+        required=required,
+    )
+    report = ci_gate.render_report(verdicts=verdicts, sha=args.sha)
+    print(report)
+    if args.summary is not None:
+        with args.summary.open("a") as summary:
+            summary.write(report)
+
+    failed = [verdict for verdict in verdicts if not verdict.passed]
+    for verdict in failed:
+        print(f"::error::Required check '{verdict.name}' {verdict.detail}. {verdict.url}".rstrip())
+    if failed:
+        raise PrepareReleaseError(
+            f"{len(failed)} of {len(verdicts)} required checks are not green on {args.sha}; "
+            "not releasing this commit."
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_ci_gate.py
+++ b/.github/scripts/tests/test_ci_gate.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import pytest
+
+from prepare_release import ci_gate
+from prepare_release.errors import PrepareReleaseError
+
+AGGREGATE_CHECKS = ["CI Success Check", "End2End Success Check"]
+
+
+def _branch_rules(*contexts: str) -> list[dict[str, object]]:
+    return [
+        {"type": "pull_request", "parameters": {}},
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "required_status_checks": [
+                    {"context": context, "integration_id": 15368} for context in contexts
+                ]
+            },
+        },
+    ]
+
+
+def _api_run(
+    name: str,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    url: str = "https://github.com/lightly-ai/lightly-studio/runs/1",
+) -> dict[str, object]:
+    return {"name": name, "status": status, "conclusion": conclusion, "html_url": url}
+
+
+def test_parse_required_checks():
+    assert ci_gate.parse_required_checks(_branch_rules(*AGGREGATE_CHECKS)) == AGGREGATE_CHECKS
+
+
+def test_parse_required_checks__no_required_checks_is_refused():
+    with pytest.raises(PrepareReleaseError):
+        ci_gate.parse_required_checks(_branch_rules())
+
+
+def test_parse_required_checks__ruleset_without_the_rule_is_refused():
+    with pytest.raises(PrepareReleaseError):
+        ci_gate.parse_required_checks([{"type": "pull_request", "parameters": {}}])
+
+
+def test_parse_required_checks__unreadable_payload_is_refused():
+    with pytest.raises(PrepareReleaseError):
+        ci_gate.parse_required_checks({"message": "Not Found"})
+
+
+def test_parse_check_runs():
+    runs = ci_gate.parse_check_runs({"check_runs": [_api_run("CI Success Check")]})
+
+    assert runs == [
+        ci_gate.CheckRun(
+            name="CI Success Check",
+            status="completed",
+            conclusion="success",
+            url="https://github.com/lightly-ai/lightly-studio/runs/1",
+        )
+    ]
+
+
+def test_parse_check_runs__slurped_pages():
+    payload = [
+        {"check_runs": [_api_run("CI Success Check")]},
+        {"check_runs": [_api_run("End2End Success Check")]},
+    ]
+
+    runs = ci_gate.parse_check_runs(payload)
+
+    assert [run.name for run in runs] == ["CI Success Check", "End2End Success Check"]
+
+
+def test_parse_check_runs__running_run_has_no_conclusion():
+    payload = {"check_runs": [_api_run("CI Success Check", status="in_progress", conclusion=None)]}
+
+    runs = ci_gate.parse_check_runs(payload)
+
+    assert runs[0].conclusion == ""
+
+
+def test_parse_check_runs__unreadable_payload_is_refused():
+    with pytest.raises(PrepareReleaseError):
+        ci_gate.parse_check_runs({"message": "Not Found"})
+
+
+def test_evaluate_check_runs__all_green():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check"),
+                _api_run("End2End Success Check"),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=AGGREGATE_CHECKS)
+
+    assert [verdict.passed for verdict in verdicts] == [True, True]
+
+
+def test_evaluate_check_runs__failed_check_is_named():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check"),
+                _api_run("End2End Success Check", conclusion="failure", url="run-2"),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=AGGREGATE_CHECKS)
+
+    assert verdicts[0].passed
+    assert not verdicts[1].passed
+    assert verdicts[1].name == "End2End Success Check"
+    assert "failure" in verdicts[1].detail
+    assert verdicts[1].url == "run-2"
+
+
+@pytest.mark.parametrize("status", ["queued", "in_progress"])
+def test_evaluate_check_runs__still_running_does_not_pass(status: str):
+    runs = ci_gate.parse_check_runs(
+        {"check_runs": [_api_run("CI Success Check", status=status, conclusion=None)]}
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "still" in verdicts[0].detail
+
+
+@pytest.mark.parametrize("conclusion", ["cancelled", "skipped", "neutral", "timed_out"])
+def test_evaluate_check_runs__non_success_conclusion_does_not_pass(conclusion: str):
+    runs = ci_gate.parse_check_runs(
+        {"check_runs": [_api_run("CI Success Check", conclusion=conclusion)]}
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert conclusion in verdicts[0].detail
+
+
+def test_evaluate_check_runs__missing_check_does_not_pass():
+    verdicts = ci_gate.evaluate_check_runs([], required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "never reported" in verdicts[0].detail
+
+
+# An aggregate job gets no check run until the jobs it waits on finish.
+def test_evaluate_check_runs__missing_check_while_ci_is_running():
+    runs = ci_gate.parse_check_runs(
+        {"check_runs": [_api_run("Backend (3.9, DuckDB)", status="in_progress", conclusion=None)]}
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert "still running" in verdicts[0].detail
+
+
+def test_evaluate_check_runs__misspelled_requirement_does_not_pass_vacuously():
+    runs = ci_gate.parse_check_runs({"check_runs": [_api_run("CI Success Check")]})
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["Unit Test"])
+
+    assert not verdicts[0].passed
+
+
+# Every commit on main carries each check twice, and the push-to-main attempt is
+# routinely cancelled, which reports as `failure`.
+def test_evaluate_check_runs__one_green_attempt_passes():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check", conclusion="failure", url="red"),
+                _api_run("CI Success Check", url="green"),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert verdicts[0].passed
+    assert "1 other attempt(s) did not" in verdicts[0].detail
+    assert verdicts[0].url == "green"
+
+
+def test_evaluate_check_runs__no_green_attempt_reports_every_outcome():
+    runs = ci_gate.parse_check_runs(
+        {
+            "check_runs": [
+                _api_run("CI Success Check", conclusion="failure"),
+                _api_run("CI Success Check", conclusion="failure"),
+                _api_run("CI Success Check", status="in_progress", conclusion=None),
+            ]
+        }
+    )
+
+    verdicts = ci_gate.evaluate_check_runs(runs, required=["CI Success Check"])
+
+    assert not verdicts[0].passed
+    assert verdicts[0].detail == "did not succeed: failure, failure, still in progress"
+
+
+def test_render_report():
+    verdicts = [
+        ci_gate.CheckVerdict(name="CI Success Check", passed=True, detail="succeeded", url="url-1"),
+        ci_gate.CheckVerdict(
+            name="End2End Success Check", passed=False, detail="concluded failure", url="url-2"
+        ),
+    ]
+
+    report = ci_gate.render_report(verdicts=verdicts, sha="0123abc")
+
+    assert "0123abc" in report
+    assert "| CI Success Check | ✅ [succeeded](url-1) |" in report
+    assert "| End2End Success Check | ❌ [concluded failure](url-2) |" in report

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -44,6 +45,25 @@ name = "lightly-studio"
 version = "1.0.5"
 source = { editable = "." }
 """
+
+SAMPLE_BRANCH_RULES = [
+    {
+        "type": "required_status_checks",
+        "parameters": {
+            "required_status_checks": [
+                {"context": "CI Success Check"},
+                {"context": "End2End Success Check"},
+            ]
+        },
+    }
+]
+
+SAMPLE_CHECK_RUN = {
+    "name": "CI Success Check",
+    "status": "completed",
+    "conclusion": "success",
+    "html_url": "https://github.com/lightly-ai/lightly-studio/runs/1",
+}
 
 
 def test_main__unknown_command_exits_nonzero():
@@ -157,3 +177,63 @@ def test_main__render_pr_body__writes_file(tmp_path: Path):
     )
     body = output.read_text()
     assert "Added thing one" in body
+
+
+def _check_ci_files(tmp_path: Path, *runs: dict[str, object]) -> tuple[Path, Path]:
+    check_runs = tmp_path / "check-runs.json"
+    check_runs.write_text(json.dumps({"check_runs": list(runs)}))
+    branch_rules = tmp_path / "branch-rules.json"
+    branch_rules.write_text(json.dumps(SAMPLE_BRANCH_RULES))
+    return check_runs, branch_rules
+
+
+def _check_ci_argv(check_runs: Path, branch_rules: Path) -> list[str]:
+    return [
+        "check-ci",
+        "--check-runs",
+        str(check_runs),
+        "--branch-rules",
+        str(branch_rules),
+        "--sha",
+        "0123abc",
+    ]
+
+
+def test_main__check_ci__green_commit_passes(tmp_path: Path):
+    check_runs, branch_rules = _check_ci_files(
+        tmp_path,
+        SAMPLE_CHECK_RUN | {"name": "CI Success Check"},
+        SAMPLE_CHECK_RUN | {"name": "End2End Success Check"},
+    )
+    summary = tmp_path / "summary.md"
+
+    exit_code = cli.main([*_check_ci_argv(check_runs, branch_rules), "--summary", str(summary)])
+
+    assert exit_code == 0
+    assert "0123abc" in summary.read_text()
+
+
+def test_main__check_ci__red_commit_fails(tmp_path: Path):
+    check_runs, branch_rules = _check_ci_files(
+        tmp_path,
+        SAMPLE_CHECK_RUN | {"name": "CI Success Check"},
+        SAMPLE_CHECK_RUN | {"name": "End2End Success Check", "conclusion": "failure"},
+    )
+
+    exit_code = cli.main(_check_ci_argv(check_runs, branch_rules))
+
+    assert exit_code == 1
+
+
+# A ruleset that requires nothing must not be read as "everything passes".
+def test_main__check_ci__ruleset_without_required_checks_fails(tmp_path: Path):
+    check_runs, branch_rules = _check_ci_files(
+        tmp_path,
+        SAMPLE_CHECK_RUN | {"name": "CI Success Check"},
+        SAMPLE_CHECK_RUN | {"name": "End2End Success Check"},
+    )
+    branch_rules.write_text(json.dumps([{"type": "pull_request", "parameters": {}}]))
+
+    exit_code = cli.main(_check_ci_argv(check_runs, branch_rules))
+
+    assert exit_code == 1


### PR DESCRIPTION
Stack for [LIG-10551](https://linear.app/lightly/issue/LIG-10551/public-repo-gate-releases-on-green-ci-for-the-exact-release-commit), 2 of 3. Follows #2124; #2126 wraps this in a composite action and is where it first runs.

## What has changed and why?

A release must not be cut from a commit whose CI is red or unfinished, and the
version-bump PR's own checks do not prove that it is not: squash-merging
produces a new commit, `workflow_dispatch` imposes no ordering against `main`'s
runs, and the emergency path releases from a release branch that may have no
runs at all. So the gate asks about the **sha**, never the branch.

This PR is the rule only - pure functions and their tests. Nothing calls it yet:

- `ci_gate.py` reads the required check names from `main`'s branch ruleset,
  matches them against the commit's check runs, and renders a verdict table for
  the job summary.
- A `check-ci` subcommand in `cli.py` reads the two API payloads from disk and
  fails when a required check is not green.

The module docstring carries the reasoning for the three rules that decide it,
each of which fails the gate open if it is wrong.

## How has it been tested?

`make static-checks` and `make test` pass (62 tests). The unit tests cover the
cases that would make the gate pass vacuously: an empty or unreadable ruleset, a
misspelled requirement, and `cancelled` / `skipped` / `neutral` on a required
check.

Also run by hand against recorded commits - `1f9b2156` (both required checks
red) exits 1 naming both, `b2dc2470` (green) exits 0, and `2ae55628` (green with
a cancelled second attempt) passes and flags the other attempt. #2126 turns the
red and green cases into a CI self-test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly, alternatively @JonasWurst.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `check-ci` command that evaluates required checks for a commit and generates a Markdown report.
  - Reports clearly identify missing, in-progress, unsuccessful, or inconclusive checks.
  - Failed checks produce command-line error annotations and prevent successful completion.
  - Supports paginated check-run data and optionally appends reports to a summary file.

- **Tests**
  - Added coverage for successful and failed checks, duplicate attempts, malformed data, and missing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->