### PR TITLE
Add the check-release-ci composite action

### DIFF
--- a/.github/actions/check-release-ci/README.md
+++ b/.github/actions/check-release-ci/README.md
@@ -1,0 +1,48 @@
+# Check release CI
+
+Fails unless every required CI check succeeded on the **exact commit** being
+released. Release workflows call it before tagging, publishing a wheel or
+deploying docs.
+
+```yaml
+- uses: lightly-ai/lightly-studio/.github/actions/check-release-ci@main
+  with:
+    ref: v1.2.3            # tag, branch or sha being released
+    github-token: ${{ github.token }}
+```
+
+GitHub checks out this whole repository for the action, so the gate in
+`.github/scripts` comes along and cross-repo callers - including the private
+repo's docs workflow - need nothing else. The runner needs `gh` and `python3`,
+and the job needs `checks: read`.
+
+Set `skip-ci-check: true` for the documented emergency path. It skips the gate
+and records the override, with the actor's name, in the job summary.
+
+## What counts as green
+
+The rules and their reasoning live in
+[`ci_gate.py`](../../scripts/prepare_release/ci_gate.py). `main` is green by
+construction - the merge queue tests the squashed candidate - so on the normal
+path this gate is a no-op. It is here for the paths that skip the queue: a fix
+released from a release branch, the docs release accepting an arbitrary commit,
+and above all automated publishing, where nothing else is looking at CI.
+
+## Verified against
+
+A gate that returns success unconditionally also passes a green commit, so the
+red cases decide. `unit_test.yml` re-runs the first and last row on every change
+to the gate; re-check the rest by hand after changing it.
+
+| Case | Commit | Expected |
+| --- | --- | --- |
+| Both required checks failed | `1f9b2156d23ecf5033b1cfe34be06af5d903d83c` | blocks, naming both |
+| One required check failed | `a311e602b9fadd5c4e950adde7786aa53bc6fa5c` | blocks, naming `CI Success Check` |
+| Every gated unit-test job `skipped`, aggregate green | `da604e0802b9f91adf9ac8cca298623a587c62e1` | passes |
+| Green, with a cancelled push attempt | `2ae55628ff29e01065d748128d7a39aa4519f8bf` | passes, flagging the other attempt |
+| Green | `b2dc2470d5a0055e791944dbd14a4e965ff615bd` | passes |
+
+Checks still running was verified live rather than against a fixed sha, since
+any commit goes green afterwards: run against `0b6cfbc8` mid-flight, the gate
+refused it. An aggregate job gets no check run until the jobs it waits on
+finish, so this arrives as an absent check rather than a running one.

