### PR TITLE
Remove FSC export for LightlyEdge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the LightlyEdge classifier export format. Downloading a classifier no longer asks for a
+  format and always writes the scikit-learn format, which is the only one LightlyStudio can load.
+
 ### Fixed
 
 - Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.

--- a/lightly_studio/src/lightly_studio/api/routes/api/classifier.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/classifier.py
@@ -11,9 +11,6 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from lightly_studio.database.db_manager import SessionDep
-from lightly_studio.few_shot_classifier.classifier import (
-    ExportType,
-)
 from lightly_studio.few_shot_classifier.classifier_manager import (
     ClassifierManagerProvider,
 )
@@ -145,24 +142,16 @@ def drop_temp_classifier(
     classifier_manager.drop_temp_classifier(classifier_id=classifier_id)
 
 
-class SaveClassifierRequest(BaseModel):
-    """Request for saving classifier to a file."""
-
-    file_path: str
-
-
 @classifier_router.post(
-    "/classifiers/{classifier_id}/save_classifier_to_file/{export_type}",
+    "/classifiers/{classifier_id}/save_classifier_to_file",
 )
 def save_classifier_to_file(
     classifier_id: UUID,
-    export_type: ExportType,
 ) -> StreamingResponse:
     """Save the classifier to a file.
 
     Args:
         classifier_id: The ID of the classifier.
-        export_type: The type of export (e.g., "sklearn", "lightly").
 
     Returns:
         StreamingResponse containing the pickled classifier file.
@@ -170,9 +159,7 @@ def save_classifier_to_file(
     classifier_manager = ClassifierManagerProvider.get_classifier_manager()
     # Use BytesIO to capture the file content and send it as a response.
     buffer = io.BytesIO()
-    classifier_manager.save_classifier_to_buffer(
-        classifier_id=classifier_id, buffer=buffer, export_type=export_type
-    )
+    classifier_manager.save_classifier_to_buffer(classifier_id=classifier_id, buffer=buffer)
     buffer.seek(0)
 
     # Get classifier name for the filename

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier.py
@@ -6,11 +6,9 @@ import io
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from lightly_studio.database.db_vector import Embedding
-
-ExportType = Literal["sklearn", "lightly"]
 
 
 @dataclass
@@ -64,7 +62,6 @@ class FewShotClassifier(Protocol):
         self,
         export_path: Path | None,
         buffer: io.BytesIO | None,
-        export_type: ExportType,
     ) -> None:
         """Exports the classifier to a specified file.
 
@@ -76,7 +73,5 @@ class FewShotClassifier(Protocol):
             be saved.
             buffer: An optional in-memory buffer to write the exported
             classifier to.
-            export_type: The type of export format to use. This can be either
-            "sklearn_instance" or "raw".
         """
         ...

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -15,7 +15,6 @@ from sqlmodel import Session
 from lightly_studio.few_shot_classifier import random_forest_classifier
 from lightly_studio.few_shot_classifier.classifier import (
     AnnotatedEmbedding,
-    ExportType,
 )
 from lightly_studio.few_shot_classifier.random_forest_classifier import (
     RandomForest,
@@ -239,7 +238,7 @@ class ClassifierManager:
             raise ValueError(
                 f"Classifier with ID {classifier_id} is not active and cannot be saved."
             )
-        classifier.few_shot_classifier.export(export_path=file_path, export_type="sklearn")
+        classifier.few_shot_classifier.export(export_path=file_path)
 
     def load_classifier_from_file(
         self, session: Session, file_path: Path, collection_id: UUID
@@ -553,15 +552,12 @@ class ClassifierManager:
             class_list=classifier.few_shot_classifier.classes,
         )
 
-    def save_classifier_to_buffer(
-        self, classifier_id: UUID, buffer: io.BytesIO, export_type: ExportType
-    ) -> None:
+    def save_classifier_to_buffer(self, classifier_id: UUID, buffer: io.BytesIO) -> None:
         """Save the classifier to a buffer.
 
         Args:
             classifier_id: The ID of the classifier to save.
             buffer: The buffer to save the classifier to.
-            export_type: The type of export to perform.
 
         Raises:
             ValueError: If the classifier with the given ID does not exist.
@@ -569,7 +565,7 @@ class ClassifierManager:
         classifier = self._classifiers.get(classifier_id)
         if classifier is None:
             raise ValueError(f"Classifier with ID {classifier_id} not found.")
-        classifier.few_shot_classifier.export(buffer=buffer, export_type=export_type)
+        classifier.few_shot_classifier.export(buffer=buffer)
 
     def load_classifier_from_buffer(
         self, session: Session, buffer: io.BytesIO, collection_id: UUID

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/random_forest_classifier.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/random_forest_classifier.py
@@ -14,15 +14,11 @@ import sklearn  # type: ignore[import-untyped]
 from sklearn.ensemble import (  # type: ignore[import-untyped]
     RandomForestClassifier,
 )
-from sklearn.tree import (  # type: ignore[import-untyped]
-    DecisionTreeClassifier,
-)
 from sklearn.utils import validation  # type: ignore[import-untyped]
-from typing_extensions import assert_never
 
 from lightly_studio.database.db_vector import Embedding
 
-from .classifier import AnnotatedEmbedding, ExportType, FewShotClassifier
+from .classifier import AnnotatedEmbedding, FewShotClassifier
 
 # The version of the file format used for exporting and importing classifiers.
 # This is used to ensure compatibility between different versions of the code.
@@ -44,42 +40,6 @@ class ModelExportMetadata:
     embedding_model_hash: str
     embedding_model_name: str
     sklearn_version: str
-
-
-@dataclass
-class InnerNode:
-    """Inner node of a decision tree.
-
-    Defaults are used for tree construction.
-    """
-
-    feature_index: int = 0
-    threshold: float = 0.0
-    left_child: int = 0
-    right_child: int = 0
-
-
-@dataclass
-class LeafNode:
-    """Leaf node of a decision tree."""
-
-    class_probabilities: list[float]
-
-
-@dataclass
-class ExportedTree:
-    """Exported tree structure."""
-
-    inner_nodes: list[InnerNode]
-    leaf_nodes: list[LeafNode]
-
-
-@dataclass
-class RandomForestExport:
-    """Datastructure for exporting the RandomForest model."""
-
-    metadata: ModelExportMetadata
-    trees: list[ExportedTree]
 
 
 class RandomForest(FewShotClassifier):
@@ -190,17 +150,12 @@ class RandomForest(FewShotClassifier):
         self,
         export_path: Path | None = None,
         buffer: io.BytesIO | None = None,
-        export_type: ExportType = "sklearn",
     ) -> None:
         """Exports the classifier to a specified file.
 
         Args:
             export_path: The full file path where the export will be saved.
             buffer: A BytesIO buffer to save the export to.
-            export_type: The type of export. Options are:
-                "sklearn": Exports the RandomForestClassifier instance.
-                "lightly": Exports the model in raw format with metadata
-                and tree details.
         """
         metadata = ModelExportMetadata(
             name=self.name,
@@ -215,38 +170,17 @@ class RandomForest(FewShotClassifier):
             sklearn_version=sklearn.__version__,
         )
 
-        if export_type == "sklearn":
-            # Combine the model and metadata into a single dictionary
-            export_data = {
-                "model": self._model,
-                "metadata": metadata,
-            }
+        export_data = {
+            "model": self._model,
+            "metadata": metadata,
+        }
 
-            if buffer is not None:
-                pickle.dump(export_data, buffer)
-            elif export_path is not None:
-                # Save to the specified file path.
-                # Ensure parent dirs exist.
-                export_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(export_path, "wb") as f:
-                    pickle.dump(export_data, f)
-
-        elif export_type == "lightly":
-            export_data_raw = _export_random_forest_model(
-                model=self._model,
-                metadata=metadata,
-                all_classes=self.classes,
-            )
-            if buffer is not None:
-                pickle.dump(export_data_raw, buffer)
-            elif export_path is not None:
-                # Save to the specified file path.
-                # Ensure parent dirs exist.
-                export_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(export_path, "wb") as f:
-                    pickle.dump(export_data_raw, f)
-        else:
-            assert_never(export_type)
+        if buffer is not None:
+            pickle.dump(export_data, buffer)
+        elif export_path is not None:
+            export_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(export_path, "wb") as f:
+                pickle.dump(export_data, f)
 
     def is_trained(self) -> bool:
         """Checks if the classifier is trained.
@@ -314,184 +248,3 @@ def load_random_forest_classifier(
     # Set the model.
     instance._model = model  # noqa: SLF001
     return instance
-
-
-def _export_random_forest_model(
-    model: RandomForestClassifier,
-    metadata: ModelExportMetadata,
-    all_classes: list[str],
-) -> RandomForestExport:
-    """Converts a sk-learn RandomForestClassifier to RandomForestExport format.
-
-    Args:
-        model: The trained random forest model to export.
-        metadata: Metadata describing the collection and training setup.
-        all_classes: Full list of all class labels.
-
-    Returns:
-        RandomForestExport: The serialized export object containing all trees
-            and metadata.
-    """
-    trained_classes: list[int] = model.classes_
-    trees = [_export_single_tree(tree, trained_classes, all_classes) for tree in model.estimators_]
-    return RandomForestExport(metadata=metadata, trees=trees)
-
-
-def load_lightly_random_forest(path: Path | None, buffer: io.BytesIO | None) -> RandomForestExport:
-    """Loads a Lightly exported RandomForest model from a file or buffer.
-
-    Args:
-        path: The path to the exported classifier file.
-        buffer: A BytesIO buffer containing the exported classifier.
-    If both path and buffer are provided, the path will be used.
-
-    Returns:
-        A RandomForestExport instance.
-
-    Raises:
-        ValueError: If the file is not a valid RandomForestExport or
-                if the version/format mismatches.
-    """
-    if path is not None:
-        with open(path, "rb") as f:
-            data = pickle.load(f)
-    elif buffer is not None:
-        data = pickle.load(buffer)
-
-    if not isinstance(data, RandomForestExport):
-        raise ValueError("Loaded object is not a RandomForestExport instance.")
-
-    if data.metadata.file_format_version != FILE_FORMAT_VERSION:
-        raise ValueError(
-            f"File format version mismatch. Expected '{FILE_FORMAT_VERSION}', "
-            f"got '{data.metadata.file_format_version}'."
-        )
-    return data
-
-
-def predict_with_lightly_random_forest(
-    model: RandomForestExport, embeddings: Sequence[Embedding]
-) -> list[list[float]]:
-    """Predicts the classification scores for a list of embeddings.
-
-    Args:
-        model: A RandomForestExport instance containing the model and metadata.
-        embeddings: A list of embeddings.
-
-    Returns:
-        A list of lists, where each inner list represents the probability
-            distribution over classes for the corresponding input embedding.
-
-    Raises:
-        ValueError: If the provided embeddings have different size than
-            expected.
-    """
-    expected_dim = model.metadata.num_input_features
-    all_probs: list[list[float]] = []
-
-    for embedding in embeddings:
-        if len(embedding) != expected_dim:
-            raise ValueError(
-                f"Embedding has wrong dimensionality: expected {expected_dim},got {len(embedding)}"
-            )
-
-        tree_probs: list[list[float]] = [
-            _predict_tree_probs(tree, embedding) for tree in model.trees
-        ]
-
-        mean_probs = np.mean(tree_probs, axis=0).tolist()
-        all_probs.append(mean_probs)
-
-    return all_probs
-
-
-def _export_single_tree(
-    tree: DecisionTreeClassifier,
-    trained_classes: list[int],
-    all_classes: list[str],
-) -> ExportedTree:
-    """Converts a single sk-learn tree into a serializable ExportedTree format.
-
-    Args:
-        tree: The decision tree to convert.
-        trained_classes: Indices of the classes the tree was trained on.
-        all_classes: Full list of all class labels.
-
-    Returns:
-        ExportedTree: A representation of the tree with explicit node and leaf
-                    structures, compatible with the Lightly format.
-    """
-    tree_structure = tree.tree_
-    inner_nodes: list[InnerNode] = []
-    leaf_nodes: list[LeafNode] = []
-    node_map = {}  # Maps node_id to (mapped_index, is_leaf)
-
-    for node_id in range(tree_structure.node_count):
-        is_leaf = tree_structure.children_left[node_id] == tree_structure.children_right[node_id]
-        if is_leaf:
-            leaf_idx = len(leaf_nodes)
-            # value[node_id] is a 2D array of shape [1, n_classes].
-            # [0] is used to extract the inner array and
-            # convert it to a 1D array of class counts.
-            class_weights = tree_structure.value[node_id][0]
-            total = sum(class_weights)
-            probs = (class_weights / total).tolist() if total > 0 else [0.0] * len(class_weights)
-
-            # Order probabilities according to the initial classes.
-            # Initialize zeros for all possible classes.
-            full_probs = [0.0 for _ in range(len(all_classes))]
-            # Map probabilities to their correct positions.
-            for trained_class, prob in zip(trained_classes, probs):
-                full_probs[trained_class] = prob
-
-            leaf_nodes.append(LeafNode(class_probabilities=full_probs))
-            node_map[node_id] = (-leaf_idx - 1, True)
-        else:
-            inner_idx = len(inner_nodes)
-            node_map[node_id] = (inner_idx, False)
-            # Reserve a spot for the inner node.
-            inner_nodes.append(InnerNode())
-
-    # Now populate inner_nodes using mapped indices.
-    for node_id in range(tree_structure.node_count):
-        mapped_idx, is_leaf = node_map[node_id]
-        if is_leaf:
-            continue
-
-        left_id = tree_structure.children_left[node_id]
-        right_id = tree_structure.children_right[node_id]
-        left_mapped = node_map[left_id][0]
-        right_mapped = node_map[right_id][0]
-
-        inner_nodes[mapped_idx] = InnerNode(
-            feature_index=int(tree_structure.feature[node_id]),
-            threshold=float(tree_structure.threshold[node_id]),
-            left_child=left_mapped,
-            right_child=right_mapped,
-        )
-
-    return ExportedTree(inner_nodes=inner_nodes, leaf_nodes=leaf_nodes)
-
-
-def _predict_tree_probs(tree: ExportedTree, embedding: Embedding) -> list[float]:
-    """Predicts class probabilities for an embedding using a single tree.
-
-    Args:
-        tree: A ExportedTree instance used to determine the probability.
-        embedding: A single embedding.
-
-    """
-    if not tree.inner_nodes:
-        return tree.leaf_nodes[0].class_probabilities
-
-    node_idx = 0  # Start at root
-    while node_idx >= 0:
-        node = tree.inner_nodes[node_idx]
-        if embedding[node.feature_index] <= node.threshold:
-            node_idx = node.left_child
-        else:
-            node_idx = node.right_child
-
-    leaf_idx = -node_idx - 1
-    leaf = tree.leaf_nodes[leaf_idx]
-    return leaf.class_probabilities

--- a/lightly_studio/tests/api/routes/api/test_classifier.py
+++ b/lightly_studio/tests/api/routes/api/test_classifier.py
@@ -10,9 +10,6 @@ from pytest_mock import MockerFixture
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_OK,
 )
-from lightly_studio.few_shot_classifier.classifier import (
-    ExportType,
-)
 from lightly_studio.few_shot_classifier.classifier_manager import (
     ClassifierEntry,
     ClassifierManager,
@@ -175,23 +172,20 @@ def test_save_classifier_to_file(mocker: MockerFixture, test_client: TestClient)
     mock_classifier_manager.get_classifier_by_id.return_value = mock_classifier
 
     # Mock save_classifier_to_buffer to write some test data
-    def mock_save_to_buffer(
-        classifier_id: UUID, buffer: io.BytesIO, export_type: ExportType
-    ) -> None:
-        content = f"test binary data - {classifier_id}.{export_type}"
+    def mock_save_to_buffer(classifier_id: UUID, buffer: io.BytesIO) -> None:
+        content = f"test binary data - {classifier_id}"
         bcontent = content.encode("utf-8")
         buffer.write(bcontent)
 
     mock_classifier_manager.save_classifier_to_buffer.side_effect = mock_save_to_buffer
-    export_type = "lightly"
     # Make the request
-    response = test_client.post(f"/api/classifiers/{mock_id}/save_classifier_to_file/{export_type}")
+    response = test_client.post(f"/api/classifiers/{mock_id}/save_classifier_to_file")
 
     # Assert response
     assert response.status_code == HTTP_STATUS_OK
     assert response.headers["content-type"] == "application/octet-stream"
     assert response.headers["content-disposition"] == 'attachment; filename="classifier1.pkl"'
-    content = f"test binary data - {mock_id}.{export_type}"
+    content = f"test binary data - {mock_id}"
     bcontent = content.encode("utf-8")
     assert response.content == bcontent
 

--- a/lightly_studio/tests/few_shot_classifier/test_random_forest_classifier.py
+++ b/lightly_studio/tests/few_shot_classifier/test_random_forest_classifier.py
@@ -11,9 +11,7 @@ from sklearn.utils import validation  # type: ignore[import-untyped]
 from lightly_studio.few_shot_classifier.classifier import AnnotatedEmbedding
 from lightly_studio.few_shot_classifier.random_forest_classifier import (
     RandomForest,
-    load_lightly_random_forest,
     load_random_forest_classifier,
-    predict_with_lightly_random_forest,
 )
 
 
@@ -272,7 +270,7 @@ class TestRandomForestClassifier:
 
         classifier.train(annotated_embeddings)
         export_path = Path(tmp_path / "test_model_sklearn_instance.pkl")
-        classifier.export(export_path, export_type="sklearn")
+        classifier.export(export_path)
 
         loaded_classifier = load_random_forest_classifier(
             classifier_path=Path(tmp_path / "test_model_sklearn_instance.pkl"),
@@ -286,88 +284,6 @@ class TestRandomForestClassifier:
         predictions_exported_model = loaded_classifier.predict(test_embeddings)
         # Check that the predictions from the 2 classifiers are the same.
         assert predictions == predictions_exported_model
-
-    def test_export__lightly_format_root_is_leaf(self, tmp_path: Path) -> None:
-        """Test the export raw functionality.
-
-        The root becomes a leaf because the training set has only 2 samples.
-        RandomForest uses bootstrapping, so some trees may see only one class
-        and cannot split. In that case, the root node is a leaf that outputs
-        a fixed class probability.
-        """
-        classifier = RandomForest(
-            name="classifier_name",
-            classes=["0", "2", "1"],
-            embedding_model_hash="hash",
-            embedding_model_name="name",
-        )
-        # Step 1: Define embeddings for training
-        annotated_embeddings = [
-            AnnotatedEmbedding(
-                embedding=np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
-                annotation="0",  # Class 0
-            ),
-            AnnotatedEmbedding(
-                embedding=np.array([1.0, 0.9, 0.8, 0.7, 0.6], dtype=np.float32),
-                annotation="1",  # Class 1
-            ),
-        ]
-
-        classifier.train(annotated_embeddings)
-        export_path = Path(tmp_path / "test_model_lightly.pkl")
-        classifier.export(export_path, export_type="lightly")
-
-        test_embeddings = [
-            np.array([0.15, 0.25, 0.35, 0.145, 0.155], dtype=np.float32),
-            np.array([0.9, 0.8, 0.7, 0.6, 0.6], dtype=np.float32),
-        ]
-        exported_classifier = load_lightly_random_forest(path=export_path, buffer=None)
-
-        predictions = classifier.predict(test_embeddings)
-        predictions_exported_model = predict_with_lightly_random_forest(
-            exported_classifier, test_embeddings
-        )
-        assert np.allclose(predictions, predictions_exported_model, atol=1e-8)
-
-    @pytest.mark.skip(reason="Skipped a long running test, lightly format should be removed.")
-    def test_export__lightly_format(self, tmp_path: Path) -> None:
-        """Test the export raw functionality."""
-        n_samples = 1000
-        n_features = 128
-        n_classes = 100
-
-        class_labels = [f"class_{i}" for i in range(n_classes)]
-        rng = np.random.default_rng(seed=42)
-
-        annotated_embeddings = [
-            AnnotatedEmbedding(
-                embedding=rng.random(n_features).tolist(),
-                annotation=str(rng.choice(class_labels)),
-            )
-            for _ in range(n_samples)
-        ]
-        # Add a class label to the beginning of the list to check that the
-        # predictions are in the correct order, using all the classes not olny
-        # the ones that are in the training data.
-        class_labels.insert(0, "class_A")
-        classifier = RandomForest(
-            name="classifier_name",
-            classes=class_labels,
-            embedding_model_hash="hash",
-            embedding_model_name="test_model",
-        )
-        classifier.train(annotated_embeddings)
-        export_path = Path(tmp_path / "test_model_lightly.pkl")
-        classifier.export(export_path, export_type="lightly")
-
-        test_embeddings = [rng.random(n_features).astype(np.float32) for _ in range(1000)]
-        exported_classifier = load_lightly_random_forest(path=export_path, buffer=None)
-
-        predictions = classifier.predict(test_embeddings)
-        predictions_exported_model = predict_with_lightly_random_forest(
-            exported_classifier, test_embeddings
-        )
-        assert np.allclose(predictions, predictions_exported_model, atol=1e-6)
 
     def test_export__to_buffer(self) -> None:
         """Test exporting the classifier to a buffer."""
@@ -396,27 +312,11 @@ class TestRandomForestClassifier:
             np.array([0.9, 0.8, 0.7, 0.6, 0.6], dtype=np.float32),
         ]
 
-        # Test sklearn export format.
-        buffer_sklearn = io.BytesIO()
-        classifier.export(export_path=None, buffer=buffer_sklearn, export_type="sklearn")
-        buffer_sklearn.seek(0)
-        loaded_classifier_sklearn = load_random_forest_classifier(
-            buffer=buffer_sklearn, classifier_path=None
-        )
-        predictions_sklearn = loaded_classifier_sklearn.predict(test_embeddings)
-
-        # Test lightly export format.
-        buffer_lightly = io.BytesIO()
-        classifier.export(export_path=None, buffer=buffer_lightly, export_type="lightly")
-        buffer_lightly.seek(0)
-        loaded_classifier_lightly = load_lightly_random_forest(buffer=buffer_lightly, path=None)
-        predictions_lightly = predict_with_lightly_random_forest(
-            loaded_classifier_lightly, test_embeddings
-        )
-
-        # Original predictions for comparison.
+        buffer = io.BytesIO()
+        classifier.export(export_path=None, buffer=buffer)
+        buffer.seek(0)
+        loaded_classifier = load_random_forest_classifier(buffer=buffer, classifier_path=None)
+        predictions_loaded = loaded_classifier.predict(test_embeddings)
         predictions_original = classifier.predict(test_embeddings)
 
-        # Verify predictions match for both export formats.
-        assert np.allclose(predictions_original, predictions_sklearn, atol=1e-6)
-        assert np.allclose(predictions_original, predictions_lightly, atol=1e-6)
+        assert np.allclose(predictions_original, predictions_loaded, atol=1e-6)

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
     import { page } from '$app/state';
-    import { writable, derived, get } from 'svelte/store';
-    import type { ClassifierExportType } from '$lib/services/types';
+    import { derived } from 'svelte/store';
     import { Tooltip } from '$lib/components/ui/tooltip';
     import { Button } from '$lib/components';
     import { Checkbox, Alert } from '$lib/components';
-    import { Select } from '$lib/components/Select';
     import * as Dialog from '$lib/components/ui/dialog';
     import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
@@ -17,8 +15,6 @@
     import { readAnnotationLabelsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
     import { Network as NetworkIcon, Pencil, Download, Upload, Play, Info } from '@lucide/svelte';
     import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
-
-    const exportOptions: ClassifierExportType[] = ['sklearn', 'lightly'];
 
     // Subscribe to page params
     const collectionId = page.params.collection_id!;
@@ -54,9 +50,6 @@
     const selectedSampleIds = getSelectedSampleIds(collectionId);
 
     // Store-based state
-    const exportType = writable<ClassifierExportType>('sklearn');
-    const showExportDialog = writable(false);
-    const selectedClassifierId = writable<string | null>(null);
     let shouldRestoreMenu = $state(false);
 
     // Derived stores
@@ -69,22 +62,6 @@
     const sortedClassifiers = derived(classifiers, ($classifiers) => {
         return [...$classifiers].sort((a, b) => a.classifier_name.localeCompare(b.classifier_name));
     });
-
-    // Handlers
-    function handleDownload(classifierId: string) {
-        selectedClassifierId.set(classifierId);
-        showExportDialog.set(true);
-    }
-
-    function handleExportWithType() {
-        const id = get(selectedClassifierId);
-        const type = get(exportType);
-        if (id) {
-            saveClassifier(id, type);
-            showExportDialog.set(false);
-            selectedClassifierId.set(null);
-        }
-    }
 
     // Function to refresh LabelsMenu by invalidating annotation labels and counts queries
     function refreshLabelsMenu() {
@@ -302,7 +279,7 @@
                                                     size: 'sm',
                                                     title: 'Download classifier',
                                                     onclick: () =>
-                                                        handleDownload(classifier.classifier_id)
+                                                        saveClassifier(classifier.classifier_id)
                                                 }}
                                             />
                                         </div>
@@ -377,35 +354,6 @@
                         <Alert title="Error occurred">{$error}</Alert>
                     </div>
                 {/if}
-            </div>
-        </Dialog.Content>
-    </Dialog.Portal>
-</Dialog.Root>
-
-<Dialog.Root bind:open={$showExportDialog}>
-    <Dialog.Portal>
-        <Dialog.Overlay />
-        <Dialog.Content class="border-border bg-background sm:max-w-[420px]">
-            <Dialog.Header>
-                <Dialog.Title>Export Classifier</Dialog.Title>
-            </Dialog.Header>
-            <div class="grid gap-4 py-4">
-                <div class="space-y-2">
-                    <label for="exportType" class="text-sm font-medium"
-                        >Select the export type for the classifier.</label
-                    >
-                    <Select
-                        items={exportOptions.map((v) => ({ value: v, label: v }))}
-                        value={$exportType}
-                        placeholder="Select export type"
-                        class="w-full"
-                        onValueChange={(v) => exportType.set(v as typeof $exportType)}
-                    />
-                </div>
-
-                <Button buttonProps={{ onclick: () => handleExportWithType(), class: 'flex-1' }}>
-                    Export
-                </Button>
             </div>
         </Dialog.Content>
     </Dialog.Portal>

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
@@ -1,4 +1,4 @@
-import type { AnnotatedSamples, ClassifierExportType } from '$lib/services/types';
+import type { AnnotatedSamples } from '$lib/services/types';
 import { page } from '$app/state';
 import { get, writable, type Readable } from 'svelte/store';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
@@ -22,7 +22,7 @@ interface UseClassifierUtilsReturn {
     classifiersSelected: Readable<Set<string>>;
 
     // Independent API functions
-    saveClassifier: (classifierId: string, exportType: ClassifierExportType) => Promise<void>;
+    saveClassifier: (classifierId: string) => Promise<void>;
     loadClassifier: (event: Event, collectionId: string) => Promise<void>;
     updateAnnotations: (classifierId: string, annotations: AnnotatedSamples) => Promise<void>;
     trainClassifier: (classifierId: string) => Promise<void>;
@@ -40,11 +40,11 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
     const error = writable<Error | null>(null);
     const isLoading = writable(false);
 
-    const saveClassifier = async (classifierId: string, exportType: ClassifierExportType) => {
+    const saveClassifier = async (classifierId: string) => {
         try {
             error.set(null);
             const response = await saveClassifierToFile({
-                path: { classifier_id: classifierId, export_type: exportType },
+                path: { classifier_id: classifierId },
                 parseAs: 'blob'
             });
 

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.test.ts
@@ -135,11 +135,11 @@ describe('useClassifiers Hook', () => {
                 );
             const downloadSpy = vi.spyOn(utils, 'triggerDownloadBlob').mockImplementation(() => {});
             const { saveClassifier, error } = useClassifiers();
-            await saveClassifier('test-id', 'sklearn');
+            await saveClassifier('test-id');
 
             // Verify SDK call
             expect(saveSpy).toHaveBeenCalledWith({
-                path: { classifier_id: 'test-id', export_type: 'sklearn' },
+                path: { classifier_id: 'test-id' },
                 parseAs: 'blob'
             });
 
@@ -155,9 +155,7 @@ describe('useClassifiers Hook', () => {
             const { saveClassifier, error } = useClassifiers();
 
             // The main hook should catch the error from the utility and set it in its error store
-            await expect(saveClassifier('test-id', 'lightly')).rejects.toThrow(
-                'Failed to save classifier'
-            );
+            await expect(saveClassifier('test-id')).rejects.toThrow('Failed to save classifier');
             expect(get(error)).toEqual(testError);
         });
 

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
@@ -1,9 +1,4 @@
-import type {
-    ClassifierInfo,
-    AnnotatedSamples,
-    RefineMode,
-    ClassifierExportType
-} from '$lib/services/types';
+import type { ClassifierInfo, AnnotatedSamples, RefineMode } from '$lib/services/types';
 import { page } from '$app/state';
 import { get, readonly, type Readable, writable } from 'svelte/store';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
@@ -43,7 +38,7 @@ interface UseClassifiersReturn {
     createClassifier: (request: CreateClassifierRequest) => Promise<CreateClassifierResponse>;
     classifierSelectionToggle: (classifierId: string) => void;
     apply: () => Promise<void>;
-    saveClassifier: (classifierId: string, exportType: ClassifierExportType) => Promise<void>;
+    saveClassifier: (classifierId: string) => Promise<void>;
     trainClassifier: (classifierId: string) => Promise<void>;
     updateAnnotations: (classifierId: string, annotations: AnnotatedSamples) => Promise<void>;
     commitTempClassifier: (classifierId: string, collectionId: string) => Promise<void>;
@@ -455,13 +450,10 @@ export function useClassifiers(): UseClassifiersReturn {
         }
     };
 
-    const saveClassifier = async (
-        classifierId: string,
-        exportType: ClassifierExportType
-    ): Promise<void> => {
+    const saveClassifier = async (classifierId: string): Promise<void> => {
         try {
             error.set(null);
-            await utils.saveClassifier(classifierId, exportType);
+            await utils.saveClassifier(classifierId);
         } catch (err) {
             error.set(err as Error);
             throw err;

--- a/lightly_studio_view/src/lib/services/types.ts
+++ b/lightly_studio_view/src/lib/services/types.ts
@@ -10,7 +10,6 @@ import type {
     AnnotationLabelTable,
     EmbeddingClassifier,
     UpdateAnnotationsRequest,
-    SaveClassifierToFileData,
     MetadataInfoView
 } from '$lib/api/lightly_studio_local/types.gen';
 import type { Readable } from 'svelte/store';
@@ -35,7 +34,6 @@ export type LoadResult<T> = {
 export type ClassifierInfo = EmbeddingClassifier;
 export type AnnotatedSamples = UpdateAnnotationsRequest;
 export type RefineMode = 'temp' | 'existing';
-export type ClassifierExportType = SaveClassifierToFileData['path']['export_type'];
 
 type AnnotationObjectDetection = Annotation & {
     object_detection_details: ObjectDetectionAnnotationView;


### PR DESCRIPTION
## What has changed and why?

The `lightly` few-shot-classifier export format existed only for LightlyEdge. It was already a one-way door: `load_classifier_from_file`/`_from_buffer` always used the sklearn loader, so a `lightly` export could never be imported back into LightlyStudio. A test in the suite was already skipped with the reason *"lightly format should be removed"*.

With `sklearn` as the only remaining format, `ExportType` and the `{export_type}` path param are gone. The export dialog existed purely to choose between the two formats, so it is gone too — the "Download classifier" button now downloads directly instead of opening a modal with a single-option dropdown.

Also removes `SaveClassifierRequest`, an unreferenced Pydantic model in the same file (never used as a request body, absent from the OpenAPI schema).

Deliberately **not** changed:
- `ModelExportMetadata` keeps all fields and `FILE_FORMAT_VERSION` stays at `1.0.0`. It is pickled inside the sklearn export, so changing its shape would break classifiers users have already exported. A few fields (`num_input_features`, `num_estimators`) are now unread, but they are traceability metadata and cost nothing to carry.
- The `export_path | buffer` interface on `export()` and `load_random_forest_classifier()` is a pre-existing wart this PR neither creates nor worsens. Left for a separate PR to keep this one a pure removal.

**Risk:** previously exported `lightly` `.pkl` files become unloadable, since they are pickles of `RandomForestExport` and unpickling needs that class at that module path. Accepted — those files were never re-importable into LightlyStudio anyway.

+45 / −479 across 11 files, almost entirely deletions.

## How has it been tested?

Existing tests, updated for the removed parameter. Deleted the two tests that covered only the `lightly` format; trimmed `test_export__to_buffer` to its sklearn half, which still covers the buffer branch that `test_load_classifier__sklearn_format` does not.

Backend (`lightly_studio`):
- `ruff check`, `ruff format --check` — pass
- `mypy src tests` — 887 files, no issues
- `pytest tests` — **2257 passed, 43 skipped**

Frontend (`lightly_studio_view`):
- `make static-checks` — prettier, eslint, `svelte-check` 0 errors
- `npm run test:unit` — **2825 passed across 362 files**

Regenerated `openapi.json` and the TS client to confirm the frontend compiles against the parameterless route; both are untracked and not part of this PR.

Note: `make static-checks` in `lightly_studio` fails locally on `check-uv-lock` (requires uv `0.12.6`, local is `0.11.21`) — pre-existing and unrelated, so the individual tools were run directly.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified classifier downloads by removing the export-format selection.
  * Downloads now use the scikit-learn format automatically.
  * Updated the download flow to require only the classifier ID.
* **Removed**
  * LightlyEdge classifier export format support.
  * The export-format selection dialog during classifier downloads.
* **Documentation**
  * Added a changelog entry describing the removed export format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->