### PR TITLE
Drop embedding_model.collection_id and add unique constraints

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -168,10 +168,8 @@ class EmbeddingManager:
         model_description = embedding_generator.get_embedding_model_input()
         model_create = EmbeddingModelCreate(
             name=model_description.name,
-            parameter_count_in_mb=model_description.parameter_count_in_mb,
             embedding_model_hash=model_description.embedding_model_hash,
             embedding_dimension=model_description.embedding_dimension,
-            collection_id=collection_id,
             dataset_id=collection.dataset_id,
         )
         db_model = embedding_model_resolver.get_or_create(

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -616,27 +616,10 @@ class ClassifierManager:
 def _get_embedding_model_by_hash(
     session: Session, embedding_model_hash: str, collection_id: UUID
 ) -> EmbeddingModelTable | None:
-    """Resolve the embedding model with the given hash within the collection's dataset.
-
-    The default is preferred while a dataset can contain one model row per collection.
-    The dataset-scoped fallback supports the final deduplicated state.
-    """
+    """Resolve the embedding model with the given hash within the collection's dataset."""
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection {collection_id} not found.")
-
-    # TODO(Michal, 08/2026): Remove once embedding models are unique per dataset and hash.
-    default_embedding_model_id = collection_embedding_model_resolver.get_default_by_collection_id(
-        session=session, collection_id=collection_id
-    )
-    if default_embedding_model_id is not None:
-        default_embedding_model = embedding_model_resolver.get_by_id(
-            session=session, embedding_model_id=default_embedding_model_id
-        )
-        if default_embedding_model is None:
-            raise ValueError("Default embedding space references a missing model.")
-        if default_embedding_model.embedding_model_hash == embedding_model_hash:
-            return default_embedding_model
 
     return embedding_model_resolver.get_by_model_hash(
         session=session,

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
@@ -12,6 +12,9 @@ is kept as canonical; ``sample_embedding`` and ``collection_embedding_model`` re
 repointed to it and the duplicate rows are deleted. Collapsing duplicates is lossy, so the
 downgrade cannot restore the removed rows.
 
+``embedding_model_hash`` also becomes ``NOT NULL``. Pre-existing NULL hashes are backfilled to
+"" before the collapse so they merge into a single row per dataset.
+
 DuckDB builds its schema with ``create_all`` and has no backfill step, so this migration only
 matters for tracked Postgres databases.
 
@@ -37,7 +40,22 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    # Backfill NULL hashes to "" before deduplicating so former-NULL rows collapse together
+    # with the "=" join (NULL = NULL is unknown, so NULLs would otherwise survive) and the
+    # NOT NULL constraint below can be added.
+    op.execute(
+        sa.text(
+            "UPDATE embedding_model SET embedding_model_hash = '' "
+            "WHERE embedding_model_hash IS NULL"
+        )
+    )
     _deduplicate_embedding_models()
+    op.alter_column(
+        "embedding_model",
+        "embedding_model_hash",
+        existing_type=sa.VARCHAR(length=128),
+        nullable=False,
+    )
     op.create_unique_constraint(
         "unique_embedding_model_hash", "embedding_model", ["dataset_id", "embedding_model_hash"]
     )
@@ -98,6 +116,12 @@ def downgrade() -> None:
     )
     op.drop_constraint("unique_embedding_model_name", "embedding_model", type_="unique")
     op.drop_constraint("unique_embedding_model_hash", "embedding_model", type_="unique")
+    op.alter_column(
+        "embedding_model",
+        "embedding_model_hash",
+        existing_type=sa.VARCHAR(length=128),
+        nullable=True,
+    )
 
 
 def _deduplicate_embedding_models() -> None:

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
@@ -19,7 +19,7 @@ DuckDB builds its schema with ``create_all`` and has no backfill step, so this m
 matters for tracked Postgres databases.
 
 Revision ID: d117a91bf587
-Revises: e5f6a7b8c9d0
+Revises: d1e2f3a4b5c6
 Create Date: 2026-08-28 15:07:13.439745
 
 """
@@ -33,7 +33,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d117a91bf587"
-down_revision: str | Sequence[str] | None = "e5f6a7b8c9d0"
+down_revision: str | Sequence[str] | None = "d1e2f3a4b5c6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
@@ -1,0 +1,188 @@
+"""drop embedding model collection and add unique constraints.
+
+Removes ``collection_id`` and ``parameter_count_in_mb`` from ``embedding_model`` and makes
+the model unique per dataset with ``(dataset_id, name)`` and ``(dataset_id, embedding_model_hash)``
+constraints.
+
+Before the constraints are added, duplicate rows are collapsed. The write path used to
+deduplicate per collection, so the same model registered under several collections of one
+dataset produced one row per collection. The oldest row per ``(dataset_id,
+embedding_model_hash)`` (by ``created_at ASC, embedding_model_id ASC``, matching the reader)
+is kept as canonical; ``sample_embedding`` and ``collection_embedding_model`` references are
+repointed to it and the duplicate rows are deleted. Collapsing duplicates is lossy, so the
+downgrade cannot restore the removed rows.
+
+DuckDB builds its schema with ``create_all`` and has no backfill step, so this migration only
+matters for tracked Postgres databases.
+
+Revision ID: d117a91bf587
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-28 15:07:13.439745
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d117a91bf587"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _deduplicate_embedding_models()
+    op.create_unique_constraint(
+        "unique_embedding_model_hash", "embedding_model", ["dataset_id", "embedding_model_hash"]
+    )
+    op.create_unique_constraint(
+        "unique_embedding_model_name", "embedding_model", ["dataset_id", "name"]
+    )
+    op.drop_index(op.f("ix_embedding_model_collection_id"), table_name="embedding_model")
+    op.drop_constraint(
+        op.f("embedding_model_collection_id_fkey"), "embedding_model", type_="foreignkey"
+    )
+    op.drop_column("embedding_model", "parameter_count_in_mb")
+    op.drop_column("embedding_model", "collection_id")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Best-effort and lossy: the duplicate rows collapsed on upgrade cannot be restored.
+    ``collection_id`` is backfilled from ``collection_embedding_model``, preferring the
+    default link, so a model that now belongs to several collections keeps only one.
+    """
+    op.add_column(
+        "embedding_model",
+        sa.Column("parameter_count_in_mb", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "embedding_model",
+        sa.Column("collection_id", sa.Uuid(), autoincrement=False, nullable=True),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE embedding_model AS em
+            SET collection_id = link.collection_id
+            FROM (
+                SELECT DISTINCT ON (embedding_model_id)
+                    embedding_model_id, collection_id
+                FROM collection_embedding_model
+                ORDER BY embedding_model_id, is_default DESC, collection_id ASC
+            ) AS link
+            WHERE link.embedding_model_id = em.embedding_model_id
+            """
+        )
+    )
+    op.alter_column("embedding_model", "collection_id", nullable=False)
+    op.create_foreign_key(
+        op.f("embedding_model_collection_id_fkey"),
+        "embedding_model",
+        "collection",
+        ["collection_id"],
+        ["collection_id"],
+    )
+    op.create_index(
+        op.f("ix_embedding_model_collection_id"),
+        "embedding_model",
+        ["collection_id"],
+        unique=False,
+    )
+    op.drop_constraint("unique_embedding_model_name", "embedding_model", type_="unique")
+    op.drop_constraint("unique_embedding_model_hash", "embedding_model", type_="unique")
+
+
+def _deduplicate_embedding_models() -> None:
+    """Collapse embedding models that share ``(dataset_id, embedding_model_hash)``.
+
+    The oldest row per ``(dataset_id, embedding_model_hash)`` becomes canonical.
+    ``sample_embedding`` and ``collection_embedding_model`` references are repointed to it;
+    rows that would collide with an existing reference on the canonical model are dropped
+    first, then the duplicate models are deleted.
+    """
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            CREATE TEMPORARY TABLE embedding_model_dedup AS
+            SELECT
+                em.embedding_model_id AS duplicate_id,
+                canonical.embedding_model_id AS canonical_id
+            FROM embedding_model AS em
+            JOIN (
+                SELECT DISTINCT ON (dataset_id, embedding_model_hash)
+                    dataset_id, embedding_model_hash, embedding_model_id
+                FROM embedding_model
+                ORDER BY dataset_id, embedding_model_hash, created_at ASC, embedding_model_id ASC
+            ) AS canonical
+                ON canonical.dataset_id = em.dataset_id
+               AND canonical.embedding_model_hash = em.embedding_model_hash
+            WHERE em.embedding_model_id <> canonical.embedding_model_id
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM sample_embedding AS se
+            USING embedding_model_dedup AS d
+            WHERE se.embedding_model_id = d.duplicate_id
+              AND EXISTS (
+                  SELECT 1 FROM sample_embedding AS existing
+                  WHERE existing.sample_id = se.sample_id
+                    AND existing.embedding_model_id = d.canonical_id
+              )
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE sample_embedding AS se
+            SET embedding_model_id = d.canonical_id
+            FROM embedding_model_dedup AS d
+            WHERE se.embedding_model_id = d.duplicate_id
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM collection_embedding_model AS cem
+            USING embedding_model_dedup AS d
+            WHERE cem.embedding_model_id = d.duplicate_id
+              AND EXISTS (
+                  SELECT 1 FROM collection_embedding_model AS existing
+                  WHERE existing.collection_id = cem.collection_id
+                    AND existing.embedding_model_id = d.canonical_id
+              )
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE collection_embedding_model AS cem
+            SET embedding_model_id = d.canonical_id
+            FROM embedding_model_dedup AS d
+            WHERE cem.embedding_model_id = d.duplicate_id
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM embedding_model AS em
+            USING embedding_model_dedup AS d
+            WHERE em.embedding_model_id = d.duplicate_id
+            """
+        )
+    )
+    bind.execute(sa.text("DROP TABLE embedding_model_dedup"))

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
@@ -108,6 +108,7 @@ def _deduplicate_embedding_models() -> None:
     first, then the duplicate models are deleted.
     """
     bind = op.get_bind()
