### PR TITLE
Fix E2E Playwright browser cache version mismatch

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -101,18 +101,20 @@ jobs:
           cache: 'npm'
           cache-dependency-path: lightly_studio_view/package-lock.json
 
+      # Run whenever either the build or the Playwright browser cache misses.
       - name: Install lightly_studio_view dependencies
-        if: steps.cache-build.outputs.cache-hit != 'true'
+        if: steps.cache-build.outputs.cache-hit != 'true' || steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         working-directory: lightly_studio_view
         run: npm ci
 
       ### Build caches ###
 
-      # Only download browser binaries when cache misses; otherwise reuse cache
+      # Only download browser binaries when cache misses; otherwise reuse cache.
+      # Invoke the pinned Playwright directly to avoid drifting browser versions.
       - name: Install Playwright browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         working-directory: lightly_studio_view
-        run: npx playwright install chromium
+        run: ./node_modules/.bin/playwright install chromium
 
       - name: Download example dataset
         if: steps.cache-example-dataset.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What has changed and why?

Install browsers using the pinned Playwright version instead of using npx. Fixes an issue where the E2E tests steps were expecting a different Chromium version than the one installed:
- https://github.com/lightly-ai/lightly-studio/actions/runs/33179818710/job/98887144587?pr=2133: "Chrome Headless Shell 151.0.7922.34 (playwright chromium-headless-shell v1234) downloaded to /home/runner/.cache/ms-playwright/chromium_headless_shell-1234"
- https://github.com/lightly-ai/lightly-studio/actions/runs/33179818710/job/98887313118?pr=2133: "Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell"

Also checks the browser cache before installing dependencies.

## How has it been tested?

Error gone in CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
