### PR TITLE
Remove embedding_model_resolver.get_all_by_collection_id

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -27,8 +27,8 @@ from lightly_studio.models.collection import AnnotationCollectionView, Collectio
 from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    embedding_model_resolver,
     sample_embedding_resolver,
 )
 from lightly_studio.resolvers.annotation_resolver.get_all import (
@@ -207,11 +207,11 @@ def read_annotation_embedding(
     Used for drag-to-search self-similarity: searching with an annotation's own
     stored embedding.
     """
-    embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=session,
         collection_id=collection_id,
     )
-    if not embedding_models:
+    if embedding_model_id is None:
         raise HTTPException(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail="No embedding model is registered for this collection.",
@@ -220,7 +220,7 @@ def read_annotation_embedding(
     embeddings = sample_embedding_resolver.get_by_sample_ids(
         session=session,
         sample_ids=[sample_id],
-        embedding_model_id=embedding_models[0].embedding_model_id,
+        embedding_model_id=embedding_model_id,
     )
     if not embeddings:
         raise HTTPException(

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -19,7 +19,7 @@ from lightly_studio.models.metadata import (
     MetadataInfoView,
     MetadataValueCountsView,
 )
-from lightly_studio.resolvers import embedding_model_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.metadata_resolver.sample import (
     categorical_value_counts as metadata_value_counts_resolver,
@@ -171,7 +171,7 @@ def compute_typicality_metadata(
     Returns:
         None (204 No Content on success).
     """
-    embedding_model = embedding_model_resolver.get_by_name(
+    embedding_model = collection_embedding_model_resolver.get_by_name(
         session=session,
         collection_id=collection.collection_id,
         embedding_model_name=request.embedding_model_name,
@@ -227,7 +227,7 @@ def compute_similarity_metadata(
         HTTPException: 404 if invalid embedding model or query tag is given.
     """
     try:
-        embedding_model = embedding_model_resolver.get_by_name(
+        embedding_model = collection_embedding_model_resolver.get_by_name(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=request.embedding_model_name,

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -171,7 +171,7 @@ def compute_typicality_metadata(
     Returns:
         None (204 No Content on success).
     """
-    embedding_model = collection_embedding_model_resolver.get_model_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
         session=session,
         collection_id=collection.collection_id,
         embedding_model_name=request.embedding_model_name,
@@ -180,7 +180,7 @@ def compute_typicality_metadata(
     compute_typicality.compute_typicality_metadata(
         session=session,
         collection_id=collection.collection_id,
-        embedding_model_id=embedding_model.embedding_model_id,
+        embedding_model_id=embedding_model_id,
         metadata_name=request.metadata_name,
     )
 
@@ -227,7 +227,7 @@ def compute_similarity_metadata(
         HTTPException: 404 if invalid embedding model or query tag is given.
     """
     try:
-        embedding_model = collection_embedding_model_resolver.get_model_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=request.embedding_model_name,
@@ -243,7 +243,7 @@ def compute_similarity_metadata(
             session=session,
             key_collection_id=collection.collection_id,
             query_tag_id=query_tag_id,
-            embedding_model_id=embedding_model.embedding_model_id,
+            embedding_model_id=embedding_model_id,
             metadata_name=request.metadata_name,
         )
     except TagNotFoundError as e:

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -171,7 +171,7 @@ def compute_typicality_metadata(
     Returns:
         None (204 No Content on success).
     """
-    embedding_model = collection_embedding_model_resolver.get_by_name(
+    embedding_model = collection_embedding_model_resolver.get_model_by_name(
         session=session,
         collection_id=collection.collection_id,
         embedding_model_name=request.embedding_model_name,
@@ -227,7 +227,7 @@ def compute_similarity_metadata(
         HTTPException: 404 if invalid embedding model or query tag is given.
     """
     try:
-        embedding_model = collection_embedding_model_resolver.get_by_name(
+        embedding_model = collection_embedding_model_resolver.get_model_by_name(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=request.embedding_model_name,

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -171,7 +171,7 @@ def compute_typicality_metadata(
     Returns:
         None (204 No Content on success).
     """
-    embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_model_id_by_name(
         session=session,
         collection_id=collection.collection_id,
         embedding_model_name=request.embedding_model_name,
@@ -227,7 +227,7 @@ def compute_similarity_metadata(
         HTTPException: 404 if invalid embedding model or query tag is given.
     """
     try:
-        embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_model_id_by_name(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=request.embedding_model_name,

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -154,7 +154,7 @@ class Dataset(Generic[T], ABC):
                 The name of the metadata to store the typicality values in. If not give, the default
                 name "typicality" is used.
         """
-        embedding_model_id = collection_embedding_model_resolver.get_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,
@@ -187,7 +187,7 @@ class Dataset(Generic[T], ABC):
         Returns:
             The name of the metadata storing the similarity values.
         """
-        embedding_model_id = collection_embedding_model_resolver.get_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -158,7 +158,7 @@ class Dataset(Generic[T], ABC):
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,
-        ).embedding_model_id
+        )
         compute_typicality.compute_typicality_metadata(
             session=self.session,
             collection_id=self.collection_id,
@@ -191,7 +191,7 @@ class Dataset(Generic[T], ABC):
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,
-        ).embedding_model_id
+        )
         query_tag = tag_resolver.get_by_name(
             session=self.session, tag_name=query_tag_name, collection_id=self.collection_id
         )

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -18,8 +18,8 @@ from lightly_studio.database import db_manager
 from lightly_studio.metadata import compute_similarity, compute_typicality
 from lightly_studio.models.collection import CollectionCreate, CollectionTable, SampleType
 from lightly_studio.resolvers import (
+    collection_embedding_model_resolver,
     collection_resolver,
-    embedding_model_resolver,
     metadata_resolver,
     tag_resolver,
 )
@@ -154,7 +154,7 @@ class Dataset(Generic[T], ABC):
                 The name of the metadata to store the typicality values in. If not give, the default
                 name "typicality" is used.
         """
-        embedding_model_id = embedding_model_resolver.get_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_by_name(
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,
@@ -187,7 +187,7 @@ class Dataset(Generic[T], ABC):
         Returns:
             The name of the metadata storing the similarity values.
         """
-        embedding_model_id = embedding_model_resolver.get_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_by_name(
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -154,7 +154,7 @@ class Dataset(Generic[T], ABC):
                 The name of the metadata to store the typicality values in. If not give, the default
                 name "typicality" is used.
         """
-        embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_model_id_by_name(
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,
@@ -187,7 +187,7 @@ class Dataset(Generic[T], ABC):
         Returns:
             The name of the metadata storing the similarity values.
         """
-        embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
+        embedding_model_id = collection_embedding_model_resolver.get_model_id_by_name(
             session=self.session,
             collection_id=self.collection_id,
             embedding_model_name=embedding_model_name,

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -147,28 +147,31 @@ def get_by_name(
         session: The database session.
         collection_id: The ID of the collection.
         embedding_model_name: The name of the embedding model.
-            If None, expects the collection to have exactly one embedding model and
-            returns it. Otherwise raises a ValueError.
+            If None, the collection's default embedding model is returned. Raises a
+            ValueError if the collection has no default.
             If set, expects the collection to have an embedding model with the given name.
             Otherwise raises a ValueError.
 
     Returns:
-        The embedding model with the given name.
+        The embedding model with the given name, or the default when no name is given.
 
     Raises:
-        ValueError: If the name is None and the collection does not have exactly one
-            model, or if no linked model has the given name.
+        ValueError: If the name is None and the collection has no default model, or if no
+            linked model has the given name.
     """
     embedding_models = get_all_models_by_collection_id(session=session, collection_id=collection_id)
 
     if embedding_model_name is None:
-        if len(embedding_models) != 1:
-            raise ValueError(
-                f"Expected exactly one embedding model, "
-                f"but found {len(embedding_models)} with names "
-                f"{[model.name for model in embedding_models]}."
-            )
-        return embedding_models[0]
+        default_model_id = get_default_by_collection_id(
+            session=session, collection_id=collection_id
+        )
+        default_model = next(
+            (model for model in embedding_models if model.embedding_model_id == default_model_id),
+            None,
+        )
+        if default_model is None:
+            raise ValueError(f"Collection {collection_id} has no default embedding model.")
+        return default_model
 
     embedding_model_with_name = next(
         (model for model in embedding_models if model.name == embedding_model_name), None

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -116,7 +116,7 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[UUID
     )
 
 
-def get_model_by_name(
+def get_model_id_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
 ) -> UUID:
     """Resolve the id of one of a collection's embedding models by name.

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -138,7 +138,7 @@ def get_all_models_by_collection_id(
     )
 
 
-def get_by_name(
+def get_model_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
 ) -> EmbeddingModelTable:
     """Resolve one of a collection's embedding models by name.
@@ -159,20 +159,10 @@ def get_by_name(
         ValueError: If the name is None and the collection has no default model, or if no
             linked model has the given name.
     """
-    embedding_models = get_all_models_by_collection_id(session=session, collection_id=collection_id)
-
     if embedding_model_name is None:
-        default_model_id = get_default_by_collection_id(
-            session=session, collection_id=collection_id
-        )
-        default_model = next(
-            (model for model in embedding_models if model.embedding_model_id == default_model_id),
-            None,
-        )
-        if default_model is None:
-            raise ValueError(f"Collection {collection_id} has no default embedding model.")
-        return default_model
+        return _get_default_model(session=session, collection_id=collection_id)
 
+    embedding_models = get_all_models_by_collection_id(session=session, collection_id=collection_id)
     embedding_model_with_name = next(
         (model for model in embedding_models if model.name == embedding_model_name), None
     )
@@ -180,6 +170,31 @@ def get_by_name(
         raise ValueError(f"Embedding model with name `{embedding_model_name}` not found.")
 
     return embedding_model_with_name
+
+
+def _get_default_model(session: Session, collection_id: UUID) -> EmbeddingModelTable:
+    """Return the collection's default embedding model, raising if it has none.
+
+    The default is resolved by the ``is_default`` flag, never by insertion order.
+
+    Raises:
+        ValueError: If the collection has no default embedding model.
+    """
+    default_model = session.exec(
+        select(EmbeddingModelTable)
+        .join(
+            CollectionEmbeddingModelTable,
+            onclause=col(CollectionEmbeddingModelTable.embedding_model_id)
+            == col(EmbeddingModelTable.embedding_model_id),
+        )
+        .where(
+            CollectionEmbeddingModelTable.collection_id == collection_id,
+            col(CollectionEmbeddingModelTable.is_default).is_(True),
+        )
+    ).one_or_none()
+    if default_model is None:
+        raise ValueError(f"Collection {collection_id} has no default embedding model.")
+    return default_model
 
 
 def _get_default_by_collection_id(

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -116,13 +116,32 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[UUID
     )
 
 
+def get_all_models_by_collection_id(
+    session: Session, collection_id: UUID
+) -> list[EmbeddingModelTable]:
+    """Return all embedding models linked to the collection, oldest first.
+
+    Membership comes from the link table, not from ``EmbeddingModelTable.collection_id``,
+    which is being removed.
+    """
+    return list(
+        session.exec(
+            select(EmbeddingModelTable)
+            .join(
+                CollectionEmbeddingModelTable,
+                onclause=col(CollectionEmbeddingModelTable.embedding_model_id)
+                == col(EmbeddingModelTable.embedding_model_id),
+            )
+            .where(CollectionEmbeddingModelTable.collection_id == collection_id)
+            .order_by(col(EmbeddingModelTable.created_at).asc())
+        ).all()
+    )
+
+
 def get_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
 ) -> EmbeddingModelTable:
     """Resolve one of a collection's embedding models by name.
-
-    Membership comes from the link table, not from ``EmbeddingModelTable.collection_id``,
-    which is being removed.
 
     Args:
         session: The database session.
@@ -140,18 +159,7 @@ def get_by_name(
         ValueError: If the name is None and the collection does not have exactly one
             model, or if no linked model has the given name.
     """
-    embedding_models = list(
-        session.exec(
-            select(EmbeddingModelTable)
-            .join(
-                CollectionEmbeddingModelTable,
-                onclause=col(CollectionEmbeddingModelTable.embedding_model_id)
-                == col(EmbeddingModelTable.embedding_model_id),
-            )
-            .where(CollectionEmbeddingModelTable.collection_id == collection_id)
-            .order_by(col(EmbeddingModelTable.created_at).asc())
-        ).all()
-    )
+    embedding_models = get_all_models_by_collection_id(session=session, collection_id=collection_id)
 
     if embedding_model_name is None:
         if len(embedding_models) != 1:

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -13,6 +13,7 @@ from sqlalchemy import exists
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
+from lightly_studio.models.embedding_model import EmbeddingModelTable
 
 
 def get_or_add_collection_model(
@@ -113,6 +114,61 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[UUID
             )
         ).all()
     )
+
+
+def get_by_name(
+    session: Session, collection_id: UUID, embedding_model_name: str | None
+) -> EmbeddingModelTable:
+    """Resolve one of a collection's embedding models by name.
+
+    Membership comes from the link table, not from ``EmbeddingModelTable.collection_id``,
+    which is being removed.
+
+    Args:
+        session: The database session.
+        collection_id: The ID of the collection.
+        embedding_model_name: The name of the embedding model.
+            If None, expects the collection to have exactly one embedding model and
+            returns it. Otherwise raises a ValueError.
+            If set, expects the collection to have an embedding model with the given name.
+            Otherwise raises a ValueError.
+
+    Returns:
+        The embedding model with the given name.
+
+    Raises:
+        ValueError: If the name is None and the collection does not have exactly one
+            model, or if no linked model has the given name.
+    """
+    embedding_models = list(
+        session.exec(
+            select(EmbeddingModelTable)
+            .join(
+                CollectionEmbeddingModelTable,
+                onclause=col(CollectionEmbeddingModelTable.embedding_model_id)
+                == col(EmbeddingModelTable.embedding_model_id),
+            )
+            .where(CollectionEmbeddingModelTable.collection_id == collection_id)
+            .order_by(col(EmbeddingModelTable.created_at).asc())
+        ).all()
+    )
+
+    if embedding_model_name is None:
+        if len(embedding_models) != 1:
+            raise ValueError(
+                f"Expected exactly one embedding model, "
+                f"but found {len(embedding_models)} with names "
+                f"{[model.name for model in embedding_models]}."
+            )
+        return embedding_models[0]
+
+    embedding_model_with_name = next(
+        (model for model in embedding_models if model.name == embedding_model_name), None
+    )
+    if embedding_model_with_name is None:
+        raise ValueError(f"Embedding model with name `{embedding_model_name}` not found.")
+
+    return embedding_model_with_name
 
 
 def _get_default_by_collection_id(

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -116,72 +116,36 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[UUID
     )
 
 
-def get_all_models_by_collection_id(
-    session: Session, collection_id: UUID
-) -> list[EmbeddingModelTable]:
-    """Return all embedding models linked to the collection, oldest first.
-
-    Membership comes from the link table, not from ``EmbeddingModelTable.collection_id``,
-    which is being removed.
-    """
-    return list(
-        session.exec(
-            select(EmbeddingModelTable)
-            .join(
-                CollectionEmbeddingModelTable,
-                onclause=col(CollectionEmbeddingModelTable.embedding_model_id)
-                == col(EmbeddingModelTable.embedding_model_id),
-            )
-            .where(CollectionEmbeddingModelTable.collection_id == collection_id)
-            .order_by(col(EmbeddingModelTable.created_at).asc())
-        ).all()
-    )
-
-
 def get_model_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
-) -> EmbeddingModelTable:
-    """Resolve one of a collection's embedding models by name.
+) -> UUID:
+    """Resolve the id of one of a collection's embedding models by name.
 
     Args:
         session: The database session.
         collection_id: The ID of the collection.
         embedding_model_name: The name of the embedding model.
-            If None, the collection's default embedding model is returned. Raises a
+            If None, the collection's default embedding model id is returned. Raises a
             ValueError if the collection has no default.
             If set, expects the collection to have an embedding model with the given name.
             Otherwise raises a ValueError.
 
     Returns:
-        The embedding model with the given name, or the default when no name is given.
+        The id of the embedding model with the given name, or of the default when no name
+        is given.
 
     Raises:
         ValueError: If the name is None and the collection has no default model, or if no
             linked model has the given name.
     """
     if embedding_model_name is None:
-        return _get_default_model(session=session, collection_id=collection_id)
+        default_id = get_default_by_collection_id(session=session, collection_id=collection_id)
+        if default_id is None:
+            raise ValueError(f"Collection {collection_id} has no default embedding model.")
+        return default_id
 
-    embedding_models = get_all_models_by_collection_id(session=session, collection_id=collection_id)
-    embedding_model_with_name = next(
-        (model for model in embedding_models if model.name == embedding_model_name), None
-    )
-    if embedding_model_with_name is None:
-        raise ValueError(f"Embedding model with name `{embedding_model_name}` not found.")
-
-    return embedding_model_with_name
-
-
-def _get_default_model(session: Session, collection_id: UUID) -> EmbeddingModelTable:
-    """Return the collection's default embedding model, raising if it has none.
-
-    The default is resolved by the ``is_default`` flag, never by insertion order.
-
-    Raises:
-        ValueError: If the collection has no default embedding model.
-    """
-    default_model = session.exec(
-        select(EmbeddingModelTable)
+    embedding_model_id = session.exec(
+        select(EmbeddingModelTable.embedding_model_id)
         .join(
             CollectionEmbeddingModelTable,
             onclause=col(CollectionEmbeddingModelTable.embedding_model_id)
@@ -189,12 +153,13 @@ def _get_default_model(session: Session, collection_id: UUID) -> EmbeddingModelT
         )
         .where(
             CollectionEmbeddingModelTable.collection_id == collection_id,
-            col(CollectionEmbeddingModelTable.is_default).is_(True),
+            EmbeddingModelTable.name == embedding_model_name,
         )
     ).one_or_none()
-    if default_model is None:
-        raise ValueError(f"Collection {collection_id} has no default embedding model.")
-    return default_model
+    if embedding_model_id is None:
+        raise ValueError(f"Embedding model with name `{embedding_model_name}` not found.")
+
+    return embedding_model_id
 
 
 def _get_default_by_collection_id(

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -43,16 +43,6 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     return db_model
 
 
-def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[EmbeddingModelTable]:
-    """Retrieve all embedding models."""
-    embedding_models = session.exec(
-        select(EmbeddingModelTable)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .order_by(col(EmbeddingModelTable.created_at).asc())
-    ).all()
-    return list(embedding_models)
-
-
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by ID."""
     return session.exec(

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -107,14 +107,3 @@ def get_by_model_hash(
         )
     )
     return session.exec(query).first()
-
-
-def delete(session: Session, embedding_model_id: UUID) -> bool:
-    """Delete an embedding model."""
-    embedding_model = get_by_id(session=session, embedding_model_id=embedding_model_id)
-    if not embedding_model:
-        return False
-
-    session.delete(embedding_model)
-    session.commit()
-    return True

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -109,46 +109,6 @@ def get_by_model_hash(
     return session.exec(query).first()
 
 
-def get_by_name(
-    session: Session, collection_id: UUID, embedding_model_name: str | None
-) -> EmbeddingModelTable:
-    """Helper function to resolve the embedding model name to its ID.
-
-    Args:
-        session: The database session.
-        collection_id: The ID of the collection.
-        embedding_model_name: The name of the embedding model.
-            If None, expects the collection to have exactly one embedding model and
-            returns it. Otherwise raises a ValueError.
-            If set, expects the collection to have an embedding model with the given name.
-            Otherwise raises a ValueError.
-
-    Returns:
-        The embedding model with the given name.
-    """
-    embedding_models = get_all_by_collection_id(
-        session=session,
-        collection_id=collection_id,
-    )
-
-    if embedding_model_name is None:
-        if len(embedding_models) != 1:
-            raise ValueError(
-                f"Expected exactly one embedding model, "
-                f"but found {len(embedding_models)} with names "
-                f"{[model.name for model in embedding_models]}."
-            )
-        return embedding_models[0]
-
-    embedding_model_with_name = next(
-        (model for model in embedding_models if model.name == embedding_model_name), None
-    )
-    if embedding_model_with_name is None:
-        raise ValueError(f"Embedding model with name `{embedding_model_name}` not found.")
-
-    return embedding_model_with_name
-
-
 def delete(session: Session, embedding_model_id: UUID) -> bool:
     """Delete an embedding model."""
     embedding_model = get_by_id(session=session, embedding_model_id=embedding_model_id)

--- a/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
@@ -9,7 +9,7 @@ from sqlmodel import Session
 
 from lightly_studio.database.db_vector import Embedding
 from lightly_studio.resolvers import (
-    embedding_model_resolver,
+    collection_embedding_model_resolver,
     sample_embedding_resolver,
     tag_resolver,
 )
@@ -26,7 +26,7 @@ def get_embeddings_by_sample_ids(
 
     Output order matches ``sample_ids``.
     """
-    embedding_model_id = embedding_model_resolver.get_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_by_name(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,
@@ -46,7 +46,7 @@ def get_embeddings_by_tag_id(
     embedding_model_name: str | None,
 ) -> list[Embedding]:
     """Resolve sample embeddings for the given model and sample tag."""
-    embedding_model_id = embedding_model_resolver.get_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_by_name(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
@@ -26,7 +26,7 @@ def get_embeddings_by_sample_ids(
 
     Output order matches ``sample_ids``.
     """
-    embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_model_id_by_name(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,
@@ -46,7 +46,7 @@ def get_embeddings_by_tag_id(
     embedding_model_name: str | None,
 ) -> list[Embedding]:
     """Resolve sample embeddings for the given model and sample tag."""
-    embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_model_id_by_name(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
@@ -26,7 +26,7 @@ def get_embeddings_by_sample_ids(
 
     Output order matches ``sample_ids``.
     """
-    embedding_model_id = collection_embedding_model_resolver.get_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,
@@ -46,7 +46,7 @@ def get_embeddings_by_tag_id(
     embedding_model_name: str | None,
 ) -> list[Embedding]:
     """Resolve sample embeddings for the given model and sample tag."""
-    embedding_model_id = collection_embedding_model_resolver.get_by_name(
+    embedding_model_id = collection_embedding_model_resolver.get_model_by_name(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
@@ -30,7 +30,7 @@ def get_embeddings_by_sample_ids(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,
-    ).embedding_model_id
+    )
     embedding_tables = sample_embedding_resolver.get_by_sample_ids(
         session=session,
         sample_ids=list(sample_ids),
@@ -50,7 +50,7 @@ def get_embeddings_by_tag_id(
         session=session,
         collection_id=collection_id,
         embedding_model_name=embedding_model_name,
-    ).embedding_model_id
+    )
     embedding_tables = sample_embedding_resolver.get_all_by_collection_id(
         session=session,
         collection_id=collection_id,

--- a/lightly_studio/tests/api/routes/api/test_annotation.py
+++ b/lightly_studio/tests/api/routes/api/test_annotation.py
@@ -319,6 +319,7 @@ def test_read_annotation_embedding__returns_stored_vector(
         session=db_session,
         collection_id=annotation_collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     create_sample_embedding(
         session=db_session,
@@ -355,6 +356,7 @@ def test_read_annotation_embedding__missing_returns_404(
         session=db_session,
         collection_id=annotation_collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
 
     response = test_client.get(

--- a/lightly_studio/tests/core/test_dataset.py
+++ b/lightly_studio/tests/core/test_dataset.py
@@ -367,6 +367,7 @@ class TestDataset:
             session=dataset.session,
             collection_id=dataset.collection_id,
             embedding_model_name="example_embedding_model",
+            set_as_default=True,
         )
         create_samples_with_embeddings(
             session=dataset.session,
@@ -394,6 +395,7 @@ class TestDataset:
             session=dataset.session,
             collection_id=dataset.collection_id,
             embedding_model_name="example_embedding_model",
+            set_as_default=True,
         )
         create_samples_with_embeddings(
             session=dataset.session,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -309,7 +309,7 @@ def create_embedding_model(  # noqa: PLR0913
 ) -> EmbeddingModelTable:
     """Helper function to create a embedding model.
 
-    The model is linked to the collection, so it resolves through ``get_model_by_name`` and
+    The model is linked to the collection, so it resolves through ``get_model_id_by_name`` and
     ``get_all_by_collection_id``, matching production where every registered model is linked.
     With ``set_as_default`` it is also recorded as the collection default, so
     ``get_default_by_collection_id`` resolves to it.

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -309,7 +309,7 @@ def create_embedding_model(  # noqa: PLR0913
 ) -> EmbeddingModelTable:
     """Helper function to create a embedding model.
 
-    The model is linked to the collection, so it resolves through ``get_by_name`` and
+    The model is linked to the collection, so it resolves through ``get_model_by_name`` and
     ``get_all_by_collection_id``, matching production where every registered model is linked.
     With ``set_as_default`` it is also recorded as the collection default, so
     ``get_default_by_collection_id`` resolves to it.

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -309,15 +309,19 @@ def create_embedding_model(  # noqa: PLR0913
 ) -> EmbeddingModelTable:
     """Helper function to create a embedding model.
 
-    With ``set_as_default`` the model is linked to the collection and recorded as its
-    default embedding model, so ``get_default_by_collection_id`` resolves to it. It is off
-    by default to avoid the ``collection_embedding_model`` foreign key blocking model or
-    collection deletes in tests that do not need a default.
+    The model is linked to the collection, so it resolves through ``get_by_name`` and
+    ``get_all_by_collection_id``, matching production where every registered model is linked.
+    With ``set_as_default`` it is also recorded as the collection default, so
+    ``get_default_by_collection_id`` resolves to it.
     """
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection with id {collection_id} not found.")
 
+    # TODO(Michal, 08/2026): Once collection_id is out of embedding_model, take dataset_id
+    # directly and make collection_id optional: link only when it is given, so unlinked
+    # models become expressible. The collection_embedding_model link is then the sole source
+    # of collection membership.
     model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
@@ -329,12 +333,12 @@ def create_embedding_model(  # noqa: PLR0913
             embedding_dimension=embedding_dimension,
         ),
     )
+    collection_embedding_model_resolver.get_or_add_collection_model(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
     if set_as_default:
-        collection_embedding_model_resolver.get_or_add_collection_model(
-            session=session,
-            collection_id=collection_id,
-            embedding_model_id=model.embedding_model_id,
-        )
         collection_embedding_model_resolver.set_default(
             session=session,
             collection_id=collection_id,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -318,12 +318,15 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     )
 
     # Assert - embedding model is copied with new ID
-    copied_embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    copied_model_ids = collection_embedding_model_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
     )
-    assert len(copied_embedding_models) == 1
-    copied_model = copied_embedding_models[0]
+    assert len(copied_model_ids) == 1
+    copied_model = embedding_model_resolver.get_by_id(
+        session=db_session, embedding_model_id=copied_model_ids[0]
+    )
+    assert copied_model is not None
     assert copied_model.embedding_model_id != embedding_model.embedding_model_id
     assert copied_model.dataset_id == copied.dataset_id
     assert copied_model.name == embedding_model.name
@@ -375,12 +378,12 @@ def test_deep_copy__with_default_embedding_space(db_session: Session) -> None:
     )
 
     # Assert - the copied collection's default resolves to the copied model, not the original.
-    copied_models = embedding_model_resolver.get_all_by_collection_id(
+    copied_model_ids = collection_embedding_model_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
     )
-    assert len(copied_models) == 1
-    copied_model_id = copied_models[0].embedding_model_id
+    assert len(copied_model_ids) == 1
+    copied_model_id = copied_model_ids[0]
     assert copied_model_id != embedding_model.embedding_model_id
 
     copied_default_id = collection_embedding_model_resolver.get_default_by_collection_id(
@@ -467,15 +470,15 @@ def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:
     )
 
     # Assert - copied collection still has embeddings
-    copied_embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    copied_model_ids = collection_embedding_model_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
     )
-    assert len(copied_embedding_models) == 1
+    assert len(copied_model_ids) == 1
     copied_embeddings = sample_embedding_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
-        embedding_model_id=copied_embedding_models[0].embedding_model_id,
+        embedding_model_id=copied_model_ids[0],
     )
     assert len(copied_embeddings) == 1
 

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -122,19 +122,6 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
     assert [row.embedding_model_id for row in defaults] == [model_2.embedding_model_id]
 
 
-def test_set_default__raises_when_unlinked(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-
-    # The model exists but was never linked, so flagging it as default is a caller bug.
-    with pytest.raises(ValueError, match="not linked"):
-        collection_embedding_model_resolver.set_default(
-            session=db_session,
-            collection_id=collection.collection_id,
-            embedding_model_id=model.embedding_model_id,
-        )
-
-
 def test_get_default_by_collection_id__none_when_unset(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
@@ -216,3 +203,128 @@ def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> No
     )
 
     assert set(linked) == {model_1.embedding_model_id, model_2.embedding_model_id}
+
+
+def test_get_by_name__none_with_single_model(db_session: Session) -> None:
+    """Resolve the only linked model when the name is None."""
+    collection = create_collection(session=db_session)
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_1",
+    )
+
+    result = collection_embedding_model_resolver.get_by_name(
+        session=db_session, collection_id=collection.collection_id, embedding_model_name=None
+    )
+
+    assert result.embedding_model_id == embedding_model.embedding_model_id
+    assert result.name == "embedding_model_1"
+
+
+def test_get_by_name__none_with_multiple_models(db_session: Session) -> None:
+    """Raise when the name is None but the collection has more than one linked model."""
+    collection = create_collection(session=db_session)
+    for name, model_hash in (("embedding_model_1", "hash_1"), ("embedding_model_2", "hash_2")):
+        create_embedding_model(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_name=name,
+            embedding_model_hash=model_hash,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Expected exactly one embedding model, but found 2 with names "
+        r"\['embedding_model_1', 'embedding_model_2'\]\.",
+    ):
+        collection_embedding_model_resolver.get_by_name(
+            session=db_session, collection_id=collection.collection_id, embedding_model_name=None
+        )
+
+
+def test_get_by_name__none_with_no_models(db_session: Session) -> None:
+    """Raise when the name is None but the collection has no linked model."""
+    collection = create_collection(session=db_session)
+
+    with pytest.raises(
+        ValueError, match=r"Expected exactly one embedding model, but found 0 with names \[\]\."
+    ):
+        collection_embedding_model_resolver.get_by_name(
+            session=db_session, collection_id=collection.collection_id, embedding_model_name=None
+        )
+
+
+def test_get_by_name__existing_name(db_session: Session) -> None:
+    """Resolve a linked model by its name."""
+    collection = create_collection(session=db_session)
+    model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_1",
+        embedding_model_hash="hash_1",
+    )
+    model_2 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_2",
+        embedding_model_hash="hash_2",
+    )
+
+    result_1 = collection_embedding_model_resolver.get_by_name(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_1",
+    )
+    assert result_1.embedding_model_id == model_1.embedding_model_id
+    assert result_1.name == "embedding_model_1"
+
+    result_2 = collection_embedding_model_resolver.get_by_name(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_2",
+    )
+    assert result_2.embedding_model_id == model_2.embedding_model_id
+    assert result_2.name == "embedding_model_2"
+
+
+def test_get_by_name__nonexistent_name(db_session: Session) -> None:
+    """Raise when no linked model has the given name."""
+    collection = create_collection(session=db_session)
+    create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_1",
+    )
+
+    with pytest.raises(ValueError, match=r"Embedding model with name `nonexistent` not found."):
+        collection_embedding_model_resolver.get_by_name(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_name="nonexistent",
+        )
+
+
+def test_get_by_name__scoped_to_the_collection(db_session: Session) -> None:
+    """Membership comes from the link table, so another collection's model is not resolved."""
+    collection = create_collection(session=db_session)
+    other_collection = create_collection(session=db_session)
+    create_embedding_model(
+        session=db_session,
+        collection_id=other_collection.collection_id,
+        embedding_model_name="other_model",
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Expected exactly one embedding model, but found 0 with names \[\]\."
+    ):
+        collection_embedding_model_resolver.get_by_name(
+            session=db_session, collection_id=collection.collection_id, embedding_model_name=None
+        )
+
+    with pytest.raises(ValueError, match=r"Embedding model with name `other_model` not found."):
+        collection_embedding_model_resolver.get_by_name(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_name="other_model",
+        )

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -205,7 +205,7 @@ def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> No
     assert set(linked) == {model_1.embedding_model_id, model_2.embedding_model_id}
 
 
-def test_get_model_by_name__none_returns_default(db_session: Session) -> None:
+def test_get_model_id_by_name__none_returns_default(db_session: Session) -> None:
     """Resolve the default model id when the name is None."""
     collection = create_collection(session=db_session)
     embedding_model = create_embedding_model(
@@ -215,14 +215,14 @@ def test_get_model_by_name__none_returns_default(db_session: Session) -> None:
         set_as_default=True,
     )
 
-    result = collection_embedding_model_resolver.get_model_by_name(
+    result = collection_embedding_model_resolver.get_model_id_by_name(
         session=db_session, collection_id=collection.collection_id, embedding_model_name=None
     )
 
     assert result == embedding_model.embedding_model_id
 
 
-def test_get_model_by_name__none_returns_default_not_oldest(db_session: Session) -> None:
+def test_get_model_id_by_name__none_returns_default_not_oldest(db_session: Session) -> None:
     """Resolve the default model, not the oldest, when the collection has several."""
     collection = create_collection(session=db_session)
     create_embedding_model(
@@ -239,14 +239,14 @@ def test_get_model_by_name__none_returns_default_not_oldest(db_session: Session)
         set_as_default=True,
     )
 
-    result = collection_embedding_model_resolver.get_model_by_name(
+    result = collection_embedding_model_resolver.get_model_id_by_name(
         session=db_session, collection_id=collection.collection_id, embedding_model_name=None
     )
 
     assert result == default_model.embedding_model_id
 
 
-def test_get_model_by_name__none_without_default(db_session: Session) -> None:
+def test_get_model_id_by_name__none_without_default(db_session: Session) -> None:
     """Raise when the name is None but no linked model is the default."""
     collection = create_collection(session=db_session)
     create_embedding_model(
@@ -256,22 +256,22 @@ def test_get_model_by_name__none_without_default(db_session: Session) -> None:
     )
 
     with pytest.raises(ValueError, match=r"has no default embedding model"):
-        collection_embedding_model_resolver.get_model_by_name(
+        collection_embedding_model_resolver.get_model_id_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
 
 
-def test_get_model_by_name__none_with_no_models(db_session: Session) -> None:
+def test_get_model_id_by_name__none_with_no_models(db_session: Session) -> None:
     """Raise when the name is None but the collection has no linked model."""
     collection = create_collection(session=db_session)
 
     with pytest.raises(ValueError, match=r"has no default embedding model"):
-        collection_embedding_model_resolver.get_model_by_name(
+        collection_embedding_model_resolver.get_model_id_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
 
 
-def test_get_model_by_name__existing_name(db_session: Session) -> None:
+def test_get_model_id_by_name__existing_name(db_session: Session) -> None:
     """Resolve a linked model id by its name."""
     collection = create_collection(session=db_session)
     model_1 = create_embedding_model(
@@ -287,14 +287,14 @@ def test_get_model_by_name__existing_name(db_session: Session) -> None:
         embedding_model_hash="hash_2",
     )
 
-    result_1 = collection_embedding_model_resolver.get_model_by_name(
+    result_1 = collection_embedding_model_resolver.get_model_id_by_name(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_1",
     )
     assert result_1 == model_1.embedding_model_id
 
-    result_2 = collection_embedding_model_resolver.get_model_by_name(
+    result_2 = collection_embedding_model_resolver.get_model_id_by_name(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_2",
@@ -302,7 +302,7 @@ def test_get_model_by_name__existing_name(db_session: Session) -> None:
     assert result_2 == model_2.embedding_model_id
 
 
-def test_get_model_by_name__nonexistent_name(db_session: Session) -> None:
+def test_get_model_id_by_name__nonexistent_name(db_session: Session) -> None:
     """Raise when no linked model has the given name."""
     collection = create_collection(session=db_session)
     create_embedding_model(
@@ -312,14 +312,14 @@ def test_get_model_by_name__nonexistent_name(db_session: Session) -> None:
     )
 
     with pytest.raises(ValueError, match=r"Embedding model with name `nonexistent` not found."):
-        collection_embedding_model_resolver.get_model_by_name(
+        collection_embedding_model_resolver.get_model_id_by_name(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_name="nonexistent",
         )
 
 
-def test_get_model_by_name__scoped_to_the_collection(db_session: Session) -> None:
+def test_get_model_id_by_name__scoped_to_the_collection(db_session: Session) -> None:
     """Membership comes from the link table, so another collection's model is not resolved."""
     collection = create_collection(session=db_session)
     other_collection = create_collection(session=db_session)
@@ -330,12 +330,12 @@ def test_get_model_by_name__scoped_to_the_collection(db_session: Session) -> Non
     )
 
     with pytest.raises(ValueError, match=r"has no default embedding model"):
-        collection_embedding_model_resolver.get_model_by_name(
+        collection_embedding_model_resolver.get_model_id_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
 
     with pytest.raises(ValueError, match=r"Embedding model with name `other_model` not found."):
-        collection_embedding_model_resolver.get_model_by_name(
+        collection_embedding_model_resolver.get_model_id_by_name(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_name="other_model",

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -205,8 +205,8 @@ def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> No
     assert set(linked) == {model_1.embedding_model_id, model_2.embedding_model_id}
 
 
-def test_get_by_name__none_returns_default(db_session: Session) -> None:
-    """Resolve the default model when the name is None."""
+def test_get_model_by_name__none_returns_default(db_session: Session) -> None:
+    """Resolve the default model id when the name is None."""
     collection = create_collection(session=db_session)
     embedding_model = create_embedding_model(
         session=db_session,
@@ -219,11 +219,10 @@ def test_get_by_name__none_returns_default(db_session: Session) -> None:
         session=db_session, collection_id=collection.collection_id, embedding_model_name=None
     )
 
-    assert result.embedding_model_id == embedding_model.embedding_model_id
-    assert result.name == "embedding_model_1"
+    assert result == embedding_model.embedding_model_id
 
 
-def test_get_by_name__none_returns_default_not_oldest(db_session: Session) -> None:
+def test_get_model_by_name__none_returns_default_not_oldest(db_session: Session) -> None:
     """Resolve the default model, not the oldest, when the collection has several."""
     collection = create_collection(session=db_session)
     create_embedding_model(
@@ -244,11 +243,10 @@ def test_get_by_name__none_returns_default_not_oldest(db_session: Session) -> No
         session=db_session, collection_id=collection.collection_id, embedding_model_name=None
     )
 
-    assert result.embedding_model_id == default_model.embedding_model_id
-    assert result.name == "default_model"
+    assert result == default_model.embedding_model_id
 
 
-def test_get_by_name__none_without_default(db_session: Session) -> None:
+def test_get_model_by_name__none_without_default(db_session: Session) -> None:
     """Raise when the name is None but no linked model is the default."""
     collection = create_collection(session=db_session)
     create_embedding_model(
@@ -263,7 +261,7 @@ def test_get_by_name__none_without_default(db_session: Session) -> None:
         )
 
 
-def test_get_by_name__none_with_no_models(db_session: Session) -> None:
+def test_get_model_by_name__none_with_no_models(db_session: Session) -> None:
     """Raise when the name is None but the collection has no linked model."""
     collection = create_collection(session=db_session)
 
@@ -273,8 +271,8 @@ def test_get_by_name__none_with_no_models(db_session: Session) -> None:
         )
 
 
-def test_get_by_name__existing_name(db_session: Session) -> None:
-    """Resolve a linked model by its name."""
+def test_get_model_by_name__existing_name(db_session: Session) -> None:
+    """Resolve a linked model id by its name."""
     collection = create_collection(session=db_session)
     model_1 = create_embedding_model(
         session=db_session,
@@ -294,19 +292,17 @@ def test_get_by_name__existing_name(db_session: Session) -> None:
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_1",
     )
-    assert result_1.embedding_model_id == model_1.embedding_model_id
-    assert result_1.name == "embedding_model_1"
+    assert result_1 == model_1.embedding_model_id
 
     result_2 = collection_embedding_model_resolver.get_model_by_name(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_2",
     )
-    assert result_2.embedding_model_id == model_2.embedding_model_id
-    assert result_2.name == "embedding_model_2"
+    assert result_2 == model_2.embedding_model_id
 
 
-def test_get_by_name__nonexistent_name(db_session: Session) -> None:
+def test_get_model_by_name__nonexistent_name(db_session: Session) -> None:
     """Raise when no linked model has the given name."""
     collection = create_collection(session=db_session)
     create_embedding_model(
@@ -323,7 +319,7 @@ def test_get_by_name__nonexistent_name(db_session: Session) -> None:
         )
 
 
-def test_get_by_name__scoped_to_the_collection(db_session: Session) -> None:
+def test_get_model_by_name__scoped_to_the_collection(db_session: Session) -> None:
     """Membership comes from the link table, so another collection's model is not resolved."""
     collection = create_collection(session=db_session)
     other_collection = create_collection(session=db_session)

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -205,13 +205,14 @@ def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> No
     assert set(linked) == {model_1.embedding_model_id, model_2.embedding_model_id}
 
 
-def test_get_by_name__none_with_single_model(db_session: Session) -> None:
-    """Resolve the only linked model when the name is None."""
+def test_get_by_name__none_returns_default(db_session: Session) -> None:
+    """Resolve the default model when the name is None."""
     collection = create_collection(session=db_session)
     embedding_model = create_embedding_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_1",
+        set_as_default=True,
     )
 
     result = collection_embedding_model_resolver.get_by_name(
@@ -222,22 +223,41 @@ def test_get_by_name__none_with_single_model(db_session: Session) -> None:
     assert result.name == "embedding_model_1"
 
 
-def test_get_by_name__none_with_multiple_models(db_session: Session) -> None:
-    """Raise when the name is None but the collection has more than one linked model."""
+def test_get_by_name__none_returns_default_not_oldest(db_session: Session) -> None:
+    """Resolve the default model, not the oldest, when the collection has several."""
     collection = create_collection(session=db_session)
-    for name, model_hash in (("embedding_model_1", "hash_1"), ("embedding_model_2", "hash_2")):
-        create_embedding_model(
-            session=db_session,
-            collection_id=collection.collection_id,
-            embedding_model_name=name,
-            embedding_model_hash=model_hash,
-        )
+    create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="oldest_model",
+        embedding_model_hash="hash_1",
+    )
+    default_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="default_model",
+        embedding_model_hash="hash_2",
+        set_as_default=True,
+    )
 
-    with pytest.raises(
-        ValueError,
-        match=r"Expected exactly one embedding model, but found 2 with names "
-        r"\['embedding_model_1', 'embedding_model_2'\]\.",
-    ):
+    result = collection_embedding_model_resolver.get_by_name(
+        session=db_session, collection_id=collection.collection_id, embedding_model_name=None
+    )
+
+    assert result.embedding_model_id == default_model.embedding_model_id
+    assert result.name == "default_model"
+
+
+def test_get_by_name__none_without_default(db_session: Session) -> None:
+    """Raise when the name is None but no linked model is the default."""
+    collection = create_collection(session=db_session)
+    create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_1",
+    )
+
+    with pytest.raises(ValueError, match=r"has no default embedding model"):
         collection_embedding_model_resolver.get_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
@@ -247,9 +267,7 @@ def test_get_by_name__none_with_no_models(db_session: Session) -> None:
     """Raise when the name is None but the collection has no linked model."""
     collection = create_collection(session=db_session)
 
-    with pytest.raises(
-        ValueError, match=r"Expected exactly one embedding model, but found 0 with names \[\]\."
-    ):
+    with pytest.raises(ValueError, match=r"has no default embedding model"):
         collection_embedding_model_resolver.get_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
@@ -315,9 +333,7 @@ def test_get_by_name__scoped_to_the_collection(db_session: Session) -> None:
         embedding_model_name="other_model",
     )
 
-    with pytest.raises(
-        ValueError, match=r"Expected exactly one embedding model, but found 0 with names \[\]\."
-    ):
+    with pytest.raises(ValueError, match=r"has no default embedding model"):
         collection_embedding_model_resolver.get_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -215,7 +215,7 @@ def test_get_by_name__none_returns_default(db_session: Session) -> None:
         set_as_default=True,
     )
 
-    result = collection_embedding_model_resolver.get_by_name(
+    result = collection_embedding_model_resolver.get_model_by_name(
         session=db_session, collection_id=collection.collection_id, embedding_model_name=None
     )
 
@@ -240,7 +240,7 @@ def test_get_by_name__none_returns_default_not_oldest(db_session: Session) -> No
         set_as_default=True,
     )
 
-    result = collection_embedding_model_resolver.get_by_name(
+    result = collection_embedding_model_resolver.get_model_by_name(
         session=db_session, collection_id=collection.collection_id, embedding_model_name=None
     )
 
@@ -258,7 +258,7 @@ def test_get_by_name__none_without_default(db_session: Session) -> None:
     )
 
     with pytest.raises(ValueError, match=r"has no default embedding model"):
-        collection_embedding_model_resolver.get_by_name(
+        collection_embedding_model_resolver.get_model_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
 
@@ -268,7 +268,7 @@ def test_get_by_name__none_with_no_models(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
     with pytest.raises(ValueError, match=r"has no default embedding model"):
-        collection_embedding_model_resolver.get_by_name(
+        collection_embedding_model_resolver.get_model_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
 
@@ -289,7 +289,7 @@ def test_get_by_name__existing_name(db_session: Session) -> None:
         embedding_model_hash="hash_2",
     )
 
-    result_1 = collection_embedding_model_resolver.get_by_name(
+    result_1 = collection_embedding_model_resolver.get_model_by_name(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_1",
@@ -297,7 +297,7 @@ def test_get_by_name__existing_name(db_session: Session) -> None:
     assert result_1.embedding_model_id == model_1.embedding_model_id
     assert result_1.name == "embedding_model_1"
 
-    result_2 = collection_embedding_model_resolver.get_by_name(
+    result_2 = collection_embedding_model_resolver.get_model_by_name(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_2",
@@ -316,7 +316,7 @@ def test_get_by_name__nonexistent_name(db_session: Session) -> None:
     )
 
     with pytest.raises(ValueError, match=r"Embedding model with name `nonexistent` not found."):
-        collection_embedding_model_resolver.get_by_name(
+        collection_embedding_model_resolver.get_model_by_name(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_name="nonexistent",
@@ -334,12 +334,12 @@ def test_get_by_name__scoped_to_the_collection(db_session: Session) -> None:
     )
 
     with pytest.raises(ValueError, match=r"has no default embedding model"):
-        collection_embedding_model_resolver.get_by_name(
+        collection_embedding_model_resolver.get_model_by_name(
             session=db_session, collection_id=collection.collection_id, embedding_model_name=None
         )
 
     with pytest.raises(ValueError, match=r"Embedding model with name `other_model` not found."):
-        collection_embedding_model_resolver.get_by_name(
+        collection_embedding_model_resolver.get_model_by_name(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_name="other_model",

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -4,7 +4,10 @@ import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
-from lightly_studio.resolvers import embedding_model_resolver
+from lightly_studio.resolvers import (
+    collection_embedding_model_resolver,
+    embedding_model_resolver,
+)
 from tests.helpers_resolvers import (
     create_collection,
     create_embedding_model,
@@ -20,31 +23,6 @@ def test_create_embedding_model(db_session: Session) -> None:
         embedding_model_name="example_embedding_model",
     )
     assert embedding_model.name == "example_embedding_model"
-
-
-def test_read_embedding_models(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    embedding_model_1 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-    embedding_model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
-    )
-
-    # Get all embedding models of a collection.
-    embedding_models = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_id
-    )
-    assert len(embedding_models) == 2
-
-    assert embedding_models[0].embedding_model_id == embedding_model_1.embedding_model_id
-    assert embedding_models[1].embedding_model_id == embedding_model_2.embedding_model_id
 
 
 def test_read_embedding_model(db_session: Session) -> None:
@@ -265,7 +243,7 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
     )
 
     assert reused.embedding_model_id == existing.embedding_model_id
-    models = embedding_model_resolver.get_all_by_collection_id(
+    models = collection_embedding_model_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
     assert len(models) == 1
@@ -334,12 +312,18 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
     assert model_1.collection_id == collection_1.collection_id
     assert model_2.collection_id == collection_2.collection_id
 
-    # Each collection should have exactly one model
-    models_1 = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_1.collection_id
+    # Each dataset resolves the shared hash to its own model, so the two are not merged.
+    model_1_by_hash = embedding_model_resolver.get_by_model_hash(
+        session=db_session,
+        dataset_id=collection_1.dataset_id,
+        embedding_model_hash="same_hash",
     )
-    models_2 = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_2.collection_id
+    model_2_by_hash = embedding_model_resolver.get_by_model_hash(
+        session=db_session,
+        dataset_id=collection_2.dataset_id,
+        embedding_model_hash="same_hash",
     )
-    assert len(models_1) == 1
-    assert len(models_2) == 1
+    assert model_1_by_hash is not None
+    assert model_2_by_hash is not None
+    assert model_1_by_hash.embedding_model_id == model_1.embedding_model_id
+    assert model_2_by_hash.embedding_model_id == model_2.embedding_model_id

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -243,10 +243,10 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
     )
 
     assert reused.embedding_model_id == existing.embedding_model_id
-    models = collection_embedding_model_resolver.get_all_by_collection_id(
+    model_ids = collection_embedding_model_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
-    assert len(models) == 1
+    assert len(model_ids) == 1
 
 
 def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from sqlmodel import Session
 
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import (
@@ -63,11 +64,19 @@ def test_read_embedding_model(db_session: Session) -> None:
 
 def test_delete_embedding_model(db_session: Session) -> None:
     collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
+    embedding_model = create_embedding_model(
+        session=db_session, collection_id=collection.collection_id
+    )
 
-    embedding_model = create_embedding_model(session=db_session, collection_id=collection_id)
+    # The model is linked to the collection, so remove the link first; otherwise the
+    # collection_embedding_model foreign key blocks the delete.
+    link = db_session.get(
+        CollectionEmbeddingModelTable,
+        (collection.collection_id, embedding_model.embedding_model_id),
+    )
+    db_session.delete(link)
+    db_session.commit()
 
-    # Delete the embedding model.
     embedding_model_resolver.delete(
         session=db_session, embedding_model_id=embedding_model.embedding_model_id
     )
@@ -232,109 +241,6 @@ def test_get_by_model_hash__scoped_by_dataset(db_session: Session) -> None:
         dataset_id=collection_3.dataset_id,
     )
     assert result_3 is None
-
-
-def test_get_by_name__none_with_single_model(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is None and exactly one model exists."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    embedding_model = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-
-    result = embedding_model_resolver.get_by_name(
-        session=db_session, collection_id=collection_id, embedding_model_name=None
-    )
-    assert result.embedding_model_id == embedding_model.embedding_model_id
-    assert result.name == "embedding_model_1"
-
-
-def test_get_by_name__none_with_multiple_models(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is None but multiple models exist."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"Expected exactly one embedding model, but found 2 with names "
-        r"\['embedding_model_1', 'embedding_model_2'\]\.",
-    ):
-        embedding_model_resolver.get_by_name(
-            session=db_session, collection_id=collection_id, embedding_model_name=None
-        )
-
-
-def test_get_by_name__none_with_no_models(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is None but no models exist."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    with pytest.raises(
-        ValueError, match=r"Expected exactly one embedding model, but found 0 with names \[\]\."
-    ):
-        embedding_model_resolver.get_by_name(
-            session=db_session, collection_id=collection_id, embedding_model_name=None
-        )
-
-
-def test_get_by_name__existing_name(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is provided and exists."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    embedding_model_1 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-    embedding_model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
-    )
-
-    result = embedding_model_resolver.get_by_name(
-        session=db_session, collection_id=collection_id, embedding_model_name="embedding_model_1"
-    )
-    assert result.embedding_model_id == embedding_model_1.embedding_model_id
-    assert result.name == "embedding_model_1"
-
-    result = embedding_model_resolver.get_by_name(
-        session=db_session, collection_id=collection_id, embedding_model_name="embedding_model_2"
-    )
-    assert result.embedding_model_id == embedding_model_2.embedding_model_id
-    assert result.name == "embedding_model_2"
-
-
-def test_get_by_name__nonexistent_name(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is provided but doesn't exist."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-
-    with pytest.raises(ValueError, match=r"Embedding model with name `nonexistent` not found."):
-        embedding_model_resolver.get_by_name(
-            session=db_session, collection_id=collection_id, embedding_model_name="nonexistent"
-        )
 
 
 def test_get_or_create__creates_new_model(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 from sqlmodel import Session
 
-from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import (
@@ -60,32 +59,6 @@ def test_read_embedding_model(db_session: Session) -> None:
     assert embedding_model_from_resolver is not None
     assert embedding_model_from_resolver.embedding_model_id == embedding_model.embedding_model_id
     assert embedding_model_from_resolver.name == embedding_model.name
-
-
-def test_delete_embedding_model(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    embedding_model = create_embedding_model(
-        session=db_session, collection_id=collection.collection_id
-    )
-
-    # The model is linked to the collection, so remove the link first; otherwise the
-    # collection_embedding_model foreign key blocks the delete.
-    link = db_session.get(
-        CollectionEmbeddingModelTable,
-        (collection.collection_id, embedding_model.embedding_model_id),
-    )
-    db_session.delete(link)
-    db_session.commit()
-
-    embedding_model_resolver.delete(
-        session=db_session, embedding_model_id=embedding_model.embedding_model_id
-    )
-
-    # Assert the embedding model was deleted.
-    embedding_model_deleted = embedding_model_resolver.get_by_id(
-        session=db_session, embedding_model_id=embedding_model.embedding_model_id
-    )
-    assert embedding_model_deleted is None
 
 
 def test_get_by_model_hash_deprecated(db_session: Session) -> None:

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -75,6 +75,7 @@ class TestSampling:
             session=dataset.session,
             collection_id=frames.collection_id,
             embedding_model_name="embedding_model_1",
+            set_as_default=True,
         )
         for i, frame in enumerate(frames):
             helpers_resolvers.create_sample_embedding(
@@ -119,6 +120,7 @@ class TestSampling:
             session=dataset.session,
             collection_id=frames.collection_id,
             embedding_model_name="embedding_model_1",
+            set_as_default=True,
         )
         for i, frame in enumerate(frames):
             helpers_resolvers.create_sample_embedding(


### PR DESCRIPTION
## What has changed and why?

Part of removing `embedding_model.collection_id`. Drops the last reads of that column path via `get_all_by_collection_id`.

- Delete `embedding_model_resolver.get_all_by_collection_id` (the direct `WHERE collection_id ==` reader).
- `read_annotation_embedding` now resolves the collection's default via `collection_embedding_model_resolver.get_default_by_collection_id`, instead of listing models and taking the first.
- Behavior change: a collection with models but no default now 404s (previously fell back to the oldest model). This is the intended "default model" semantics.
- Remaining test call sites moved to the link-table resolver; the same-hash dedup test now checks dataset-scoped `get_by_model_hash`.

No other production sites needed changing — everywhere else already uses `get_default_by_collection_id` / `get_model_by_name`.

## How has it been tested?

- `make static-checks` (ruff + mypy) clean.
- Affected suites pass: `test_embedding_model_resolver`, `test_collection_embedding_model_resolver`, `test_deep_copy`, `test_embedding_manager`, and the `test_annotation` embedding route tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---
Suggested reviewer: @KondratSh; alternative: @JonasWurst