### PR TITLE
Bump actions/cache to v6

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache build
         id: cache-build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           lookup-only: true
           path: &cache-build-path |
@@ -80,7 +80,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: cache-playwright-browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: &cache-playwright-browsers-path ~/.cache/ms-playwright
           key: &cache-playwright-browsers-key >-
@@ -91,7 +91,7 @@ jobs:
 
       - name: Cache example dataset
         id: cache-example-dataset
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           # No need to download a cached version in cache preparation step
           lookup-only: true
@@ -285,7 +285,7 @@ jobs:
 
       - name: Check e2e success cache
         id: cache-success
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           lookup-only: true
           path: ${{ matrix.success_marker }}
@@ -296,7 +296,7 @@ jobs:
       - name: Cache build
         if: steps.cache-success.outputs.cache-hit != 'true'
         id: cache-build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           fail-on-cache-miss: true
           path: *cache-build-path
@@ -305,7 +305,7 @@ jobs:
       - name: Cache Playwright browsers
         if: steps.cache-success.outputs.cache-hit != 'true'
         id: cache-playwright-browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           fail-on-cache-miss: true
           path: *cache-playwright-browsers-path
@@ -314,7 +314,7 @@ jobs:
       - name: Cache example dataset
         if: steps.cache-success.outputs.cache-hit != 'true'
         id: cache-example-dataset
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           fail-on-cache-miss: true
           path: *cache-example-dataset-path
@@ -457,7 +457,7 @@ jobs:
 
       - name: Save e2e success marker
         if: steps.cache-success.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: ${{ matrix.success_marker }}
           key: ${{ matrix.success_key }}-${{ needs.prepare-caches.outputs.file-hash }}


### PR DESCRIPTION
## What has changed and why?

Bumps all `actions/cache` usages in `End2End Test` from `@v5` to `@v6` (7x `actions/cache`, 1x `actions/cache/save`). It is the only workflow in the repo that uses the action.

`@v6` currently resolves to v6.1.0 — both tags point at `55cc834`.

- **v6.0.0** — migrates the action to ESM and the `node24` runtime.
- **v6.1.0** — bumps `@actions/cache` to handle read-only cache access.

Every input this workflow uses (`path`, `key`, `lookup-only`, `fail-on-cache-miss`) and the `cache-hit` output are unchanged from v5, so this is a pure version bump.

Risk to watch: v5.1.0 was published about an hour after v6.1.0, so `v5` is not strictly a subset of v6. Nothing in this workflow depends on what landed there.

## How has it been tested?

The E2E workflow on this PR exercises every changed step: cache preparation writes the build, Playwright browser, and example dataset caches, and the test jobs restore them with `fail-on-cache-miss: true` — a cache format or input regression would fail the run rather than pass silently. Verified locally that the workflow YAML still parses (the file relies on anchors and aliases) and that the v6 `action.yml` and `save/action.yml` still declare each input used here.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly (most `git blame` history on the cache steps). Alternative: @lukas-lightly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated end-to-end workflow caching to use the latest supported cache action.
  * Improved caching for successful end-to-end test markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->