### PR TITLE
Add SampleType.MCAP and mcap_sample table

### DIFF
--- a/lightly_studio/.vscode/settings.json
+++ b/lightly_studio/.vscode/settings.json
@@ -16,12 +16,5 @@
             "source.fixAll": "always"
         }
     },
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "python-envs.pythonProjects": [
-        {
-            "path": ".",
-            "envManager": "ms-python.python:venv",
-            "packageManager": "ms-python.python:pip"
-        }
-    ]
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/lightly_studio/.vscode/settings.json
+++ b/lightly_studio/.vscode/settings.json
@@ -16,5 +16,12 @@
             "source.fixAll": "always"
         }
     },
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ]
 }

--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -31,6 +31,9 @@ from lightly_studio.models.group_component_definition import (
 from lightly_studio.models.image import (
     ImageTable,  # noqa: F401, required for SQLModel to work properly
 )
+from lightly_studio.models.mcap import (
+    McapTable,  # noqa: F401, required for SQLModel to work properly
+)
 from lightly_studio.models.metadata import (
     SampleMetadataTable,  # noqa: F401, required for SQLModel to work properly
 )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -2,7 +2,7 @@
 
 Adds the ``mcap`` locator table (1:1 with ``sample``) and the ``MCAP`` value on the
 ``SampleType`` enum. Rows hold seek keys into an ``.mcap`` file (channel id + log
-time), not payload bytes; camera vs. lidar is the ``mcap_data_type`` column.
+time), not payload bytes.
 
 Revision ID: af51a31f2cd3
 Revises: e5f6a7b8c9d0
@@ -16,7 +16,6 @@ from typing import Union
 import sqlalchemy as sa
 from alembic import op
 from alembic_postgresql_enum import TableReference
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "af51a31f2cd3"
@@ -27,14 +26,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    sa.Enum("IMAGE", "POINT_CLOUD", name="mcapdatatype").create(op.get_bind())
     op.create_table(
         "mcap",
-        sa.Column(
-            "mcap_data_type",
-            postgresql.ENUM("IMAGE", "POINT_CLOUD", name="mcapdatatype", create_type=False),
-            nullable=False,
-        ),
         sa.Column("channel_id", sa.Integer(), nullable=False),
         sa.Column("log_time_ns", sa.BigInteger(), nullable=False),
         sa.Column("capture_timestamp_ns", sa.BigInteger(), nullable=False),
@@ -78,4 +71,3 @@ def downgrade() -> None:
     )
     op.drop_index(op.f("ix_mcap_created_at"), table_name="mcap")
     op.drop_table("mcap")
-    sa.Enum("IMAGE", "POINT_CLOUD", name="mcapdatatype").drop(op.get_bind())

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -5,7 +5,7 @@ Adds the ``mcap`` locator table (1:1 with ``sample``) and the ``MCAP`` value on 
 time), not payload bytes.
 
 Revision ID: af51a31f2cd3