+    # Map each duplicate model to its canonical (oldest) row within the same dataset and hash.
     bind.execute(
         sa.text(
             """
@@ -128,6 +129,7 @@ def _deduplicate_embedding_models() -> None:
             """
         )
     )
+    # Drop duplicate-model embeddings where the sample already has one on the canonical model.
     bind.execute(
         sa.text(
             """
@@ -142,6 +144,7 @@ def _deduplicate_embedding_models() -> None:
             """
         )
     )
+    # Repoint the remaining duplicate-model embeddings onto the canonical model.
     bind.execute(
         sa.text(
             """
@@ -152,6 +155,7 @@ def _deduplicate_embedding_models() -> None:
             """
         )
     )
+    # Drop duplicate-model links where the collection already links the canonical model.
     bind.execute(
         sa.text(
             """
@@ -166,6 +170,7 @@ def _deduplicate_embedding_models() -> None:
             """
         )
     )
+    # Repoint the remaining duplicate-model links onto the canonical model.
     bind.execute(
         sa.text(
             """
@@ -176,6 +181,7 @@ def _deduplicate_embedding_models() -> None:
             """
         )
     )
+    # Delete the now-unreferenced duplicate models.
     bind.execute(
         sa.text(
             """
@@ -185,4 +191,5 @@ def _deduplicate_embedding_models() -> None:
             """
         )
     )