--- a/.github/actions/check-release-ci/action.yml
+++ b/.github/actions/check-release-ci/action.yml
@@ -1,0 +1,79 @@
+name: Check release CI
+description: >-
+  Fails unless every required CI check succeeded on the exact commit being
+  released, so a release is never cut from an untested or red commit.
+
+inputs:
+  ref:
+    description: Tag, branch or sha being released. Resolved to a commit sha.
+    required: true
+  skip-ci-check:
+    description: >-
+      Emergency override for the documented path where a fix is released from a
+      release branch rather than main. "true" skips the gate entirely and
+      records who overrode it in the log and the job summary.
+    required: false
+    default: "false"
+  github-token:
+    description: Token with read access to the repository's contents and checks.
+    required: true
+
+outputs:
+  sha:
+    description: The commit sha that `ref` resolved to.
+    value: ${{ steps.resolve.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve the release commit
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: lightly-ai/lightly-studio
+        REF: ${{ inputs.ref }}
+      run: |
+        set -euo pipefail
+        sha="$(gh api "repos/${REPO}/commits/${REF}" --jq .sha)"
+        echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+        echo "Release ref '${REF}' resolves to ${sha}."
+
+    - name: Record the override
+      if: inputs.skip-ci-check == 'true'
+      shell: bash
+      env:
+        SHA: ${{ steps.resolve.outputs.sha }}
+      run: |
+        set -euo pipefail
+        echo "::warning::Release CI gate skipped for ${SHA} by ${GITHUB_ACTOR} (skip-ci-check=true)."
+        {
+          echo "### Release CI gate for \`${SHA}\`"
+          echo
+          echo "⚠️ **Skipped** via \`skip-ci-check\`, requested by @${GITHUB_ACTOR}."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Verify the required checks are green
+      if: inputs.skip-ci-check != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: lightly-ai/lightly-studio
+        SHA: ${{ steps.resolve.outputs.sha }}
+        # The gate lives with the rest of the release tooling so it is linted,
+        # type checked and unit tested, rather than being inlined here where
+        # nothing could test it.
+        PYTHONPATH: ${{ github.action_path }}/../../scripts
+      # `--slurp` keeps the paginated pages as a JSON array instead of
+      # concatenating them into invalid JSON.
+      run: |
+        set -euo pipefail
+        gh api "repos/${REPO}/rules/branches/main" > "${RUNNER_TEMP}/branch-rules.json"
+        gh api --paginate --slurp \
+          "repos/${REPO}/commits/${SHA}/check-runs?per_page=100" \
+          > "${RUNNER_TEMP}/check-runs.json"
+        python3 -m prepare_release check-ci \
+          --check-runs "${RUNNER_TEMP}/check-runs.json" \
+          --branch-rules "${RUNNER_TEMP}/branch-rules.json" \
+          --sha "${SHA}" \
+          --summary "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -62,9 +62,10 @@ jobs:
             fast_track:
               - '.github/workflows/unit_test.yml'
               - 'fast_track/**'
-            # Release tooling: CI-internal, so it has its own toolchain.
+            # Release tooling and the CI gate that reads this workflow's checks.
             release_tooling:
               - '.github/workflows/unit_test.yml'
+              - '.github/actions/check-release-ci/**'
               - '.github/scripts/**'
 
   check-python:
@@ -312,9 +313,11 @@ jobs:
     # This job runs code the pull request itself supplies - pytest collects the
     # PR's conftest.py, and `uv run --with` resolves tools from PyPI at job
     # time. The repository default is a write-scoped token, so pin this job to
-    # read-only and keep the token out of .git/config.
+    # read-only and keep the token out of .git/config. `checks: read` is for the
+    # gate self-test below.
     permissions:
       contents: read
+      checks: read
     defaults:
       run:
         working-directory: .github/scripts
@@ -335,6 +338,35 @@ jobs:
 
       - name: Tests
         run: make test
+
+      # A gate that returns success unconditionally also passes a green commit,
+      # so the red case is the one that proves anything. Both shas are recorded
+      # in the action's README; replace them there and here together.
+      - name: Release gate must block a known-red commit
+        id: known-red
+        continue-on-error: true
+        uses: ./.github/actions/check-release-ci
+        with:
+          ref: 1f9b2156d23ecf5033b1cfe34be06af5d903d83c
+          github-token: ${{ github.token }}
+
+      # `continue-on-error` forces the step's conclusion to success, so the real
+      # result is in `outcome`.
+      - name: Assert the known-red commit was blocked
+        env:
+          OUTCOME: ${{ steps.known-red.outcome }}
+        run: |
+          echo "Release gate outcome on the known-red commit: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
+            echo "::error::The release gate passed a commit whose required checks failed."
+            exit 1
+          fi
+
+      - name: Release gate must pass a known-green commit
+        uses: ./.github/actions/check-release-ci
+        with:
+          ref: b2dc2470d5a0055e791944dbd14a4e965ff615bd
+          github-token: ${{ github.token }}
 
   # The single required status check: always runs, so gated jobs can be skipped
   # without stranding the merge queue. Require this in the branch ruleset.


### PR DESCRIPTION
Stack for [LIG-10551](https://linear.app/lightly/issue/LIG-10551/public-repo-gate-releases-on-green-ci-for-the-exact-release-commit), 3 of 3. Stacked on #2125. This is the part that runs.

## What has changed and why?

Wraps the gate rule from #2125 in a composite action, so release workflows can
call it before tagging, publishing a wheel or deploying docs:

```yaml
- uses: lightly-ai/lightly-studio/.github/actions/check-release-ci@main
  with:
    ref: v1.2.3
    github-token: ${{ github.token }}
```

A composite action rather than a reusable workflow: GitHub checks out this
repository for it, so the tooling in `.github/scripts` comes along, and it works
cross-repo — which is what the private docs workflow needs. It fetches `main`'s
branch ruleset for the required check names and the commit's check runs, then
runs the gate. `skip-ci-check: true` is the override for `RELEASE.md`'s
emergency path; it records the actor in the log and the job summary.

**It self-tests in CI.** `Static Checks + Tests Release Tooling` now runs the
action against a recorded known-red commit and fails the build unless the gate
*blocked* it, then against a known-green one. A gate that returns success
unconditionally passes a green commit too, so the red case is the one that
proves anything — and it is now checked on every change to the gate, not just
once by hand.

## How has it been tested?

The self-test runs on this PR; look for these three steps in
`Static Checks + Tests Release Tooling`. On the previous, un-split branch it
produced:

```
Release gate must block a known-red commit
  | CI Success Check      | ❌ concluded failure (link) |
  | End2End Success Check | ❌ concluded failure (link) |
Assert the known-red commit was blocked
  Release gate outcome on the known-red commit: failure
Release gate must pass a known-green commit
  | CI Success Check      | ✅ succeeded (link) |
  | End2End Success Check | ✅ succeeded (link) |
```

The recorded acceptance commits are in the action's `README.md` so the gate can
be re-verified after any future edit.

## Not included

- `workflow_dispatch` wrapper for checking a ref by hand — deferred until
  LIG-10553 adds a publish workflow to attach it to.
- The `skip-ci-check` docs in `RELEASE.md`, which lives in the private repo and
  is rewritten by LIG-10557.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly, alternatively @JonasWurst.
