### PR TITLE
Add a review checklist to the release PR body

### DIFF
--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -103,7 +103,7 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
     section_body = changelog.extract_released_section(
         changelog_text=args.changelog.read_text(), version=args.version
     )
-    body = pr_body.render_pr_body(section_body=section_body)
+    body = pr_body.render_pr_body(section_body=section_body, version=args.version)
     args.output.write_text(body)
 
 

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -44,6 +44,6 @@ def render_pr_body(section_body: str, version: str) -> str:
         f"## Review checklist\n\n"
         f"{_GUARDS}\n\n"
         f"{_CHECKLIST}\n\n"
-        f"Merging publishes nothing - tag, GitHub release, PyPI and docs stay manual, see "
-        f"`RELEASE.md`.\n"
+        f"Merging publishes nothing - tagging, the GitHub release, PyPI and the docs are still "
+        f"manual.\n"
     )

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -1,15 +1,53 @@
-"""Render the release PR body: the draft release notes."""
+"""Render the release PR body: the draft release notes plus a reviewer checklist."""
 
 from __future__ import annotations
 
+# What the workflow already asserted before opening the PR, so the reviewer does
+# not re-check it by hand. Keep in sync with prepare_release.yml.
+_GUARDS = """\
+The workflow already checked that:
 
-def render_pr_body(section_body: str) -> str:
-    """Assembles the release PR body: the draft release notes.
+- exactly `CHANGELOG.md`, `lightly_studio/pyproject.toml` and `lightly_studio/uv.lock` changed,
+- the `uv.lock` diff is only this version bump,
+- `CHANGELOG.md` keeps an empty `[Unreleased]` skeleton and every earlier release is byte-identical,
+- Labelformat is pinned by version, not by git sha.
 
-    section_body is the CHANGELOG section already promoted for this version.
+What is left is editorial, and it is what this review is for."""
+
+_CHECKLIST = """\
+- [ ] The notes read as user-facing release notes: no ticket ids (`LIG 1234`), PR numbers or
+      internal jargon.
+- [ ] Nothing user-visible since the last release is missing.
+- [ ] Every entry is under the right heading, and near-duplicate entries are merged into one.
+- [ ] The version matches the impact of the entries ([semver](https://semver.org)): minor when
+      something notable is added or changed, patch otherwise.
+- [ ] CI is green on this branch."""
+
+_AFTER_MERGE = """\
+Merging publishes nothing. Tagging, the GitHub release, PyPI, the docs and the self-hosted
+image are still manual - follow `RELEASE.md` in `lightly-studio-private`."""
+
+
+def render_pr_body(section_body: str, version: str) -> str:
+    """Assembles the release PR body.
+
+    Args:
+        section_body: The CHANGELOG section already promoted for this version.
+        version: The version being released, e.g. "1.0.6".
+
+    Returns:
+        The Markdown body for the release PR.
     """
     return (
-        "## Draft release notes\n\n"
-        "> Mechanically promoted from CHANGELOG.md - review and edit before publishing.\n\n"
-        f"{section_body}\n"
+        f"Prepares the LightlyStudio {version} release: promotes the `[Unreleased]` changelog "
+        f"section, bumps the version and relocks.\n\n"
+        f"## Release notes for {version}\n\n"
+        f"Edit `CHANGELOG.md` on this branch rather than this description - the changelog is what "
+        f"gets published, this is a copy of it from when the PR was opened.\n\n"
+        f"{section_body}\n\n"
+        f"## Review checklist\n\n"
+        f"{_GUARDS}\n\n"
+        f"{_CHECKLIST}\n\n"
+        f"## After merging\n\n"
+        f"{_AFTER_MERGE}\n"
     )

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -23,10 +23,6 @@ _CHECKLIST = """\
       something notable is added or changed, patch otherwise.
 - [ ] CI is green on this branch."""
 
-_AFTER_MERGE = """\
-Merging publishes nothing. Tagging, the GitHub release, PyPI, the docs and the self-hosted
-image are still manual - follow `RELEASE.md` in `lightly-studio-private`."""
-
 
 def render_pr_body(section_body: str, version: str) -> str:
     """Assembles the release PR body.
@@ -48,6 +44,6 @@ def render_pr_body(section_body: str, version: str) -> str:
         f"## Review checklist\n\n"
         f"{_GUARDS}\n\n"
         f"{_CHECKLIST}\n\n"
-        f"## After merging\n\n"
-        f"{_AFTER_MERGE}\n"
+        f"Merging publishes nothing - tag, GitHub release, PyPI and docs stay manual, see "
+        f"`RELEASE.md`.\n"
     )

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -15,5 +15,5 @@ def test_render_pr_body__review_checklist():
 
 def test_render_pr_body__no_leftover_manual_steps():
     body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
-    assert "## After merging" in body
+    assert "Merging publishes nothing" in body
     assert "RELEASE.md" in body

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -13,7 +13,6 @@ def test_render_pr_body__review_checklist():
     assert body.count("- [ ] ") == 5
 
 
-def test_render_pr_body__no_leftover_manual_steps():
+def test_render_pr_body__says_merging_publishes_nothing():
     body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
     assert "Merging publishes nothing" in body
-    assert "RELEASE.md" in body

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -2,6 +2,18 @@ from prepare_release import pr_body
 
 
 def test_render_pr_body():
-    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.")
-    assert "Draft release notes" in body
+    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
+    assert "Release notes for 1.0.6" in body
     assert "Added thing one" in body
+
+
+def test_render_pr_body__review_checklist():
+    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
+    assert "## Review checklist" in body
+    assert body.count("- [ ] ") == 5
+
+
+def test_render_pr_body__no_leftover_manual_steps():
+    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
+    assert "## After merging" in body
+    assert "RELEASE.md" in body


### PR DESCRIPTION
## What has changed and why?

Follow-up on the review feedback for #2122, the first release PR opened by the
Prepare Release workflow. Its body was the promoted changelog under one note,
"Mechanically promoted from CHANGELOG.md - review and edit before publishing",
which told the reviewer neither what to check nor where to make edits.

The body now has two parts:

- **Release notes** - the promoted changelog section, as before, with a line saying to edit
  `CHANGELOG.md` on the branch rather than the PR description, since the changelog is what
  gets published and the description is a snapshot from when the PR was opened.
- **Review checklist** - first what the workflow already asserted (file set, narrow `uv.lock`
  diff, changelog structure, Labelformat pin), so nobody re-checks it by hand, then five boxes
  for what only a human can judge: user-facing wording, missing entries, entries under the right
  heading, the semver bump, green CI. It closes with one line saying merging publishes nothing,
  since tagging, the GitHub release, PyPI and the docs are still manual.

`render_pr_body` now takes the version so the notes heading names it.

## How has it been tested?

- `.github/scripts`: `ruff format --check`, `ruff check`, `mypy prepare_release`, `pytest` -
  the same four commands the workflow runs before it does anything else. 37 tests pass, three of
  them covering the new body.
- Rendered the body locally against the 1.0.6 changelog section and checked the Markdown.

The next dispatch of Prepare Release is the real end-to-end check.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @ikondrat, who reviewed the tooling stack (#2043-#2046).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Release pull requests now include a version-specific release-notes heading.
  * Added a review checklist with five items to complete before merging.
  * Added a summary of automated workflow checks.
  * Added an “After merging” section outlining required manual release steps.
  * Clarified that merging the pull request does not publish a release and highlighted the relevant release documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->