### PR TITLE
Save the uv cache only on main

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -19,6 +19,7 @@ env:
   E2E_BASE_URL: http://localhost:8001
   # Every run restores the uv cache, only main writes one: per-ref copies are
   # ~3.4GB each and blew the 10GB quota, evicting the caches the e2e skip needs.
+  # `python-version` is part of the uv cache key: 3.9 shares `unit_test.yml`'s entry.
   UV_SAVE_CACHE: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
@@ -111,6 +112,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
+          python-version: "3.9"
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
 
@@ -331,6 +333,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
+          python-version: "3.9"
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
 

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -17,10 +17,8 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
   DATASET_PATH: $(pwd)/datasets
   E2E_BASE_URL: http://localhost:8001
-  # One shared uv cache on main instead of a ~3.4GB copy per pull request and
-  # merge-queue ref: every run restores main's, only main writes one. Per-ref
-  # copies blew the 10GB repository quota, and the eviction that followed turned
-  # off the e2e skip that depends on cached success markers.
+  # Every run restores the uv cache, only main writes one: per-ref copies are
+  # ~3.4GB each and blew the 10GB quota, evicting the caches the e2e skip needs.
   UV_SAVE_CACHE: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -17,6 +17,11 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
   DATASET_PATH: $(pwd)/datasets
   E2E_BASE_URL: http://localhost:8001
+  # One shared uv cache on main instead of a ~3.4GB copy per pull request and
+  # merge-queue ref: every run restores main's, only main writes one. Per-ref
+  # copies blew the 10GB repository quota, and the eviction that followed turned
+  # off the e2e skip that depends on cached success markers.
+  UV_SAVE_CACHE: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
   prepare-caches:
@@ -93,6 +98,7 @@ jobs:
         with:
           version: "0.12.6"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Set Up Node.js
         uses: actions/setup-node@v6
@@ -312,6 +318,7 @@ jobs:
         with:
           version: "0.12.6"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Set Up Node.js
         if: steps.cache-success.outputs.cache-hit != 'true'

--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -75,6 +75,7 @@ jobs:
           version: "0.12.6"
           python-version: "3.9"
           enable-cache: true
+          save-cache: false
 
       - name: Install backend dependencies
         if: steps.changes.outputs.backend == 'true' || steps.changes.outputs.frontend == 'true'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,6 +10,12 @@ on:
 
 env:
   NODE_OPTIONS: --max-old-space-size=4096
