### PR TITLE
Share one install id across both PostHog SDKs

### DIFF
--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -21,6 +21,7 @@ from lightly_studio.api.routes import (
     webapp,
 )
 from lightly_studio.api.routes.api import (
+    analytics,
     annotation,
     annotation_label,
     caption,
@@ -149,6 +150,7 @@ api_router.include_router(settings.settings_router)
 api_router.include_router(classifier.classifier_router)
 api_router.include_router(embeddings2d.embeddings2d_router)
 api_router.include_router(features.features_router)
+api_router.include_router(analytics.analytics_router)
 api_router.include_router(evaluation.evaluation_router)
 api_router.include_router(metadata.metadata_router)
 api_router.include_router(sampling.sampling_router)

--- a/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
@@ -1,0 +1,28 @@
+"""This module contains the API routes for analytics identity."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from lightly_studio.analytics import install_id
+
+__all__ = ["analytics_router"]
+
+analytics_router = APIRouter(tags=["analytics"])
+
+
+class InstallId(BaseModel):
+    """The anonymous install id shared across the analytics SDKs."""
+
+    install_id: str
+
+
+@analytics_router.get("/install_id")
+def get_install_id() -> InstallId:
+    """Get the anonymous install id.
+
+    The web app calls PostHog's identify() with this id so that browser events
+    and the Python SDK's events land under one distinct id per install.
+    """
+    return InstallId(install_id=str(install_id.get_install_id()))

--- a/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
@@ -6,6 +6,8 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from lightly_studio.analytics import install_id
+from lightly_studio.dataset.env import LIGHTLY_STUDIO_ANALYTICS_ENABLED
+from lightly_studio.errors import NotFoundError
 
 __all__ = ["analytics_router"]
 
@@ -25,4 +27,7 @@ def get_install_id() -> InstallId:
     The web app calls PostHog's identify() with this id so that browser events
     and the Python SDK's events land under one distinct id per install.
     """
+    if not LIGHTLY_STUDIO_ANALYTICS_ENABLED:
+        # Opting out must leave no id on disk, so refuse before get_install_id() creates one.
+        raise NotFoundError("Usage tracking is disabled.")
     return InstallId(install_id=str(install_id.get_install_id()))

--- a/lightly_studio/tests/api/routes/api/test_analytics.py
+++ b/lightly_studio/tests/api/routes/api/test_analytics.py
@@ -6,15 +6,30 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
 from lightly_studio.analytics import install_id
-from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
+from lightly_studio.api.routes.api import analytics
+from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK
 
 INSTALL_ID = UUID("0199f1a2-b775-76b8-9b09-c2fd260c67c1")
 
 
 def test_get_install_id(test_client: TestClient, mocker: MockerFixture) -> None:
+    mocker.patch.object(analytics, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(install_id, "get_install_id", return_value=INSTALL_ID)
 
     response = test_client.get("/api/install_id")
 
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() == {"install_id": str(INSTALL_ID)}
+
+
+def test_get_install_id__returns_not_found_when_analytics_disabled(
+    test_client: TestClient, mocker: MockerFixture
+) -> None:
+    """Opting out must leave no install id on disk, so the endpoint refuses to create one."""
+    mocker.patch.object(analytics, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", False)
+    get_install_id = mocker.patch.object(install_id, "get_install_id")
+
+    response = test_client.get("/api/install_id")
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+    get_install_id.assert_not_called()

--- a/lightly_studio/tests/api/routes/api/test_analytics.py
+++ b/lightly_studio/tests/api/routes/api/test_analytics.py
@@ -1,0 +1,20 @@
+"""Tests for the analytics API route."""
+
+from uuid import UUID
+
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+from lightly_studio.analytics import install_id
+from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
+
+INSTALL_ID = UUID("0199f1a2-b775-76b8-9b09-c2fd260c67c1")
+
+
+def test_get_install_id(test_client: TestClient, mocker: MockerFixture) -> None:
+    mocker.patch.object(install_id, "get_install_id", return_value=INSTALL_ID)
+
+    response = test_client.get("/api/install_id")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"install_id": str(INSTALL_ID)}

--- a/lightly_studio_view/src/lib/hooks/usePostHog.test.ts
+++ b/lightly_studio_view/src/lib/hooks/usePostHog.test.ts
@@ -14,24 +14,30 @@ vi.mock('$lib/version.json', () => ({
     version: '1.2.3'
 }));
 
+const INSTALL_ID = '0199f1a2-b775-76b8-9b09-c2fd260c67c1';
+
 const mockInit = vi.fn();
 const mockCapture = vi.fn();
 const mockRegister = vi.fn();
+const mockIdentify = vi.fn();
 
 vi.mock('posthog-js', () => ({
     default: {
         init: (...args: unknown[]) => mockInit(...args),
         capture: (...args: unknown[]) => mockCapture(...args),
-        register: (...args: unknown[]) => mockRegister(...args)
+        register: (...args: unknown[]) => mockRegister(...args),
+        identify: (...args: unknown[]) => mockIdentify(...args)
     }
 }));
 
 // Mocked at the module registry rather than spied on, so it survives the vi.resetModules() the
 // tests below need to get an uninitialized hook.
 const mockGetFeatures = vi.fn();
+const mockGetInstallId = vi.fn();
 
 vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
-    getFeatures: (...args: unknown[]) => mockGetFeatures(...args)
+    getFeatures: (...args: unknown[]) => mockGetFeatures(...args),
+    getInstallId: (...args: unknown[]) => mockGetInstallId(...args)
 }));
 
 describe('usePostHog', () => {
@@ -39,8 +45,11 @@ describe('usePostHog', () => {
         mockInit.mockClear();
         mockCapture.mockClear();
         mockRegister.mockClear();
+        mockIdentify.mockClear();
         mockGetFeatures.mockReset();
         mockGetFeatures.mockResolvedValue({ data: ['analytics'] });
+        mockGetInstallId.mockReset();
+        mockGetInstallId.mockResolvedValue({ data: { install_id: INSTALL_ID } });
     });
 
     it('should initialize PostHog with correct configuration', async () => {
@@ -55,6 +64,23 @@ describe('usePostHog', () => {
             capture_exceptions: true
         });
         expect(mockRegister).toHaveBeenCalledWith({ app_version: '1.2.3' });
+    });
+
+    it('should identify with the backend install id after initialization', async () => {
+        const { init } = await freshPostHog();
+        await init();
+
+        expect(mockIdentify).toHaveBeenCalledWith(INSTALL_ID);
+    });
+
+    it('should still initialize but not identify when the install id request fails', async () => {
+        mockGetInstallId.mockRejectedValue(new Error('API Error'));
+
+        const { init } = await freshPostHog();
+        await init();
+
+        expect(mockInit).toHaveBeenCalled();
+        expect(mockIdentify).not.toHaveBeenCalled();
     });
 
     it('should track events after initialization', async () => {

--- a/lightly_studio_view/src/lib/hooks/usePostHog.ts
+++ b/lightly_studio_view/src/lib/hooks/usePostHog.ts
@@ -6,6 +6,7 @@ import {
     PUBLIC_POSTHOG_HOST
 } from '$env/static/public';
 import { version } from '$lib/version.json';
+import { getInstallId } from '$lib/api/lightly_studio_local/sdk.gen';
 // Imported by its own path: $lib/hooks re-exports usePostHog, so going through the barrel would
 // make the two modules import each other.
 import { useFeatureFlags } from '$lib/hooks/useFeatureFlags/useFeatureFlags';
@@ -62,8 +63,19 @@ export const usePostHog = () => {
             capture_exceptions: true
         });
         posthog.register({ app_version: version });
-
+        // Set before the awaited identify() below so the guard above stays a synchronous critical
+        // section: a second concurrent caller must see this flip before we yield, or it inits twice.
         initialized = true;
+
+        // Identify with the backend install id so browser events and the Python SDK, which keys
+        // on the same id, report under one distinct id per install instead of two. On failure we
+        // leave posthog on its own anonymous id.
+        try {
+            const { data } = await getInstallId();
+            if (data) posthog.identify(data.install_id);
+        } catch (error) {
+            console.warn('Failed to identify PostHog user with install id', error);
+        }
     };
 
     /**


### PR DESCRIPTION
## What has changed and why?

The Python SDK and the web app both send events to one PostHog project but keyed them on separate distinct ids. A single install then counted as two users. The web app now fetches the install id from the backend and calls `posthog.identify()` with it, so both SDKs report under one id per install.

- `api/routes/api/analytics.py`: new `GET /install_id` route returning the install UUID.
- `hooks/usePostHog.ts`: `init()` identifies with the backend install id after `posthog.init()`. On a failed request it stays on the anonymous id.

## How has it been tested?

- Backend: `test_analytics.py` covers the route returning the install id.
- Frontend: `usePostHog.test.ts` covers identify-after-init and the fallback when the request fails.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an analytics endpoint that provides a consistent anonymous installation identifier when analytics is enabled.
  - PostHog now associates analytics data with the installation identifier when available.
  - Anonymous tracking continues if retrieving the identifier fails.

- **Bug Fixes**
  - Prevented duplicate analytics initialization during concurrent startup operations.
  - Disabled analytics no longer creates or returns an installation identifier.

- **Tests**
  - Added coverage for enabled, disabled, successful, and failed installation identifier retrieval and analytics initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->