### PR TITLE
Cover every e2e input in the skip hash

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -19,10 +19,8 @@ env:
   E2E_BASE_URL: http://localhost:8001
 
 jobs:
-  # Drives the skipping: every matrix job below looks up
-  # `e2e-success-<name>-<file-hash>` and skips all of its steps on a hit. So the
-  # hash must cover every input the run depends on - miss one, and a commit that
-  # changes it reports green without running the tests.
+  # Matrix jobs skip every step when `e2e-success-<name>-<file-hash>` is cached,
+  # so the hash has to cover every input the run depends on.
   prepare-caches:
     name: Build Cache and Skip Steps
     runs-on: ubuntu-latest

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -19,8 +19,12 @@ env:
   E2E_BASE_URL: http://localhost:8001
 
 jobs:
+  # Drives the skipping: every matrix job below looks up
+  # `e2e-success-<name>-<file-hash>` and skips all of its steps on a hit. So the
+  # hash must cover every input the run depends on - miss one, and a commit that
+  # changes it reports green without running the tests.
   prepare-caches:
-    name: Build Cache
+    name: Build Cache and Skip Steps
     runs-on: ubuntu-latest
     # Recent runs: 3.5min median, 10min worst.
     timeout-minutes: 15
@@ -37,15 +41,29 @@ jobs:
         run: >-
           echo "hash=${{ hashFiles(
             '.github/workflows/end2end_test.yml',
+            'Makefile',
             'lightly_studio/e2e-tests/**/*',
             'lightly_studio/src/**/*',
             'lightly_studio/pyproject.toml',
+            'lightly_studio/uv.lock',
+            'lightly_studio/Makefile',
+            'lightly_studio/alembic.ini',
             'lightly_studio_view/e2e/**/*',
             'lightly_studio_view/src/**/*',
             'lightly_studio_view/public/**/*',
+            'lightly_studio_view/static/**/*',
             'lightly_studio_view/package.json',
             'lightly_studio_view/package-lock.json',
-            'lightly_studio_view/vite.config.ts'
+            'lightly_studio_view/vite.config.ts',
+            'lightly_studio_view/svelte.config.js',
+            'lightly_studio_view/tailwind.config.ts',
+            'lightly_studio_view/postcss.config.js',
+            'lightly_studio_view/tsconfig.json',
+            'lightly_studio_view/playwright.config.ts',
+            'lightly_studio_view/langium-config.json',
+            'lightly_studio_view/openapi-ts.config.ts',
+            'lightly_studio_view/Makefile',
+            'lightly_studio_view/.nvmrc'
           ) }}" >> $GITHUB_OUTPUT
 
       - name: Cache build


### PR DESCRIPTION
## What has changed and why?

Follow-up to #2131, which I closed: the skip mechanism exists, it just does not cover all of its
inputs.

Matrix jobs skip every step when `e2e-success-<name>-<file-hash>` is cached, so `file-hash`
defines an unchanged run. It missed `uv.lock` (the versions `install-optional-deps` installs),
`playwright.config.ts` (the test config), `static/**`, `.nvmrc`, the svelte/tailwind/postcss/
tsconfig build configs, `langium-config.json` and `openapi-ts.config.ts` (both read by
`prebuild`), the three `Makefile`s and `alembic.ini`. A commit touching only those kept the hash,
hit the markers - including ones from an earlier commit on the same PR - and e2e reported green
without running. Now hashed.

Also renames the job to `Build Cache and Skip Steps` per @michal-lightly's suggestion.

## How has it been tested?

Confirmed every newly hashed path exists, so no pattern contributes nothing. This PR changes a
hashed file, so its own run must build fresh caches and run the full matrix.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @michal-lightly, whose review on #2131 prompted this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test caching by tracking additional configuration and build files.
  * Enabled more reliable skipping of unchanged test setup steps, helping streamline test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->