+  # One shared uv cache on main instead of a ~3.4GB copy per pull request and
+  # merge-queue ref: every run restores main's, only main writes one. Per-ref
+  # copies blew the 10GB repository quota, and the eviction that followed turned
+  # off the e2e skip that depends on cached success markers.
+  UV_SAVE_CACHE: ${{ github.ref == 'refs/heads/main' }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -83,6 +89,7 @@ jobs:
         with:
           version: "0.12.6"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Set Up Python
         uses: actions/setup-python@v6
@@ -120,6 +127,7 @@ jobs:
           version: "0.12.6"
           python-version: "3.9"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio
@@ -171,6 +179,7 @@ jobs:
         with:
           version: "0.12.6"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Set Up Python
         uses: actions/setup-python@v6
@@ -221,6 +230,7 @@ jobs:
           version: "0.12.6"
           python-version: "3.9"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio
@@ -260,6 +270,7 @@ jobs:
         with:
           version: "0.12.6"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Set Up Python
         uses: actions/setup-python@v6
@@ -329,6 +340,7 @@ jobs:
         with:
           version: "0.12.6"
           enable-cache: true
+          save-cache: ${{ env.UV_SAVE_CACHE }}
 
       - name: Static checks
         run: make static-checks

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,6 +12,8 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
   # Every run restores the uv cache, only main writes one: per-ref copies are
   # ~3.4GB each and blew the 10GB quota, evicting the caches the e2e skip needs.
+  # The Python version is part of the uv cache key, so each step passes the one its job runs:
+  # the 3.9 jobs share an entry instead of the release-tooling key, whose deps are ~30MB.
   UV_SAVE_CACHE: ${{ github.ref == 'refs/heads/main' }}
 
 concurrency:
@@ -86,6 +88,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
+          python-version: "3.9"
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
 
@@ -176,6 +179,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
+          python-version: ${{ matrix.python }}
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
 
@@ -267,6 +271,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
+          python-version: "3.9"
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,10 +10,8 @@ on:
 
 env:
   NODE_OPTIONS: --max-old-space-size=4096
-  # One shared uv cache on main instead of a ~3.4GB copy per pull request and
-  # merge-queue ref: every run restores main's, only main writes one. Per-ref
-  # copies blew the 10GB repository quota, and the eviction that followed turned
-  # off the e2e skip that depends on cached success markers.
+  # Every run restores the uv cache, only main writes one: per-ref copies are
+  # ~3.4GB each and blew the 10GB quota, evicting the caches the e2e skip needs.
   UV_SAVE_CACHE: ${{ github.ref == 'refs/heads/main' }}
 
 concurrency:


### PR DESCRIPTION
## What has changed and why?

Each uv cache entry is ~3.4GB, and every PR and merge-queue attempt wrote up to three of them.
Repo usage has been running at 47-98GB against a
[10GB quota](https://docs.github.com/en/actions/reference/limits#storage-limits-for-all-github-hosted-runners),
so eviction keeps deleting the caches we actually need - `e2e-success-*` markers are ~180 bytes
each and are the least recently accessed, so they go first. That is why a scripts-only PR ran 8 of
11 e2e jobs in full last week.

Two fixes:

1. **Only main writes.** `setup-uv` takes `save-cache` separately from `restore-cache`, so every
   run restores as before and only main saves. `fast_track_guardrails.yml` gets a plain
   `save-cache: false` - it runs on `pull_request` only, so the expression could never be true.
2. **Every key carries the Python version its job runs.** It is part of the cache key. Six jobs
   left it off, keyed on the runner default, and so shared a key with `Static Checks + Tests
   Release Tooling`, whose deps are ~30MB - they got a "cache hit" that restored 30MB and then
   installed from PyPI anyway.

Main should end up with one ~3.4GB entry for the 3.9 jobs, one for 3.14 and 0.03GB for release
tooling, against 7.9GB in three entries today.

<details>
<summary>Why restores still work without a per-PR copy</summary>

A run can read caches from its own ref, its base branch and the default branch - all `main` here -
so PR and merge-queue runs restore main's entry. The reverse is not true: a PR's cache can only be
read by re-runs of that PR, which is why the per-ref copies were pure waste.
See [the caching docs](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
</details>

<details>
<summary>The one regression: a PR that changes <code>pyproject.toml</code> or <code>uv.lock</code></summary>

It gets no uv cache at all rather than a partial one. The fallback is by scope, not by key:
`setup-uv` passes no `restore-keys` and the dependency hash sits at the end of the key, so a
changed lockfile matches nothing. With no save of its own it re-downloads on every push until the
change lands on main.

Measured at ~10s per job (44s uncached vs 35s cached in `fast_track`), and rare, so this is
accepted rather than worked around.
</details>

<details>
<summary>Measurements behind fix 2</summary>

Every job below logged a cache hit. The six on the runner-default key restored 0.03GB in 2s and
installed from PyPI anyway; only the two that passed `python-version` got the real 3.4GB entry:

```
Backend (3.9, DuckDB)      uv= 2s  install=34s   <- "hit" on the 30MB entry
Build Docs                 uv= 2s  install=39s
Static Checks Python       uv= 2s  install=40s
Backend (3.14, Postgres)   uv= 3s  install=37s
Backend (3.14, DuckDB)     uv= 2s  install=37s
Static Checks Typescript   uv=32s  install= 4s   <- the 3.9 entry, 3.4GB
Frontend Tests             uv=41s  install= 4s
```

`setup-uv` never tops up an existing key, so once release tooling saved first on main the entry
was frozen at 0.03GB. The backend matrix keys per leg and already sets
`UV_PYTHON: ${{ matrix.python }}` on its install step.
</details>

## How has it been tested?

This PR's own runs exercise restore-without-save: all 8 jobs logged
`Cache hit for: setup-uv-...-555a4abd...`, a key that exists only on `refs/heads/main`, and the
PR's ref holds no uv entry.

<details>
<summary>What to check after merge</summary>

`gh cache list --json key,ref` should show `setup-uv-*` only on `refs/heads/main`, with the
runner-default entry written by release tooling alone. Worth a look at the size of the new 3.14
entry: those legs install in ~21s today, so if its cache lands near 3.4GB it costs more to restore
than it saves and they are better off with `enable-cache: false`.

Timings come from runs `33374737866` (this PR) and `33388742321`/`33389325434` (`fast_track` miss
vs hit).
</details>

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @michal-lightly; reviewable on its own.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI dependency caching by sharing the cache from the main branch.
  * Pull-request and merge-queue checks now reuse the shared cache without creating additional copies.
  * Reduced unnecessary cache writes across automated test and validation workflows.
  * Expanded cache tracking to cover additional project configuration and build files, helping checks use up-to-date cached dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