-Revises: e5f6a7b8c9d0
+Revises: d1e2f3a4b5c6
 Create Date: 2026-08-28 16:48:57.097750
 
 """
@@ -19,7 +19,7 @@ from alembic_postgresql_enum import TableReference
 
 # revision identifiers, used by Alembic.
 revision: str = "af51a31f2cd3"
-down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "d1e2f3a4b5c6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -1,0 +1,81 @@
+"""add mcap table.
+
+Adds the ``mcap`` locator table (1:1 with ``sample``) and the ``MCAP`` value on the
+``SampleType`` enum. Rows hold seek keys into an ``.mcap`` file (channel id + log
+time), not payload bytes; camera vs. lidar is the ``mcap_data_type`` column.
+
+Revision ID: af51a31f2cd3
+Revises: e5f6a7b8c9d0
+Create Date: 2026-08-28 16:48:57.097750
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from alembic_postgresql_enum import TableReference
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "af51a31f2cd3"
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    sa.Enum("IMAGE", "POINT_CLOUD", name="mcapdatatype").create(op.get_bind())
+    op.create_table(
+        "mcap",
+        sa.Column(
+            "mcap_data_type",
+            postgresql.ENUM("IMAGE", "POINT_CLOUD", name="mcapdatatype", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("channel_id", sa.Integer(), nullable=False),
+        sa.Column("log_time_ns", sa.BigInteger(), nullable=False),
+        sa.Column("capture_timestamp_ns", sa.BigInteger(), nullable=False),
+        sa.Column("keyframe_log_time_ns", sa.BigInteger(), nullable=True),
+        sa.Column("point_count", sa.Integer(), nullable=True),
+        sa.Column("sample_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["sample_id"],
+            ["sample.sample_id"],
+        ),
+        sa.PrimaryKeyConstraint("sample_id"),
+    )
+    op.create_index(op.f("ix_mcap_created_at"), "mcap", ["created_at"], unique=False)
+    op.sync_enum_values( # type: ignore[attr-defined]
+        enum_schema="public",
+        enum_name="sampletype",
+        new_values=["VIDEO", "VIDEO_FRAME", "IMAGE", "ANNOTATION", "CAPTION", "GROUP", "MCAP"],
+        affected_columns=[
+            TableReference(
+                table_schema="public", table_name="collection", column_name="sample_type"
+            )
+        ],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.sync_enum_values( # type: ignore[attr-defined]
+        enum_schema="public",
+        enum_name="sampletype",
+        new_values=["VIDEO", "VIDEO_FRAME", "IMAGE", "ANNOTATION", "CAPTION", "GROUP"],
+        affected_columns=[
+            TableReference(
+                table_schema="public", table_name="collection", column_name="sample_type"
+            )
+        ],
+        enum_values_to_rename=[],
+    )
+    op.drop_index(op.f("ix_mcap_created_at"), table_name="mcap")
+    op.drop_table("mcap")
+    sa.Enum("IMAGE", "POINT_CLOUD", name="mcapdatatype").drop(op.get_bind())

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -32,7 +32,6 @@ def upgrade() -> None:
         sa.Column("log_time_ns", sa.BigInteger(), nullable=False),
         sa.Column("capture_timestamp_ns", sa.BigInteger(), nullable=False),
         sa.Column("keyframe_log_time_ns", sa.BigInteger(), nullable=True),
-        sa.Column("point_count", sa.Integer(), nullable=True),
         sa.Column("sample_id", sa.Uuid(), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -58,6 +58,18 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
+    mcap_collections = (
+        op.get_bind()
+        .execute(sa.text("SELECT COUNT(*) FROM collection WHERE sample_type = 'MCAP'"))
+        .scalar()
+    )
+    if mcap_collections:
+        raise RuntimeError(
+            "Cannot remove MCAP from sampletype enum: "
+            f"{mcap_collections} collection(s) still have sample_type = 'MCAP'. "
+            "Remove or remap those collections before downgrading."
+        )
+
     op.sync_enum_values( # type: ignore[attr-defined]
         enum_schema="public",
         enum_name="sampletype",

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -5,7 +5,7 @@ Adds the ``mcap`` locator table (1:1 with ``sample``) and the ``MCAP`` value on 
 time), not payload bytes.
 
 Revision ID: af51a31f2cd3
-Revises: d1e2f3a4b5c6
+Revises: d117a91bf587
 Create Date: 2026-08-28 16:48:57.097750
 
 """
@@ -19,7 +19,7 @@ from alembic_postgresql_enum import TableReference
 
 # revision identifiers, used by Alembic.
 revision: str = "af51a31f2cd3"
-down_revision: Union[str, Sequence[str], None] = "d1e2f3a4b5c6"
+down_revision: Union[str, Sequence[str], None] = "d117a91bf587"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787924937_af51a31f2cd3_add_mcap_table.py
@@ -43,7 +43,7 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("sample_id"),
     )
     op.create_index(op.f("ix_mcap_created_at"), "mcap", ["created_at"], unique=False)
-    op.sync_enum_values( # type: ignore[attr-defined]
+    op.sync_enum_values(  # type: ignore[attr-defined]
         enum_schema="public",
         enum_name="sampletype",
         new_values=["VIDEO", "VIDEO_FRAME", "IMAGE", "ANNOTATION", "CAPTION", "GROUP", "MCAP"],
@@ -70,7 +70,7 @@ def downgrade() -> None:
             "Remove or remap those collections before downgrading."
         )
 
-    op.sync_enum_values( # type: ignore[attr-defined]
+    op.sync_enum_values(  # type: ignore[attr-defined]
         enum_schema="public",
         enum_name="sampletype",
         new_values=["VIDEO", "VIDEO_FRAME", "IMAGE", "ANNOTATION", "CAPTION", "GROUP"],

--- a/lightly_studio/src/lightly_studio/models/collection.py
+++ b/lightly_studio/src/lightly_studio/models/collection.py
@@ -18,6 +18,7 @@ class SampleType(str, Enum):
     ANNOTATION = "annotation"
     CAPTION = "caption"
     GROUP = "group"
+    MCAP = "mcap"
 
 
 class CollectionBase(SQLModel):

--- a/lightly_studio/src/lightly_studio/models/mcap.py
+++ b/lightly_studio/src/lightly_studio/models/mcap.py
@@ -6,11 +6,9 @@ locator fields; no payload bytes, file path, or topic are stored here.
 """
 
 from datetime import datetime, timezone
-from enum import Enum
 from typing import Optional
 from uuid import UUID
 
-from pydantic import model_validator
 from sqlalchemy import BigInteger
 from sqlalchemy.orm import Mapped
 from sqlmodel import Field, Relationship, SQLModel
@@ -19,20 +17,8 @@ from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleTable, SampleView
 
 
-class McapDataType(str, Enum):
-    """Canonical discriminant for the MCAP payload behind a locator row."""
-
-    IMAGE = "image"
-    """foxglove CompressedVideo / camera."""
-    POINT_CLOUD = "point_cloud"
-    """PointCloud2 / lidar."""
-
-
 class McapBase(SQLModel):
     """Base class for the Mcap model."""
-
-    """The MCAP data type (camera vs. lidar) of the referenced channel."""
-    mcap_data_type: McapDataType
 
     """The MCAP channel id, unique within the source bag."""
     channel_id: int
@@ -43,29 +29,15 @@ class McapBase(SQLModel):
     """The sensor/header capture timestamp, in nanoseconds. Used for cross-channel sync."""
     capture_timestamp_ns: int = Field(sa_type=BigInteger)
 
-    """GOP seek time for keyframe-aligned decoding. Required when `mcap_data_type` is IMAGE."""
+    """GOP seek time for keyframe-aligned decoding. Required for camera channels."""
     keyframe_log_time_ns: Optional[int] = Field(default=None, sa_type=BigInteger)
 
-    """Optional point count. Only meaningful when `mcap_data_type` is POINT_CLOUD."""
+    """Optional point count. Only meaningful for lidar channels."""
     point_count: Optional[int] = Field(default=None)
 
 
 class McapCreate(McapBase):
     """Mcap class when inserting."""
-
-    @model_validator(mode="after")
-    def _validate_data_type_fields(self) -> "McapCreate":  # noqa: N804
-        if self.mcap_data_type == McapDataType.IMAGE:
-            if self.keyframe_log_time_ns is None:
-                raise ValueError("keyframe_log_time_ns is required when mcap_data_type is IMAGE")
-            if self.point_count is not None:
-                raise ValueError("point_count must be None when mcap_data_type is IMAGE")
-        elif self.mcap_data_type == McapDataType.POINT_CLOUD:
-            if self.keyframe_log_time_ns is not None:
-                raise ValueError(
-                    "keyframe_log_time_ns must be None when mcap_data_type is POINT_CLOUD"
-                )
-        return self
 
 
 class McapTable(McapBase, table=True):
@@ -85,7 +57,6 @@ class McapView(SQLModel):
 
     type: SampleType = SampleType.MCAP
     sample_id: UUID
-    mcap_data_type: McapDataType
     channel_id: int
     log_time_ns: int
     capture_timestamp_ns: int
@@ -103,7 +74,6 @@ class McapView(SQLModel):
         """
         return cls(
             sample_id=mcap.sample_id,
-            mcap_data_type=mcap.mcap_data_type,
             channel_id=mcap.channel_id,
             log_time_ns=mcap.log_time_ns,
             capture_timestamp_ns=mcap.capture_timestamp_ns,

--- a/lightly_studio/src/lightly_studio/models/mcap.py
+++ b/lightly_studio/src/lightly_studio/models/mcap.py
@@ -1,7 +1,7 @@
 """This module defines the Mcap model for the application.
 
-Stores seek keys into an ``.mcap`` file (channel id + log time, optionally a GOP
-keyframe time for video). Decoding and range requests happen later from these
+Stores seek keys into an ``.mcap`` file (channel id + log time, optionally a
+keyframe log time for video). Decoding and range requests happen later from these
 locator fields; no payload bytes, file path, or topic are stored here.
 """
 
@@ -29,7 +29,7 @@ class McapBase(SQLModel):
     """The sensor/header capture timestamp, in nanoseconds. Used for cross-channel sync."""
     capture_timestamp_ns: int = Field(sa_type=BigInteger)
 
-    """GOP seek time for keyframe-aligned decoding. Required for camera channels."""
+    """Log time of the keyframe to seek to before decoding. Required for camera channels."""
     keyframe_log_time_ns: Optional[int] = Field(default=None, sa_type=BigInteger)
 
     """Optional point count. Only meaningful for lidar channels."""

--- a/lightly_studio/src/lightly_studio/models/mcap.py
+++ b/lightly_studio/src/lightly_studio/models/mcap.py
@@ -32,9 +32,6 @@ class McapBase(SQLModel):
     """Log time of the keyframe to seek to before decoding. Required for camera channels."""
     keyframe_log_time_ns: Optional[int] = Field(default=None, sa_type=BigInteger)
 
-    """Optional point count. Only meaningful for lidar channels."""
-    point_count: Optional[int] = Field(default=None)
-
 
 class McapCreate(McapBase):
     """Mcap class when inserting."""
@@ -61,7 +58,6 @@ class McapView(SQLModel):
     log_time_ns: int
     capture_timestamp_ns: int
     keyframe_log_time_ns: Optional[int] = None
-    point_count: Optional[int] = None
 
     sample: SampleView
 
@@ -78,6 +74,5 @@ class McapView(SQLModel):
             log_time_ns=mcap.log_time_ns,
             capture_timestamp_ns=mcap.capture_timestamp_ns,
             keyframe_log_time_ns=mcap.keyframe_log_time_ns,
-            point_count=mcap.point_count,
             sample=SampleView.model_validate(mcap.sample),
         )

--- a/lightly_studio/src/lightly_studio/models/mcap.py
+++ b/lightly_studio/src/lightly_studio/models/mcap.py
@@ -1,0 +1,113 @@
+"""This module defines the Mcap model for the application.
+
+Stores seek keys into an ``.mcap`` file (channel id + log time, optionally a GOP
+keyframe time for video). Decoding and range requests happen later from these
+locator fields; no payload bytes, file path, or topic are stored here.
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+
+from pydantic import model_validator
+from sqlalchemy import BigInteger
+from sqlalchemy.orm import Mapped
+from sqlmodel import Field, Relationship, SQLModel
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable, SampleView
+
+
+class McapDataType(str, Enum):
+    """Canonical discriminant for the MCAP payload behind a locator row."""
+
+    IMAGE = "image"
+    """foxglove CompressedVideo / camera."""
+    POINT_CLOUD = "point_cloud"
+    """PointCloud2 / lidar."""
+
+
+class McapBase(SQLModel):
+    """Base class for the Mcap model."""
+
+    """The MCAP data type (camera vs. lidar) of the referenced channel."""
+    mcap_data_type: McapDataType
+
+    """The MCAP channel id, unique within the source bag."""
+    channel_id: int
+
+    """The MCAP log time, in nanoseconds."""
+    log_time_ns: int = Field(sa_type=BigInteger)
+
+    """The sensor/header capture timestamp, in nanoseconds. Used for cross-channel sync."""
+    capture_timestamp_ns: int = Field(sa_type=BigInteger)
+
+    """GOP seek time for keyframe-aligned decoding. Required when `mcap_data_type` is IMAGE."""
+    keyframe_log_time_ns: Optional[int] = Field(default=None, sa_type=BigInteger)
+
+    """Optional point count. Only meaningful when `mcap_data_type` is POINT_CLOUD."""
+    point_count: Optional[int] = Field(default=None)
+
+
+class McapCreate(McapBase):
+    """Mcap class when inserting."""
+
+    @model_validator(mode="after")
+    def _validate_data_type_fields(self) -> "McapCreate":  # noqa: N804
+        if self.mcap_data_type == McapDataType.IMAGE:
+            if self.keyframe_log_time_ns is None:
+                raise ValueError("keyframe_log_time_ns is required when mcap_data_type is IMAGE")
+            if self.point_count is not None:
+                raise ValueError("point_count must be None when mcap_data_type is IMAGE")
+        elif self.mcap_data_type == McapDataType.POINT_CLOUD:
+            if self.keyframe_log_time_ns is not None:
+                raise ValueError(
+                    "keyframe_log_time_ns must be None when mcap_data_type is POINT_CLOUD"
+                )
+        return self
+
+
+class McapTable(McapBase, table=True):
+    """This class defines the Mcap model."""
+
+    __tablename__ = "mcap"
+    sample_id: UUID = Field(foreign_key="sample.sample_id", primary_key=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), index=True)
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+    sample: Mapped["SampleTable"] = Relationship()
+
+
+class McapView(SQLModel):
+    """Mcap class when retrieving."""
+
+    type: SampleType = SampleType.MCAP
+    sample_id: UUID
+    mcap_data_type: McapDataType
+    channel_id: int
+    log_time_ns: int
+    capture_timestamp_ns: int
+    keyframe_log_time_ns: Optional[int] = None
+    point_count: Optional[int] = None
+
+    sample: SampleView
+
+    @classmethod
+    def from_mcap_table(cls, mcap: "McapTable") -> "McapView":
+        """Convert a McapTable to a McapView.
+
+        Args:
+            mcap: The mcap row to convert.
+        """
+        return cls(
+            sample_id=mcap.sample_id,
+            mcap_data_type=mcap.mcap_data_type,
+            channel_id=mcap.channel_id,
+            log_time_ns=mcap.log_time_ns,
+            capture_timestamp_ns=mcap.capture_timestamp_ns,
+            keyframe_log_time_ns=mcap.keyframe_log_time_ns,
+            point_count=mcap.point_count,
+            sample=SampleView.model_validate(mcap.sample),
+        )

--- a/lightly_studio/src/lightly_studio/plugins/operator_context.py
+++ b/lightly_studio/src/lightly_studio/plugins/operator_context.py
@@ -76,6 +76,9 @@ class OperatorScope(str, Enum):
     CAPTION = "caption"
     """Operate on captions."""
 
+    MCAP = "mcap"
+    """Operate on MCAP samples."""
+
 
 def get_allowed_scopes_for_collection(
     sample_type: SampleType, is_root_collection: bool

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -56,6 +56,7 @@ from lightly_studio.models.group_component_definition import (
     GroupComponentDefinitionTable,
 )
 from lightly_studio.models.image import ImageTable
+from lightly_studio.models.mcap import McapTable
 from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
@@ -126,6 +127,7 @@ def deep_copy(
     _copy_evaluation_runs(session=session, new_dataset_id=new_dataset_id, now=now)
 
     _copy_images(session=session, now=now)
+    _copy_mcaps(session=session, now=now)
     _copy_videos(session=session)
     _copy_video_frames(session=session)
     _copy_groups(session=session)
@@ -506,6 +508,25 @@ def _copy_images(session: Session, now: datetime) -> None:
     _copy_table(
         session=session,
         target=ImageTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_mcaps(session: Session, now: datetime) -> None:
+    """Copy mcap rows, remapping sample_id."""
+    src = _table(McapTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "created_at": literal(now),
+        "updated_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=McapTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -48,6 +48,7 @@ from lightly_studio.models.group_component_definition import (
     GroupComponentDefinitionTable,
 )
 from lightly_studio.models.image import ImageTable
+from lightly_studio.models.mcap import McapTable
 from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
@@ -118,6 +119,7 @@ def delete_dataset(
     _delete_groups(session=session, dataset_id=dataset_id)
     _delete_videos(session=session, dataset_id=dataset_id)
     _delete_images(session=session, dataset_id=dataset_id)
+    _delete_mcaps(session=session, dataset_id=dataset_id)
 
     # 5. Samples and collection/dataset-scoped entities.
     _delete_samples(session=session, dataset_id=dataset_id)
@@ -295,6 +297,14 @@ def _delete_images(session: Session, dataset_id: UUID) -> None:
     """Delete images for the dataset's samples."""
     session.exec(
         delete(ImageTable).where(col(ImageTable.sample_id).in_(_sample_ids_subquery(dataset_id))),
+        execution_options=_DELETE_EXECUTION_OPTIONS,
+    )
+
+
+def _delete_mcaps(session: Session, dataset_id: UUID) -> None:
+    """Delete mcap rows for the dataset's samples."""
+    session.exec(
+        delete(McapTable).where(col(McapTable.sample_id).in_(_sample_ids_subquery(dataset_id))),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,7 +11,7 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
-_HANDLED_TABLES_COUNT = 27
+_HANDLED_TABLES_COUNT = 28
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)

--- a/lightly_studio/tests/models/test_mcap.py
+++ b/lightly_studio/tests/models/test_mcap.py
@@ -1,27 +1,61 @@
 """Tests for the Mcap model."""
 
-from lightly_studio.models.mcap import McapCreate
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.mcap import McapTable, McapView
+from lightly_studio.models.sample import SampleTable
+from tests.helpers_resolvers import create_collection
 
 
-class TestMcapCreate:
-    """Tests for the McapCreate model."""
+class TestMcapView:
+    """Tests for the McapView model."""
 
-    def test_image__valid(self) -> None:
-        """A well-formed camera locator passes validation."""
-        mcap = McapCreate(
+    def test_from_mcap_table__camera(self, db_session: Session) -> None:
+        """Conversion includes the keyframe log time for a camera channel."""
+        collection = create_collection(session=db_session, sample_type=SampleType.MCAP)
+        sample = SampleTable(collection_id=collection.collection_id)
+        db_session.add(sample)
+        db_session.commit()
+
+        mcap = McapTable(
+            sample_id=sample.sample_id,
             channel_id=3,
             log_time_ns=100,
-            capture_timestamp_ns=100,
+            capture_timestamp_ns=95,
             keyframe_log_time_ns=90,
         )
-        assert mcap.keyframe_log_time_ns == 90
+        db_session.add(mcap)
+        db_session.commit()
+        db_session.refresh(mcap)
 
-    def test_point_cloud__valid(self) -> None:
-        """A well-formed lidar locator passes validation."""
-        mcap = McapCreate(
+        mcap_view = McapView.from_mcap_table(mcap=mcap)
+
+        assert mcap_view.sample_id == sample.sample_id
+        assert mcap_view.channel_id == 3
+        assert mcap_view.log_time_ns == 100
+        assert mcap_view.capture_timestamp_ns == 95
+        assert mcap_view.keyframe_log_time_ns == 90
+        assert mcap_view.sample.sample_id == sample.sample_id
+
+    def test_from_mcap_table__point_cloud(self, db_session: Session) -> None:
+        """Conversion leaves the keyframe log time unset for a lidar channel."""
+        collection = create_collection(session=db_session, sample_type=SampleType.MCAP)
+        sample = SampleTable(collection_id=collection.collection_id)
+        db_session.add(sample)
+        db_session.commit()
+
+        mcap = McapTable(
+            sample_id=sample.sample_id,
             channel_id=5,
             log_time_ns=100,
             capture_timestamp_ns=100,
-            point_count=11000,
         )
-        assert mcap.point_count == 11000
+        db_session.add(mcap)
+        db_session.commit()
+        db_session.refresh(mcap)
+
+        mcap_view = McapView.from_mcap_table(mcap=mcap)
+
+        assert mcap_view.channel_id == 5
+        assert mcap_view.keyframe_log_time_ns is None

--- a/lightly_studio/tests/models/test_mcap.py
+++ b/lightly_studio/tests/models/test_mcap.py
@@ -1,39 +1,14 @@
 """Tests for the Mcap model."""
 
-import pytest
-
-from lightly_studio.models.mcap import McapCreate, McapDataType
+from lightly_studio.models.mcap import McapCreate
 
 
 class TestMcapCreate:
     """Tests for the McapCreate model."""
 
-    def test_image__requires_keyframe_log_time_ns(self) -> None:
-        """IMAGE locators must carry a GOP seek time."""
-        with pytest.raises(ValueError, match="keyframe_log_time_ns is required"):
-            McapCreate(
-                mcap_data_type=McapDataType.IMAGE,
-                channel_id=3,
-                log_time_ns=100,
-                capture_timestamp_ns=100,
-            )
-
-    def test_image__rejects_point_count(self) -> None:
-        """IMAGE locators must not carry a point count."""
-        with pytest.raises(ValueError, match="point_count must be None"):
-            McapCreate(
-                mcap_data_type=McapDataType.IMAGE,
-                channel_id=3,
-                log_time_ns=100,
-                capture_timestamp_ns=100,
-                keyframe_log_time_ns=90,
-                point_count=11000,
-            )
-
     def test_image__valid(self) -> None:
-        """A well-formed IMAGE locator passes validation."""
+        """A well-formed camera locator passes validation."""
         mcap = McapCreate(
-            mcap_data_type=McapDataType.IMAGE,
             channel_id=3,
             log_time_ns=100,
             capture_timestamp_ns=100,
@@ -41,21 +16,9 @@ class TestMcapCreate:
         )
         assert mcap.keyframe_log_time_ns == 90
 
-    def test_point_cloud__rejects_keyframe_log_time_ns(self) -> None:
-        """POINT_CLOUD locators have no GOP to seek, so no keyframe time."""
-        with pytest.raises(ValueError, match="keyframe_log_time_ns must be None"):
-            McapCreate(
-                mcap_data_type=McapDataType.POINT_CLOUD,
-                channel_id=5,
-                log_time_ns=100,
-                capture_timestamp_ns=100,
-                keyframe_log_time_ns=90,
-            )
-
     def test_point_cloud__valid(self) -> None:
-        """A well-formed POINT_CLOUD locator passes validation."""
+        """A well-formed lidar locator passes validation."""
         mcap = McapCreate(
-            mcap_data_type=McapDataType.POINT_CLOUD,
             channel_id=5,
             log_time_ns=100,
             capture_timestamp_ns=100,

--- a/lightly_studio/tests/models/test_mcap.py
+++ b/lightly_studio/tests/models/test_mcap.py
@@ -1,0 +1,64 @@
+"""Tests for the Mcap model."""
+
+import pytest
+
+from lightly_studio.models.mcap import McapCreate, McapDataType
+
+
+class TestMcapCreate:
+    """Tests for the McapCreate model."""
+
+    def test_image__requires_keyframe_log_time_ns(self) -> None:
+        """IMAGE locators must carry a GOP seek time."""
+        with pytest.raises(ValueError, match="keyframe_log_time_ns is required"):
+            McapCreate(
+                mcap_data_type=McapDataType.IMAGE,
+                channel_id=3,
+                log_time_ns=100,
+                capture_timestamp_ns=100,
+            )
+
+    def test_image__rejects_point_count(self) -> None:
+        """IMAGE locators must not carry a point count."""
+        with pytest.raises(ValueError, match="point_count must be None"):
+            McapCreate(
+                mcap_data_type=McapDataType.IMAGE,
+                channel_id=3,
+                log_time_ns=100,
+                capture_timestamp_ns=100,
+                keyframe_log_time_ns=90,
+                point_count=11000,
+            )
+
+    def test_image__valid(self) -> None:
+        """A well-formed IMAGE locator passes validation."""
+        mcap = McapCreate(
+            mcap_data_type=McapDataType.IMAGE,
+            channel_id=3,
+            log_time_ns=100,
+            capture_timestamp_ns=100,
+            keyframe_log_time_ns=90,
+        )
+        assert mcap.keyframe_log_time_ns == 90
+
+    def test_point_cloud__rejects_keyframe_log_time_ns(self) -> None:
+        """POINT_CLOUD locators have no GOP to seek, so no keyframe time."""
+        with pytest.raises(ValueError, match="keyframe_log_time_ns must be None"):
+            McapCreate(
+                mcap_data_type=McapDataType.POINT_CLOUD,
+                channel_id=5,
+                log_time_ns=100,
+                capture_timestamp_ns=100,
+                keyframe_log_time_ns=90,
+            )
+
+    def test_point_cloud__valid(self) -> None:
+        """A well-formed POINT_CLOUD locator passes validation."""
+        mcap = McapCreate(
+            mcap_data_type=McapDataType.POINT_CLOUD,
+            channel_id=5,
+            log_time_ns=100,
+            capture_timestamp_ns=100,
+            point_count=11000,
+        )
+        assert mcap.point_count == 11000

--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.test.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.test.ts
@@ -28,8 +28,14 @@ describe('getMenuItem', () => {
         [SampleType.GROUP, 'Groups', 'group-col-id']
     ] as const)('%s returns correct title, and id', (sampleType, expectedTitle, expectedId) => {
         const item = getMenuItem('dataset-id', undefined, 'col-id', sampleType);
+        if (!item) throw new Error('expected a menu item');
         expect(item.title).toBe(expectedTitle);
         expect(item.id).toBe(expectedId);
+    });
+
+    it('returns null for sample types without a dedicated view', () => {
+        const item = getMenuItem('dataset-id', undefined, 'col-id', SampleType.MCAP);
+        expect(item).toBeNull();
     });
 
     it('uses groupComponentName as title when provided', () => {
@@ -40,6 +46,7 @@ describe('getMenuItem', () => {
             SampleType.IMAGE,
             'Group Component Name'
         );
+        if (!item) throw new Error('expected a menu item');
         expect(item.title).toBe('Group Component Name');
     });
 
@@ -51,18 +58,21 @@ describe('getMenuItem', () => {
             SampleType.ANNOTATION,
             'ground_truth'
         );
+        if (!item) throw new Error('expected a menu item');
         expect(item.title).toBe('Annotations: ground_truth');
     });
 
     it('sets isSelected when collectionId matches currentCollectionId', () => {
         const selected = getMenuItem('dataset-id', 'col-id', 'col-id', SampleType.IMAGE);
         const notSelected = getMenuItem('dataset-id', 'other-col-id', 'col-id', SampleType.IMAGE);
+        if (!selected || !notSelected) throw new Error('expected a menu item');
         expect(selected.isSelected).toBe(true);
         expect(notSelected.isSelected).toBe(false);
     });
 
     it('generates correct href', () => {
         const item = getMenuItem('dataset-id', 'current-col-id', 'col-id', SampleType.IMAGE);
+        if (!item) throw new Error('expected a menu item');
         expect(item.href).toBe('/datasets/dataset-id/image/col-id/images');
     });
 });
@@ -110,6 +120,16 @@ describe('buildBreadcrumbLevels', () => {
         expect(levels[0].selected.id).toBe('image-root');
         expect(levels[0].siblings).toHaveLength(1);
         expect(levels[0].siblings[0].id).toBe('image-root');
+    });
+
+    it('excludes MCAP siblings, which have no dedicated view', () => {
+        const child1 = makeCollection('child-1', SampleType.VIDEO);
+        const child2 = makeCollection('child-2', SampleType.MCAP);
+        const root = makeCollection('root', SampleType.IMAGE, [child1, child2]);
+
+        const levels = buildBreadcrumbLevels([root, child1], root, 'child-1', 'dataset-id');
+
+        expect(levels[1].siblings.map((s) => s.id)).toEqual(['video-child-1']);
     });
 
     it('returns two levels for root > child path', () => {

--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
@@ -4,13 +4,17 @@ import { routeHelpers } from '$lib/routes';
 import { Image, WholeWord, Video, Frame, ComponentIcon, LayoutDashboard } from '@lucide/svelte';
 import type { BreadcrumbLevel, NavigationMenuItem } from './types';
 
+/**
+ * Builds the nav menu item for a collection, or null if the sample type has no
+ * dedicated view to navigate to (e.g. MCAP, which is locator-only for now).
+ */
 export function getMenuItem(
     datasetId: string,
     currentCollectionId: string | undefined,
     collectionId: string,
     sampleType: SampleType,
     groupComponentName?: string | null
-): NavigationMenuItem {
+): NavigationMenuItem | null {
     const collectionType = sampleType.toLowerCase();
     const isSelected = collectionId === currentCollectionId;
     const elementId = `${collectionType}-${collectionId}`;
@@ -64,6 +68,8 @@ export function getMenuItem(
                 isSelected,
                 icon: LayoutDashboard
             };
+        case SampleType.MCAP:
+            return null;
     }
 }
 
@@ -123,7 +129,7 @@ export function buildBreadcrumbLevels(
     const hasSeveralAnnotationCollections = rootCollection.children
         ? rootCollection.children.filter((c) => c.sample_type === SampleType.ANNOTATION).length > 1
         : false;
-    const toMenuItem = (c: CollectionView): NavigationMenuItem =>
+    const toMenuItem = (c: CollectionView): NavigationMenuItem | null =>
         getMenuItem(
             datasetId,
             currentCollectionId,
@@ -134,13 +140,23 @@ export function buildBreadcrumbLevels(
                 ? c.name
                 : c.group_component_definition?.group_component_name
         );
+    const isNavigationMenuItem = (item: NavigationMenuItem | null): item is NavigationMenuItem =>
+        item !== null;
 
-    return ancestorPath.map((node, index) => {
-        const siblings = index === 0 ? [rootCollection] : (ancestorPath[index - 1].children ?? []);
+    return ancestorPath
+        .map((node, index) => {
+            const selected = toMenuItem(node);
+            if (!selected) return null;
 
-        return {
-            selected: toMenuItem(node),
-            siblings: siblings.map((sibling) => toMenuItem(sibling))
-        };
-    });
+            const siblings =
+                index === 0 ? [rootCollection] : (ancestorPath[index - 1].children ?? []);
+
+            return {
+                selected,
+                siblings: siblings
+                    .map((sibling) => toMenuItem(sibling))
+                    .filter(isNavigationMenuItem)
+            };
+        })
+        .filter((level): level is BreadcrumbLevel => level !== null);
 }

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+page.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+page.ts
@@ -3,9 +3,8 @@ import { SampleType } from '$lib/api/lightly_studio_local';
 import { routeHelpers } from '$lib/routes';
 import type { PageLoad } from './$types';
 
-const sampleTypeRoutes: Record<
-    SampleType,
-    (datasetId: string, collectionType: string, collectionId: string) => string
+const sampleTypeRoutes: Partial<
+    Record<SampleType, (datasetId: string, collectionType: string, collectionId: string) => string>
 > = {
     [SampleType.VIDEO]: routeHelpers.toVideos,
     [SampleType.VIDEO_FRAME]: routeHelpers.toFrames,


### PR DESCRIPTION
## What has changed and why?

Added MCAP model that will hold locator rows that point into an .mcap file (channel_id + log_time_ns). No data (image, point cloud) will be stored, decoding will happen later using this fields.

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCAP as a supported collection sample type.
  * Added storage and retrieval of MCAP metadata, including channel IDs, timestamps, keyframe information, and point counts.
  * Added MCAP support to operator scopes.
* **Improvements**
  * Simplified MCAP metadata handling by removing restrictive channel-type requirements.
  * Added MCAP support when copying or deleting datasets.
  * Improved navigation and breadcrumb handling for unsupported sample types.
  * Added safeguards when removing MCAP support from collections containing MCAP samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->