+    # Drop the temporary mapping table now that the merge is complete.
     bind.execute(sa.text("DROP TABLE embedding_model_dedup"))

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
@@ -21,17 +21,18 @@ Create Date: 2026-08-28 15:07:13.439745
 
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
-from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d117a91bf587"
-down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787922433_d117a91bf587_drop_embedding_model_collection_and_add_.py
@@ -16,7 +16,7 @@ DuckDB builds its schema with ``create_all`` and has no backfill step, so this m
 matters for tracked Postgres databases.
 
 Revision ID: d117a91bf587
-Revises: d4e5f6a7b8c9
+Revises: e5f6a7b8c9d0
 Create Date: 2026-08-28 15:07:13.439745
 
 """
@@ -30,7 +30,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d117a91bf587"
-down_revision: str | Sequence[str] | None = "d4e5f6a7b8c9"
+down_revision: str | Sequence[str] | None = "e5f6a7b8c9d0"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -13,7 +13,7 @@ class EmbeddingSpaceDescription(SQLModel):
     """Description of an embedding space."""
 
     name: str
-    embedding_model_hash: str = Field(sa_column=Column(VARCHAR(128)))
+    embedding_model_hash: str = Field(sa_column=Column(VARCHAR(128), nullable=False))
     embedding_dimension: int
 
 

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
+from sqlalchemy import UniqueConstraint
 from sqlmodel import VARCHAR, Column, Field, SQLModel
 
 
@@ -12,7 +13,6 @@ class EmbeddingSpaceDescription(SQLModel):
     """Description of an embedding space."""
 
     name: str
-    parameter_count_in_mb: int | None = None
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
 
@@ -20,7 +20,6 @@ class EmbeddingSpaceDescription(SQLModel):
 class EmbeddingModelBase(EmbeddingSpaceDescription):
     """Base class for the EmbeddingModel."""
 
-    collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
 
 
@@ -32,5 +31,9 @@ class EmbeddingModelTable(EmbeddingModelBase, table=True):
     """This class defines the EmbeddingModel model."""
 
     __tablename__ = "embedding_model"
+    __table_args__ = (
+        UniqueConstraint("dataset_id", "name", name="unique_embedding_model_name"),
+        UniqueConstraint("dataset_id", "embedding_model_hash", name="unique_embedding_model_hash"),
+    )
     embedding_model_id: UUID = Field(default_factory=uuid4, primary_key=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), index=True)

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -13,7 +13,7 @@ class EmbeddingSpaceDescription(SQLModel):
     """Description of an embedding space."""
 
     name: str
-    embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
+    embedding_model_hash: str = Field(sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -444,16 +444,12 @@ def _copy_annotation_labels(session: Session, new_dataset_id: UUID) -> None:
 
 
 def _copy_embedding_models(session: Session, new_dataset_id: UUID, now: datetime) -> None:
-    """Copy embedding models, remapping collection_id and dataset_id."""
+    """Copy embedding models, remapping the id and dataset_id."""
     src = _table(EmbeddingModelTable).alias("src")
     map_model = _map(_MAP_EMBEDDING_MODEL)
-    map_collection = _map(_MAP_COLLECTION)
-    from_clause = src.join(map_model, map_model.c.old_id == src.c["embedding_model_id"]).join(
-        map_collection, map_collection.c.old_id == src.c["collection_id"]
-    )
+    from_clause = src.join(map_model, map_model.c.old_id == src.c["embedding_model_id"])
     overrides = {
         "embedding_model_id": map_model.c.new_id,
-        "collection_id": map_collection.c.new_id,
         "dataset_id": literal(new_dataset_id),
         "created_at": literal(now),
     }

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlmodel import Session, col, select
+from sqlmodel import Session, select
 
 from lightly_studio.models.embedding_model import (
     EmbeddingModelCreate,
@@ -23,9 +23,9 @@ def create(session: Session, embedding_model: EmbeddingModelCreate) -> Embedding
 
 def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> EmbeddingModelTable:
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
-    db_model = get_by_model_hash_deprecated(
+    db_model = get_by_model_hash(
         session=session,
-        collection_id=embedding_model.collection_id,
+        dataset_id=embedding_model.dataset_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -34,7 +34,6 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     # Validate that the existing model matches the provided data.
     if (
         db_model.name != embedding_model.name
-        or db_model.parameter_count_in_mb != embedding_model.parameter_count_in_mb
         or db_model.embedding_dimension != embedding_model.embedding_dimension
     ):
         raise ValueError(
@@ -52,32 +51,10 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
     ).one_or_none()
 
 
-# TODO(Michal, 08/2026): Remove once the write path deduplicates per dataset and the readers
-# no longer resolve embedding models by collection.
-def get_by_model_hash_deprecated(
-    session: Session, collection_id: UUID, embedding_model_hash: str
-) -> EmbeddingModelTable | None:
-    """Retrieve a single embedding model by hash and collection.
-
-    Kept for the write path, which still deduplicates per collection until the readers move
-    to dataset scope. Prefer :func:`get_by_model_hash` for new reads.
-    """
-    query = select(EmbeddingModelTable).where(
-        EmbeddingModelTable.embedding_model_hash == embedding_model_hash
-    )
-    query = query.where(EmbeddingModelTable.collection_id == collection_id)
-    return session.exec(query).one_or_none()
-
-
 def get_by_model_hash(
     session: Session, dataset_id: UUID, embedding_model_hash: str
 ) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by hash within a dataset.
-
-    The same hash can appear once per collection because the write path still deduplicates
-    per collection (see :func:`get_by_model_hash_deprecated`), so a dataset can hold
-    duplicates. The oldest match is returned so they resolve deterministically to the
-    canonical row.
 
     Args:
         session: The database session.
@@ -85,15 +62,11 @@ def get_by_model_hash(
         embedding_model_hash: The hash identifying the embedding model.
 
     Returns:
-        The oldest matching embedding model, or None if no matching model exists.
+        The matching embedding model, or None if no matching model exists.
     """
     query = (
         select(EmbeddingModelTable)
         .where(EmbeddingModelTable.embedding_model_hash == embedding_model_hash)
         .where(EmbeddingModelTable.dataset_id == dataset_id)
-        .order_by(
-            col(EmbeddingModelTable.created_at).asc(),
-            col(EmbeddingModelTable.embedding_model_id).asc(),
-        )
     )
