### PR TITLE
Fix the Load Classifier button not opening the file picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.
 - Hide every bounding box and its annotation counts when all annotation sources are unchecked, instead of showing them all.
 - Keep long-lived PostgreSQL connections alive.
+- The "Load Classifier (.pkl)" button now opens the file picker. The button covered the invisible
+  file input that was meant to receive the click, so nothing happened.
 
 ### Security
 

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
@@ -58,6 +58,7 @@
     const showExportDialog = writable(false);
     const selectedClassifierId = writable<string | null>(null);
     let shouldRestoreMenu = $state(false);
+    let classifierFileInput = $state<HTMLInputElement | null>(null);
 
     // Derived stores
     const isApplyButtonEnabled = derived(
@@ -227,18 +228,23 @@
 
                             <!-- Load Classifier -->
                             <div class="space-y-3">
-                                <div class="relative">
-                                    <input
-                                        title="Load Classifier"
-                                        type="file"
-                                        accept=".pkl"
-                                        class="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-                                        onchange={handleLoadClassifier}
-                                    />
-                                    <Button icon={Upload} buttonProps={{ class: 'w-full' }}>
-                                        Load Classifier (.pkl)
-                                    </Button>
-                                </div>
+                                <input
+                                    title="Load Classifier"
+                                    type="file"
+                                    accept=".pkl"
+                                    class="hidden"
+                                    bind:this={classifierFileInput}
+                                    onchange={handleLoadClassifier}
+                                />
+                                <Button
+                                    icon={Upload}
+                                    buttonProps={{
+                                        class: 'w-full',
+                                        onclick: () => classifierFileInput?.click()
+                                    }}
+                                >
+                                    Load Classifier (.pkl)
+                                </Button>
                             </div>
                         </div>
                     </TabsContent>


### PR DESCRIPTION
## What has changed and why?

The "Load Classifier (.pkl)" button in the classifiers menu did nothing when clicked — the file picker never opened, so there was no way to import a classifier through the GUI.

The control stacked an invisible file input under the button:

```svelte
<div class="relative">
  <input type="file" class="absolute inset-0 ... opacity-0" />  <!-- DOM order 1 -->
  <Button icon={Upload}>Load Classifier (.pkl)</Button>          <!-- DOM order 2 -->
</div>
```

`Button.svelte` applies `cn('relative', ...)`, so **both** siblings are positioned with `z-index: auto`. Among positioned elements with equal z-index, DOM order decides paint order — the button comes second, so it painted over the input and swallowed every click.

The overlay markup dates from the initial release, but the button became positioned in #1301 (Jun 2026), which introduced the button primitive. The control has been broken since then.

Fixed by hiding the input and triggering it from the button's `onclick`, matching the pattern `CollectionSearch.svelte` already uses for its image upload. This also makes the control keyboard accessible — with the old markup the button was focusable but Enter did nothing, and the input was focusable but invisible.

## How has it been tested?

- `make static-checks` — prettier, eslint, `svelte-check` 0 errors
- `npm run test:unit` — full suite passes

**Not verified by clicking it in a running app.** I have no dataset indexed locally, so reproducing the flow end to end would have meant indexing one first. The change is a 6-line rewrite to the same pattern that demonstrably works today in `CollectionSearch`, but a quick manual check by the reviewer is worthwhile since the original bug was purely visual/layout.

No test added. The real failure mode is CSS paint order, which jsdom does not model, so a unit test cannot reproduce the original bug — and `ClassifiersMenu` has no test harness today (it needs `page` state, a `QueryClient`, and five hooks mocked). A test asserting "clicking the button triggers the input" *would* have caught this specific regression, so it may still be worth adding; I left it out to keep the fix reviewable and would rather add it as a follow-up alongside the missing classifier e2e coverage. Happy to add it here if you prefer.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes

Suggested reviewer: @michal-lightly (most commits in the classifier components). Alternative: @MalteEbner, who authored the button primitive in #1301.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Classifier downloads now use the standard scikit-learn format without requiring an export-type selection.
  - Updated the Python SDK embedding generator interface for simpler embedding configuration.

- **Bug Fixes**
  - Fixed the “Load Classifier (.pkl)” button so it reliably opens the file picker.
  - Improved file selection behavior without changing the classifier loading workflow.
  - Corrected percentage-based numerical metadata charts so each compared tag scales independently and matches its tooltip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->