### PR TITLE
Drop embedding_model_hash column

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -20,7 +20,6 @@ from lightly_studio.dataset.embedding_generator import (
 )
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.embedding_model import (
-    EMBEDDING_MODEL_HASH_MAX_LENGTH,
     EmbeddingModelCreate,
     EmbeddingModelTable,
 )
@@ -172,7 +171,6 @@ class EmbeddingManager:
         space_spec = embedding_generator.embedding_space_spec()
         model_create = EmbeddingModelCreate(
             name=space_spec.space_key,
-            embedding_model_hash=_space_key_to_hash(space_spec.space_key),
             embedding_dimension=space_spec.dimension,
             dataset_id=collection.dataset_id,
         )
@@ -695,18 +693,3 @@ def _load_video_embedding_generator() -> VideoEmbeddingGenerator | None:
     except ImportError:
         logger.warning("Embedding functionality is disabled.")
         return None
-
-
-def _space_key_to_hash(space_key: str) -> str:
-    """Fits a space key into the `embedding_model_hash` column.
-
-    A `space_key` may be any string, but the column is a bounded `VARCHAR`, so keys
-    longer than the limit are truncated.
-
-    Args:
-        space_key: The embedding space key to store.
-
-    Returns:
-        The space key truncated to the column limit.
-    """
-    return space_key[:EMBEDDING_MODEL_HASH_MAX_LENGTH]