-    return session.exec(query).first()
+    return session.exec(query).one_or_none()

--- a/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
+++ b/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
@@ -160,7 +160,6 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,

--- a/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
+++ b/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
@@ -169,7 +169,6 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,

--- a/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
+++ b/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
@@ -185,7 +185,6 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID]:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,

--- a/lightly_studio/tests/benchmarks/gui_benchmark.py
+++ b/lightly_studio/tests/benchmarks/gui_benchmark.py
@@ -400,7 +400,6 @@ def _resolve_embedding_model(session: Session, collection_id: UUID) -> tuple[UUI
     synthetic_model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
-            collection_id=collection_id,
             dataset_id=collection.dataset_id,
             name=DEFAULT_EMBEDDING_MODEL_NAME,
             embedding_dimension=DEFAULT_EMBEDDING_DIM,

--- a/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
+++ b/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
@@ -224,7 +224,6 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID, UUID]:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -234,7 +234,6 @@ def collections(db_session: Session) -> list[CollectionTable]:
 def embedding_model_input(collection: CollectionTable) -> EmbeddingModelCreate:
     """Create an EmbeddingModelCreate instance."""
     return EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         dataset_id=collection.dataset_id,
         embedding_dimension=3,
         name="test_model",

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -109,7 +109,6 @@ def test_register_multiple_models(
             return EmbeddingSpaceDescription(
                 name="Fake",
                 embedding_model_hash="fake_hash",
-                parameter_count_in_mb=50,
                 embedding_dimension=5,
             )
 
@@ -148,8 +147,7 @@ def test_register_multiple_models(
     assert len(stored_models) == 2
     model_names = {model.name for model in stored_models}
     assert model_names == {"Random", "Fake"}
-    # Verify both models are associated with the same collection and dataset
-    assert all(model.collection_id == collection.collection_id for model in stored_models)
+    # Verify both models are associated with the same dataset
     assert all(model.dataset_id == collection.dataset_id for model in stored_models)
 
     # Both models are linked to the collection, not only the default one.
@@ -578,8 +576,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
 ) -> None:
     """An annotation child collection reuses the parent's loaded generator.
 
-    The generator weights are loaded once, but each collection still gets its
-    own embedding-model record and id.
+    The generator weights are loaded once, and both collections resolve to the same
+    embedding-model record because the model is deduplicated per dataset.
     """
     image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
     annotation_collection = create_collection(
@@ -608,8 +606,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
     mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)
     assert manager._models[image_model_id] is manager._models[annotation_model_id]
 
-    # Each collection still owns a distinct embedding-model record.
-    assert image_model_id != annotation_model_id
+    # Both collections share the dataset, so the model is deduplicated to one record.
+    assert image_model_id == annotation_model_id
 
 
 def test_load_or_get_default_model__cant_load(

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -60,7 +60,6 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
     embedding_model = EmbeddingModelCreate(
         embedding_model_hash="mock_hash",
         name="test_model",
-        collection_id=collection.collection_id,
         dataset_id=collection.dataset_id,
         embedding_dimension=3,
     )

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -966,33 +966,23 @@ class TestClassifierManager:
             )
 
 
-def test_get_embedding_model_by_hash__prefers_default(db_session: Session) -> None:
-    # A child collection shares its parent's dataset, so both can hold a row for the same
-    # hash while the write path deduplicates per collection. Sample embeddings are keyed to
-    # the collection's own row, so the lookup must return that row and not the oldest one in
-    # the dataset.
+def test_get_embedding_model_by_hash__resolves_within_dataset(db_session: Session) -> None:
+    # A child collection shares its parent's dataset, so a model registered under the parent
+    # resolves by hash when the lookup starts from the child collection.
     parent = create_collection(session=db_session, collection_name="parent")
     child = create_collection(
         session=db_session, collection_name="child", parent_collection_id=parent.collection_id
     )
     assert child.dataset_id == parent.dataset_id
-    # The parent's row is created first, so it is the oldest in the dataset.
-    create_embedding_model(
+    model = create_embedding_model(
         session=db_session,
         collection_id=parent.collection_id,
-        embedding_model_name="model_in_parent",
-        embedding_model_hash="same_hash",
-    )
-    child_model = create_embedding_model(
-        session=db_session,
-        collection_id=child.collection_id,
-        embedding_model_name="model_in_child",
-        embedding_model_hash="same_hash",
-        set_as_default=True,
+        embedding_model_name="model",
+        embedding_model_hash="some_hash",
     )
 
     result = classifier_manager_module._get_embedding_model_by_hash(
-        session=db_session, embedding_model_hash="same_hash", collection_id=child.collection_id
+        session=db_session, embedding_model_hash="some_hash", collection_id=child.collection_id
     )
     assert result is not None
-    assert result.embedding_model_id == child_model.embedding_model_id
+    assert result.embedding_model_id == model.embedding_model_id

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -303,7 +303,6 @@ def create_embedding_model(  # noqa: PLR0913
     collection_id: UUID,
     embedding_model_name: str = "example_embedding_model",
     embedding_model_hash: str = "example_hash",
-    parameter_count_in_mb: int = 100,
     embedding_dimension: int = 128,
     set_as_default: bool = False,
 ) -> EmbeddingModelTable:
@@ -318,18 +317,15 @@ def create_embedding_model(  # noqa: PLR0913
     if collection is None:
         raise ValueError(f"Collection with id {collection_id} not found.")
 
-    # TODO(Michal, 08/2026): Once collection_id is out of embedding_model, take dataset_id
-    # directly and make collection_id optional: link only when it is given, so unlinked
-    # models become expressible. The collection_embedding_model link is then the sole source
-    # of collection membership.
+    # TODO(Michal, 08/2026): Make collection_id optional here: link only when it is given, so
+    # unlinked models become expressible. The collection_embedding_model link is then the sole
+    # source of collection membership.
     model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
-            collection_id=collection_id,
             dataset_id=collection.dataset_id,
             name=embedding_model_name,
             embedding_model_hash=embedding_model_hash,
-            parameter_count_in_mb=parameter_count_in_mb,
             embedding_dimension=embedding_dimension,
         ),
     )
@@ -438,6 +434,7 @@ def fill_db_with_samples_and_embeddings(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
+            embedding_model_hash=f"hash_{embedding_model_name}",
             # The first model is the collection default, matching production and the
             # queries that resolve the default embedding space (e.g. embeddings2d).
             set_as_default=index == 0,
@@ -483,6 +480,7 @@ def fill_db_with_video_samples_and_embeddings(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
+            embedding_model_hash=f"hash_{embedding_model_name}",
             # The first model is the collection default, matching production and the
             # queries that resolve the default embedding space (e.g. embeddings2d).
             set_as_default=index == 0,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -320,7 +320,7 @@ def create_embedding_model(  # noqa: PLR0913
     # TODO(Michal, 08/2026): Make collection_id optional here: link only when it is given, so
     # unlinked models become expressible. The collection_embedding_model link is then the sole
     # source of collection membership.
-    model = embedding_model_resolver.create(
+    model = embedding_model_resolver.get_or_create(
         session=session,
         embedding_model=EmbeddingModelCreate(
             dataset_id=collection.dataset_id,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -109,7 +109,7 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
         ),
         "tag": count(TagTable, col(TagTable.collection_id).in_(collection_ids)),
         "embedding_model": count(
-            EmbeddingModelTable, col(EmbeddingModelTable.collection_id).in_(collection_ids)
+            EmbeddingModelTable, col(EmbeddingModelTable.dataset_id) == dataset_id
         ),
         "collection_embedding_model": count(
             CollectionEmbeddingModelTable,

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -39,84 +39,6 @@ def test_read_embedding_model(db_session: Session) -> None:
     assert embedding_model_from_resolver.name == embedding_model.name
 
 
-def test_get_by_model_hash_deprecated(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    embedding_model_1 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-        embedding_model_hash="hash_1",
-    )
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
-        embedding_model_hash="hash_2",
-    )
-
-    embedding_model = embedding_model_resolver.get_by_model_hash_deprecated(
-        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
-    )
-    assert embedding_model is not None
-    assert embedding_model.name == embedding_model_1.name
-
-    embedding_model = embedding_model_resolver.get_by_model_hash_deprecated(
-        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
-    )
-    assert embedding_model is None
-
-
-def test_get_by_model_hash_deprecated__with_collection_id(db_session: Session) -> None:
-    collection_1 = create_collection(session=db_session, collection_name="collection_1")
-    collection_2 = create_collection(session=db_session, collection_name="collection_2")
-
-    # Create models with same hash in different collections
-    model_1 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_1.collection_id,
-        embedding_model_name="model_in_collection_1",
-        embedding_model_hash="same_hash",
-    )
-    model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_2.collection_id,
-        embedding_model_name="model_in_collection_2",
-        embedding_model_hash="same_hash",
-    )
-
-    # With collection_id, returns the correct model
-    result = embedding_model_resolver.get_by_model_hash_deprecated(
-        session=db_session,
-        embedding_model_hash="same_hash",
-        collection_id=collection_1.collection_id,
-    )
-    assert result is not None
-    assert result.embedding_model_id == model_1.embedding_model_id
-    assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_1.collection_id
-
-    result = embedding_model_resolver.get_by_model_hash_deprecated(
-        session=db_session,
-        embedding_model_hash="same_hash",
-        collection_id=collection_2.collection_id,
-    )
-    assert result is not None
-    assert result.embedding_model_id == model_2.embedding_model_id
-    assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_2.collection_id
-
-    # With non-matching collection_id, returns None
-    collection_3 = create_collection(session=db_session, collection_name="collection_3")
-    result_3 = embedding_model_resolver.get_by_model_hash_deprecated(
-        session=db_session,
-        embedding_model_hash="same_hash",
-        collection_id=collection_3.collection_id,
-    )
-    assert result_3 is None
-
-
 def test_get_by_model_hash(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
@@ -199,11 +121,9 @@ def test_get_or_create__creates_new_model(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
     model_create = EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
-        parameter_count_in_mb=200,
         embedding_dimension=768,
     )
     created = embedding_model_resolver.get_or_create(
@@ -212,9 +132,8 @@ def test_get_or_create__creates_new_model(db_session: Session) -> None:
 
     assert created.embedding_model_hash == "model_hash"
     assert created.name == "Model Name"
-    assert created.parameter_count_in_mb == 200
     assert created.embedding_dimension == 768
-    assert created.collection_id == collection.collection_id
+    assert created.dataset_id == collection.dataset_id
 
 
 def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
@@ -225,16 +144,13 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
         collection_id=collection.collection_id,
         embedding_model_name="Model Name",
         embedding_model_hash="model_hash",
-        parameter_count_in_mb=10,
         embedding_dimension=32,
     )
 
     model_create = EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
-        parameter_count_in_mb=10,
         embedding_dimension=32,
     )
 
@@ -257,16 +173,13 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
         collection_id=collection.collection_id,
         embedding_model_name="Model Name",
         embedding_model_hash="model_hash",
-        parameter_count_in_mb=10,
         embedding_dimension=32,
     )
 
     conflicting_model_create = EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
-        parameter_count_in_mb=2000,
         embedding_dimension=64,
     )
 
@@ -279,16 +192,15 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
         )
 
 
-def test_get_or_create__same_hash_different_collections(db_session: Session) -> None:
+def test_get_or_create__same_hash_different_datasets(db_session: Session) -> None:
+    # Root collections each get their own dataset, so these models live in different datasets.
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
     model_create_1 = EmbeddingModelCreate(
-        collection_id=collection_1.collection_id,
         dataset_id=collection_1.dataset_id,
         name="Test Model",
         embedding_model_hash="same_hash",
-        parameter_count_in_mb=10,
         embedding_dimension=32,
     )
     model_1 = embedding_model_resolver.get_or_create(
@@ -296,11 +208,9 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
     )
 
     model_create_2 = EmbeddingModelCreate(
-        collection_id=collection_2.collection_id,
         dataset_id=collection_2.dataset_id,
         name="Test Model",
         embedding_model_hash="same_hash",
-        parameter_count_in_mb=10,
         embedding_dimension=32,
     )
     model_2 = embedding_model_resolver.get_or_create(
@@ -309,8 +219,8 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
 
     # Should be different models
     assert model_1.embedding_model_id != model_2.embedding_model_id
-    assert model_1.collection_id == collection_1.collection_id
-    assert model_2.collection_id == collection_2.collection_id
+    assert model_1.dataset_id == collection_1.dataset_id
+    assert model_2.dataset_id == collection_2.dataset_id
 
     # Each dataset resolves the shared hash to its own model, so the two are not merged.
     model_1_by_hash = embedding_model_resolver.get_by_model_hash(

--- a/lightly_studio/tests/resolvers/test_sample_embedding_resolver.py
+++ b/lightly_studio/tests/resolvers/test_sample_embedding_resolver.py
@@ -253,9 +253,19 @@ def test_get_embedding_count(db_session: Session) -> None:
     create_images(db_session=db_session, collection_id=col2_id, images=[ImageStub("sample.png")])
 
     # Create an embedding models
-    embedding_model_1 = create_embedding_model(session=db_session, collection_id=col1_id)
+    embedding_model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=col1_id,
+        embedding_model_name="model_1",
+        embedding_model_hash="hash_1",
+    )
     embedding_model_1_id = embedding_model_1.embedding_model_id
-    embedding_model_2 = create_embedding_model(session=db_session, collection_id=col1_id)
+    embedding_model_2 = create_embedding_model(
+        session=db_session,
+        collection_id=col1_id,
+        embedding_model_name="model_2",
+        embedding_model_hash="hash_2",
+    )
     embedding_model_2_id = embedding_model_2.embedding_model_id
 
     # Create embeddings for col1


### PR DESCRIPTION
## What has changed and why?

Final step of LIG-10548. Drops the last of `collection_id` from `embedding_model` now that nothing reads it, and enforces one model per dataset.

- Drop `collection_id` and unused `parameter_count_in_mb` from `embedding_model`.
- Add unique constraints `(dataset_id, name)` and `(dataset_id, embedding_model_hash)`.
- Write path now dedups per dataset, so `get_by_model_hash` returns `one_or_none`; the deprecated per-collection lookup and its readers are removed.
- Migration collapses pre-existing per-collection duplicates onto the oldest canonical row (repointing `sample_embedding` and `collection_embedding_model`) before adding the constraints. Lossy, so downgrade is best-effort.
- DuckDB uses `create_all`, so the migration only matters for Postgres.

Stacked on #2130.

## How has it been tested?

- `make static-checks` (ruff, mypy, format) passes.
- Updated resolver, manager, and deep-copy tests.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding models are now shared and deduplicated within datasets rather than tied to individual collections.
  * Models are consistently resolved using their dataset and model hash.
  * Dataset-level safeguards prevent duplicate models with the same name or hash.

* **Bug Fixes**
  * Improved model copying and lookup to preserve dataset associations.
  * Removed outdated model metadata and collection-specific associations.
  * Updated existing data to support the new dataset-scoped model structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->