### PR TITLE
Remove pool recycle

### DIFF
--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -121,13 +121,9 @@ class DatabaseEngine:
                 # A middlebox (e.g., firewalls, VPNs) can silently drop idle connections,
                 # and the next statement will fail with "server closed the connection unexpectedly".
                 # TCP keepalives keep the socket warm so the flow is never reaped.
-                # Pre_ping and recycle replace a pooled connection that died before it is
-                # handed out again.
 
                 # Test a pooled connection before handing it out, so a dead one is never reused.
                 engine_kwargs["pool_pre_ping"] = True
-                # Discard & reopen any connection older than 1800s.
-                engine_kwargs["pool_recycle"] = 1800
                 engine_kwargs["connect_args"] = {
                     "keepalives": 1,  # Setting this explicitly so the intent is visible.
                     "keepalives_idle": 30,  # Send a probe after 30s of idleness.

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -466,7 +466,6 @@ def test_database_engine__postgres_sets_keepalive_and_pool_options(
 
     kwargs = create_engine_mock.call_args.kwargs
     assert kwargs["pool_pre_ping"] is True
-    assert kwargs["pool_recycle"] == 1800
     assert kwargs["connect_args"] == {
         "keepalives": 1,
         "keepalives_idle": 30,
@@ -498,7 +497,8 @@ def test_database_engine__postgres_pool_options_applied_on_real_engine(
     engine = DatabaseEngine(engine_url=postgres_url)
     try:
         assert engine._engine.pool._pre_ping is True
-        assert engine._engine.pool._recycle == 1800
+        # recycle stays disabled (-1): a forced reconnect would re-auth as an expired temp role.
+        assert engine._engine.pool._recycle == -1
     finally:
         engine.close()
 

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -486,7 +486,6 @@ def test_database_engine__duckdb_omits_postgres_pool_options(
     kwargs = create_engine_mock.call_args.kwargs
     assert "connect_args" not in kwargs
     assert "pool_pre_ping" not in kwargs
-    assert "pool_recycle" not in kwargs
 
 
 @pytest.mark.postgres_only
@@ -497,7 +496,7 @@ def test_database_engine__postgres_pool_options_applied_on_real_engine(
     engine = DatabaseEngine(engine_url=postgres_url)
     try:
         assert engine._engine.pool._pre_ping is True
-        # recycle stays disabled (-1): a forced reconnect would re-auth as an expired temp role.
+        # No pool recycle (-1): a forced reconnect would re-auth as an expired temp role.
         assert engine._engine.pool._recycle == -1
     finally:
         engine.close()


### PR DESCRIPTION
## What has changed and why?

Removes the pool recycling introduced in https://github.com/lightly-ai/lightly-studio/pull/2051 as it is not compatible with the enterprise short TTL temp roles: long-running operations would hold a connection open, Postgres would recycle it, SQLAlchemy would try to reopen it with the same URL having an already expired role.

## How has it been tested?

Updates tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connections now remain available in the connection pool without being automatically recycled after 30 minutes.
  * Improved connection-pool stability for long-running sessions and applications that maintain persistent database access.

* **Tests**
  * Updated database connection tests to verify that automatic connection recycling remains disabled.
  * Added coverage confirming consistent connection-pool behavior across supported database configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->