### PR TITLE
Skip end-to-end tests for release-tooling-only changes

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -9,12 +9,6 @@ on:
   workflow_dispatch:
 
 
-# Nothing in this workflow writes. The repository default is a write token, so
-# narrow it: checkout needs `contents: read`, and `detect` also needs
-# `pull-requests: read` to list a pull request's changed files.
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,10 +22,6 @@ jobs:
   detect:
     name: Detect changes
     runs-on: ubuntu-latest
-    # Job-level permissions replace the workflow-level block, so repeat `contents`.
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
       # Empty when the filter is skipped (non-PR/MG events), so `|| 'true'`
       # runs everything. A real 'false' is non-empty and preserved.

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -19,8 +19,39 @@ env:
   E2E_BASE_URL: http://localhost:8001
 
 jobs:
+  detect:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      # Empty when the filter is skipped (non-PR/MG events), so `|| 'true'`
+      # runs everything. A real 'false' is non-empty and preserved.
+      e2e: ${{ steps.filter.outputs.e2e || 'true' }}
+    steps:
+      - name: Checkout Code # Needed for merge_group event
+        uses: actions/checkout@v6
+
+      - name: Filter changed paths
+        id: filter
+        # Other events have no base to diff; they fall back to running the tests.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # `every` turns the `!` rules into exclusions: a changed file counts only
+          # if it matches every rule. So `e2e` is 'false' only when all changed
+          # files are excluded. Excluding the few paths the app cannot see, instead
+          # of listing the paths it can, keeps a new product directory from
+          # silently skipping the tests.
+          predicate-quantifier: 'every'
+          filters: |
+            e2e:
+              - '**'
+              # Release tooling, tested by its own checks in prepare_release.yml.
+              - '!.github/scripts/**'
+
   prepare-caches:
     name: Build Cache
+    needs: detect
+    if: needs.detect.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     # Recent runs: 3.5min median, 10min worst.
     timeout-minutes: 15
@@ -479,16 +510,44 @@ jobs:
         run: |
           kill ${{ env.SERVER_PID }} || true
 
+  # The single required status check: always runs, so gated jobs can be skipped
+  # without stranding the merge queue. Require this in the branch ruleset.
   success-check:
     name: End2End Success Check
     runs-on: ubuntu-latest
     needs:
+      - detect
       - prepare-caches
       - end-to-end
     if: always()
     steps:
-      - name: Check failure
-        if: needs.end-to-end.result != 'success'
+      - name: Verify required jobs
+        env:
+          DETECT: ${{ needs.detect.result }}
+          CACHES: ${{ needs.prepare-caches.result }}
+          END_TO_END: ${{ needs.end-to-end.result }}
         run: |
-          echo "❌ End-to-End tests did not complete successfully."
-          exit 1
+          echo "Detect changes: $DETECT"
+          echo "Build Cache: $CACHES"
+          echo "End2End Test: $END_TO_END"
+
+          # If detection failed, jobs were skipped for the wrong reason.
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::Change detection did not succeed (result=$DETECT); failing the gate."
+            exit 1
+          fi
+
+          # A gated job is fine only if it passed or was skipped. A failing
+          # Build Cache surfaces as 'failure' here, so it is not mistaken for a
+          # deliberate skip even though it also skips the tests downstream.
+          for result in "$CACHES" "$END_TO_END"; do
+            case "$result" in
+              success | skipped) ;;
+              *)
+                echo "❌ End-to-End tests did not complete successfully."
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "✅ End-to-End tests passed or were not needed for these changes."

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -45,8 +45,30 @@ jobs:
           filters: |
             e2e:
               - '**'
-              # Release tooling, tested by its own checks in prepare_release.yml.
+              # Release tooling and the other workflows: this workflow runs none
+              # of them, and prepare_release.yml checks its own tooling.
               - '!.github/scripts/**'
+              - '!.github/workflows/unit_test.yml'
+              - '!.github/workflows/prepare_release.yml'
+              - '!.github/workflows/fast_track_*.yml'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/CODEOWNERS'
+              # Backend unit tests: the app under test never imports them.
+              - '!lightly_studio/tests/**'
+              # Docs and dev scripts: the wheel is only src/lightly_studio plus
+              # alembic.ini, and nothing here is read at runtime.
+              - '!lightly_studio/docs/**'
+              - '!lightly_studio/scripts/**'
+              # Self-contained Node package with its own toolchain.
+              - '!fast_track/**'
+              # Agent instructions, git hooks and README assets.
+              - '!.agents/**'
+              - '!.claude/**'
+              - '!.githooks/**'
+              - '!assets/**'
+              # No markdown is imported or read at runtime, in either the backend
+              # or the view - checked before adding this rule.
+              - '!**/*.md'
 
   prepare-caches:
     name: Build Cache

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -9,6 +9,12 @@ on:
   workflow_dispatch:
 
 
+# Nothing in this workflow writes. The repository default is a write token, so
+# narrow it: checkout needs `contents: read`, and `detect` also needs
+# `pull-requests: read` to list a pull request's changed files.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -22,6 +28,10 @@ jobs:
   detect:
     name: Detect changes
     runs-on: ubuntu-latest
+    # Job-level permissions replace the workflow-level block, so repeat `contents`.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       # Empty when the filter is skipped (non-PR/MG events), so `|| 'true'`
       # runs everything. A real 'false' is non-empty and preserved.


### PR DESCRIPTION
## What has changed and why?

The e2e matrix - 11 jobs, ~6 min each - ran on every PR, including ones that cannot change what
it boots: release tooling, backend unit tests, docs, `fast_track`, agent instructions, markdown.

`end2end_test.yml` now gates on a `detect` job, as `unit_test.yml` already does. The filter is
`'**'` minus an exclusion list, with `predicate-quantifier: every`, so it skips only when *every*
changed file is excluded - a new product directory keeps running the tests rather than silently
skipping. `End2End Success Check` still always runs, and now accepts `skipped` for the gated
jobs while still failing on a failed Build Cache.

`lightly_studio/src/**` is deliberately not excluded: the run starts the real backend and
Playwright drives the GUI against it, so backend changes are what these tests are for.

## How has it been tested?

Replayed the 16 rules through picomatch (what the action uses) under the `every` quantifier over
32 real repo paths: the 14 that must trigger the tests all match, the 18 that must not are all
excluded. Each exclusion was checked against the repo first - the index scripts import only the
`lightly_studio` package, the wheel ships only `src/lightly_studio` plus `alembic.ini`, nothing
outside `fast_track` references it, and no `.md` is read at runtime.

This PR touches a workflow, so the full matrix must run and be green. #2128 is the other half of
the check: it only touches `.github/scripts`, so e2e should skip there once this lands.

A least-privilege `permissions:` block was tried here and reverted: it made all 11 matrix jobs
fail to restore the build cache. Left for a separate workflow-wide hardening ticket, see the
review thread.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @michal-lightly; @ikondrat as an alternative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated end-to-end validation by running relevant tests when application changes are detected.
  * Preserved test coverage for other types of changes and non-pull-request events.
  * Updated status checks to correctly recognize successful and intentionally skipped validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