--- a/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
@@ -1,13 +1,14 @@
-"""drop embedding_model_hash column.
+"""drop embedding_model_hash column and add remote_embedder_url.
 
 The write path now keys embedding models by ``name`` (the generator's ``space_key``), and
 the ``unique_embedding_model_name`` constraint on ``(dataset_id, name)`` already enforces
 uniqueness. Nothing reads ``embedding_model_hash`` anymore, so the column is redundant. This
-migration drops the ``unique_embedding_model_hash`` constraint and then the column.
+migration drops the ``unique_embedding_model_hash`` constraint and then the column. It also adds
+the nullable ``remote_embedder_url`` column; being optional, it needs no backfill.
 
-The downgrade re-adds the column as nullable, backfills it from ``name``, sets it ``NOT NULL``,
-and re-adds the constraint. The original checkpoint file hashes cannot be reconstructed, so the
-backfill uses ``name``.
+The downgrade drops ``remote_embedder_url``, then re-adds ``embedding_model_hash`` as nullable,
+backfills it from ``name``, sets it ``NOT NULL``, and re-adds the constraint. The original
+checkpoint file hashes cannot be reconstructed, so the backfill uses ``name``.
 
 DuckDB builds its schema with ``create_all`` and has no backfill step, so this migration only
 matters for tracked Postgres databases.
@@ -36,14 +37,20 @@ def upgrade() -> None:
     """Upgrade schema."""
     op.drop_constraint("unique_embedding_model_hash", "embedding_model", type_="unique")
     op.drop_column("embedding_model", "embedding_model_hash")
+    op.add_column(
+        "embedding_model",
+        sa.Column("remote_embedder_url", sa.VARCHAR(), nullable=True),
+    )
 
 
 def downgrade() -> None:
     """Downgrade schema.
 
-    Re-adds the column and backfills it from ``name``. The original file hashes cannot be
-    reconstructed, so the backfilled value equals ``name``.
+    Drops ``remote_embedder_url``, then re-adds ``embedding_model_hash`` and backfills it from
+    ``name``. The original file hashes cannot be reconstructed, so the backfilled value equals
+    ``name``.
     """
+    op.drop_column("embedding_model", "remote_embedder_url")
     op.add_column(
         "embedding_model",
         sa.Column(

--- a/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
@@ -1,0 +1,66 @@
+"""drop embedding_model_hash column.
+
+The write path now keys embedding models by ``name`` (the generator's ``space_key``), and
+the ``unique_embedding_model_name`` constraint on ``(dataset_id, name)`` already enforces
+uniqueness. The previous migration (``f1a2b3c4d5e6``) set ``embedding_model_hash = name`` on
+every row, so the column is redundant. This migration drops the
+``unique_embedding_model_hash`` constraint and then the column.
+
+The downgrade re-adds the column as nullable, backfills it from ``name``, sets it ``NOT NULL``,
+and re-adds the constraint. The original checkpoint file hashes were already overwritten by
+``f1a2b3c4d5e6`` and cannot be reconstructed, so the backfill uses ``name``.
+
+DuckDB builds its schema with ``create_all`` and has no backfill step, so this migration only
+matters for tracked Postgres databases.
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-31 10:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a2b3c4d5e6f7"
+down_revision: str | Sequence[str] | None = "f1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint("unique_embedding_model_hash", "embedding_model", type_="unique")
+    op.drop_column("embedding_model", "embedding_model_hash")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Re-adds the column and backfills it from ``name``. The original file hashes cannot be
+    reconstructed, so the backfilled value equals ``name``.
+    """
+    op.add_column(
+        "embedding_model",
+        sa.Column(
+            "embedding_model_hash",
+            sa.VARCHAR(length=128),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.execute(sa.text("UPDATE embedding_model SET embedding_model_hash = name"))
+    op.alter_column(
+        "embedding_model",
+        "embedding_model_hash",
+        existing_type=sa.VARCHAR(length=128),
+        nullable=False,
+    )
+    op.create_unique_constraint(
+        "unique_embedding_model_hash", "embedding_model", ["dataset_id", "embedding_model_hash"]
+    )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
@@ -2,19 +2,18 @@
 
 The write path now keys embedding models by ``name`` (the generator's ``space_key``), and
 the ``unique_embedding_model_name`` constraint on ``(dataset_id, name)`` already enforces
-uniqueness. The previous migration (``f1a2b3c4d5e6``) set ``embedding_model_hash = name`` on
-every row, so the column is redundant. This migration drops the
-``unique_embedding_model_hash`` constraint and then the column.
+uniqueness. Nothing reads ``embedding_model_hash`` anymore, so the column is redundant. This
+migration drops the ``unique_embedding_model_hash`` constraint and then the column.
 
 The downgrade re-adds the column as nullable, backfills it from ``name``, sets it ``NOT NULL``,
-and re-adds the constraint. The original checkpoint file hashes were already overwritten by
-``f1a2b3c4d5e6`` and cannot be reconstructed, so the backfill uses ``name``.
+and re-adds the constraint. The original checkpoint file hashes cannot be reconstructed, so the
+backfill uses ``name``.
 
 DuckDB builds its schema with ``create_all`` and has no backfill step, so this migration only
 matters for tracked Postgres databases.
 
 Revision ID: a2b3c4d5e6f7
-Revises: f1a2b3c4d5e6
+Revises: d117a91bf587
 Create Date: 2026-08-31 10:00:00.000000
 
 """
@@ -28,7 +27,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a2b3c4d5e6f7"
-down_revision: str | Sequence[str] | None = "f1a2b3c4d5e6"
+down_revision: str | Sequence[str] | None = "d117a91bf587"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1788184800_a2b3c4d5e6f7_drop_embedding_model_hash.py
@@ -28,7 +28,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a2b3c4d5e6f7"
-down_revision: str | Sequence[str] | None = "d117a91bf587"
+down_revision: str | Sequence[str] | None = "af51a31f2cd3"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -15,6 +15,7 @@ class EmbeddingModelBase(SQLModel):
     name: str
     embedding_dimension: int
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
+    remote_embedder_url: str | None = None
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -6,19 +6,13 @@ from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 from sqlalchemy import UniqueConstraint
-from sqlmodel import VARCHAR, Column, Field, SQLModel
-
-# Maximum length of the `embedding_model_hash` column.
-EMBEDDING_MODEL_HASH_MAX_LENGTH = 128
+from sqlmodel import Field, SQLModel
 
 
 class EmbeddingModelBase(SQLModel):
     """Base class for the EmbeddingModel."""
 
     name: str
-    embedding_model_hash: str = Field(
-        sa_column=Column(VARCHAR(EMBEDDING_MODEL_HASH_MAX_LENGTH), nullable=False)
-    )
     embedding_dimension: int
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
 
@@ -31,9 +25,6 @@ class EmbeddingModelTable(EmbeddingModelBase, table=True):
     """This class defines the EmbeddingModel model."""
 
     __tablename__ = "embedding_model"
-    __table_args__ = (
-        UniqueConstraint("dataset_id", "name", name="unique_embedding_model_name"),
-        UniqueConstraint("dataset_id", "embedding_model_hash", name="unique_embedding_model_hash"),
-    )
+    __table_args__ = (UniqueConstraint("dataset_id", "name", name="unique_embedding_model_name"),)
     embedding_model_id: UUID = Field(default_factory=uuid4, primary_key=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), index=True)

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -58,7 +58,6 @@ def fine_tuning_embeddings() -> list[SampleEmbeddingTable]:
 def embedding_model(db_session: Session, collection: CollectionTable) -> EmbeddingModelTable:
     """Fixture to create an embedding model."""
     embedding_model = EmbeddingModelCreate(
-        embedding_model_hash="mock_hash",
         name="test_model",
         dataset_id=collection.dataset_id,
         embedding_dimension=3,

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -116,9 +116,7 @@ class TestClassifierManager:
         mocker.patch.object(
             embedding_model_resolver,
             "get_by_id",
-            return_value=EmbeddingModelTable(
-                name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
-            ),
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             classifier_manager_module,
@@ -183,9 +181,7 @@ class TestClassifierManager:
         mocker.patch.object(
             embedding_model_resolver,
             "get_by_id",
-            return_value=EmbeddingModelTable(
-                name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
-            ),
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             classifier_manager_module,
@@ -728,9 +724,7 @@ class TestClassifierManager:
         mocker.patch.object(
             embedding_model_resolver,
             "get_by_id",
-            return_value=EmbeddingModelTable(
-                name="test", embedding_dimension=3, embedding_model_hash="mock_hash"
-            ),
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             classifier_manager_module,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -298,11 +298,10 @@ def create_annotations(
     return list(annotation_resolver.get_by_ids(session=session, annotation_ids=annotation_ids))
 
 
-def create_embedding_model(  # noqa: PLR0913
+def create_embedding_model(
     session: Session,
     collection_id: UUID,
     embedding_model_name: str = "example_embedding_model",
-    embedding_model_hash: str = "example_hash",
     embedding_dimension: int = 128,
     set_as_default: bool = False,
 ) -> EmbeddingModelTable:
@@ -325,7 +324,6 @@ def create_embedding_model(  # noqa: PLR0913
         embedding_model=EmbeddingModelCreate(
             dataset_id=collection.dataset_id,
             name=embedding_model_name,
-            embedding_model_hash=embedding_model_hash,
             embedding_dimension=embedding_dimension,
         ),
     )
@@ -434,7 +432,6 @@ def fill_db_with_samples_and_embeddings(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
-            embedding_model_hash=f"hash_{embedding_model_name}",
             # The first model is the collection default, matching production and the
             # queries that resolve the default embedding space (e.g. embeddings2d).
             set_as_default=index == 0,
@@ -480,7 +477,6 @@ def fill_db_with_video_samples_and_embeddings(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
-            embedding_model_hash=f"hash_{embedding_model_name}",
             # The first model is the collection default, matching production and the
             # queries that resolve the default embedding space (e.g. embeddings2d).
             set_as_default=index == 0,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -330,7 +330,6 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     assert copied_model.embedding_model_id != embedding_model.embedding_model_id
     assert copied_model.dataset_id == copied.dataset_id
     assert copied_model.name == embedding_model.name
-    assert copied_model.embedding_model_hash == embedding_model.embedding_model_hash
     assert copied_model.embedding_dimension == embedding_model.embedding_dimension
 
     # Assert - embeddings copied

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -80,13 +80,11 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="model_1",
-        embedding_model_hash="hash_1",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="model_2",
-        embedding_model_hash="hash_2",
     )
     for model in (model_1, model_2):
         collection_embedding_model_resolver.get_or_add_collection_model(
@@ -183,13 +181,11 @@ def test_get_all_by_collection_id__returns_all_linked(db_session: Session) -> No
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="model_1",
-        embedding_model_hash="hash_1",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="model_2",
-        embedding_model_hash="hash_2",
     )
     for model in (model_1, model_2):
         collection_embedding_model_resolver.get_or_add_collection_model(
@@ -229,13 +225,11 @@ def test_get_model_id_by_name__none_returns_default_not_oldest(db_session: Sessi
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="oldest_model",
-        embedding_model_hash="hash_1",
     )
     default_model = create_embedding_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="default_model",
-        embedding_model_hash="hash_2",
         set_as_default=True,
     )
 
@@ -278,13 +272,11 @@ def test_get_model_id_by_name__existing_name(db_session: Session) -> None:
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_1",
-        embedding_model_hash="hash_1",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="embedding_model_2",
-        embedding_model_hash="hash_2",
     )
 
     result_1 = collection_embedding_model_resolver.get_model_id_by_name(

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -47,13 +47,11 @@ def test_get_by_name(db_session: Session) -> None:
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
-        embedding_model_hash="hash_1",
     )
     create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_2",
-        embedding_model_hash="hash_2",
     )
 
     embedding_model = embedding_model_resolver.get_by_name(
@@ -115,40 +113,36 @@ def test_get_by_name__scoped_by_dataset(db_session: Session) -> None:
 
 
 def test_get_or_create__creates_new_model(db_session: Session) -> None:
-    """get_or_create should insert a model when none exists for the hash."""
+    """get_or_create should insert a model when none exists for the name."""
     collection = create_collection(session=db_session)
 
     model_create = EmbeddingModelCreate(
         dataset_id=collection.dataset_id,
         name="Model Name",
-        embedding_model_hash="model_hash",
         embedding_dimension=768,
     )
     created = embedding_model_resolver.get_or_create(
         session=db_session, embedding_model=model_create
     )
 
-    assert created.embedding_model_hash == "model_hash"
     assert created.name == "Model Name"
     assert created.embedding_dimension == 768
     assert created.dataset_id == collection.dataset_id
 
 
 def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
-    """get_or_create should return the existing model for a matching hash."""
+    """get_or_create should return the existing model for a matching name."""
     collection = create_collection(session=db_session)
     existing = create_embedding_model(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="Model Name",
-        embedding_model_hash="model_hash",
         embedding_dimension=32,
     )
 
     model_create = EmbeddingModelCreate(
         dataset_id=collection.dataset_id,
         name="Model Name",
-        embedding_model_hash="model_hash",
         embedding_dimension=32,
     )
 
@@ -170,14 +164,12 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_name="Model Name",
-        embedding_model_hash="model_hash",
         embedding_dimension=32,
     )
 
     conflicting_model_create = EmbeddingModelCreate(
         dataset_id=collection.dataset_id,
         name="Model Name",
-        embedding_model_hash="model_hash",
         embedding_dimension=64,
     )
 
@@ -198,7 +190,6 @@ def test_get_or_create__same_name_different_datasets(db_session: Session) -> Non
     model_create_1 = EmbeddingModelCreate(
         dataset_id=collection_1.dataset_id,
         name="Test Model",
-        embedding_model_hash="same_hash",
         embedding_dimension=32,
     )
     model_1 = embedding_model_resolver.get_or_create(
@@ -208,7 +199,6 @@ def test_get_or_create__same_name_different_datasets(db_session: Session) -> Non
     model_create_2 = EmbeddingModelCreate(
         dataset_id=collection_2.dataset_id,
         name="Test Model",
-        embedding_model_hash="same_hash",
         embedding_dimension=32,
     )
     model_2 = embedding_model_resolver.get_or_create(

--- a/lightly_studio/tests/resolvers/test_sample_embedding_resolver.py
+++ b/lightly_studio/tests/resolvers/test_sample_embedding_resolver.py
@@ -257,14 +257,12 @@ def test_get_embedding_count(db_session: Session) -> None:
         session=db_session,
         collection_id=col1_id,
         embedding_model_name="model_1",
-        embedding_model_hash="hash_1",
     )
     embedding_model_1_id = embedding_model_1.embedding_model_id
     embedding_model_2 = create_embedding_model(
         session=db_session,
         collection_id=col1_id,
         embedding_model_name="model_2",
-        embedding_model_hash="hash_2",
     )
     embedding_model_2_id = embedding_model_2.embedding_model_id
 

--- a/lightly_studio/tests/resolvers/test_similarity_utils.py
+++ b/lightly_studio/tests/resolvers/test_similarity_utils.py
@@ -103,14 +103,12 @@ class TestGetDistanceExpression:
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_name="other_model",
-            embedding_model_hash="other_hash",
             embedding_dimension=3,
         )
         default_model = create_embedding_model(
             session=db_session,
             collection_id=collection.collection_id,
             embedding_model_name="default_model",
-            embedding_model_hash="default_hash",
             embedding_dimension=3,
             set_as_default=True,
         )


### PR DESCRIPTION
## What has changed and why?

Second of two stacked PRs removing `embedding_model.embedding_model_hash`. With reads already routed through `name`, this PR:

- Removes the obsolete model field and registration code.
- Drops the database constraint and column; the downgrade restores and backfills it from `name`.
- Adds an optional `remote_embedder_url` for future use.

The serialized `RandomForest.embedding_model_hash` field is unchanged.

## How has it been tested?

- `make static-checks`
- `make test`
- `make migration-check-postgresql`
- Manual PostgreSQL downgrade/upgrade round trip

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified embedding model identification using the model name, dataset, and dimensions.
  * Removed the requirement to provide a separate embedding model hash.
  * Added optional support for specifying a remote embedder URL.

* **Data Migration**
  * Updated existing databases to remove the legacy embedding model hash field while preserving model uniqueness and supporting rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->