### PR TITLE
Mark evaluation runs stale instead of deleting metrics on annotation deletion

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotations.py
@@ -9,10 +9,7 @@ from sqlmodel import Session, col, delete
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
 )
-from lightly_studio.resolvers import annotation_resolver
-from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
-    delete_evaluation_metrics,
-)
+from lightly_studio.resolvers import annotation_resolver, evaluation_run_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
@@ -48,14 +45,11 @@ def delete_annotations(
 
     # Now delete the annotations themselves
     annotation_ids = [annotation.sample_id for annotation in annotations]
-    parent_sample_ids = list({annotation.parent_sample_id for annotation in annotations})
-    if annotation_ids:
-        # TODO(Jonas, 06/2026): Replace eager deletion with explicit evaluation invalidation
-        # once evaluation results can be recomputed or marked stale independently.
-        delete_evaluation_metrics(
+    collection_ids = {annotation.annotation_collection_id for annotation in annotations}
+    for collection_id in collection_ids:
+        evaluation_run_resolver.mark_stale_by_collection_id(
             session=session,
-            annotation_ids=annotation_ids,
-            parent_sample_ids=parent_sample_ids,
+            collection_id=collection_id,
         )
     for batch in batching.batched(items=annotation_ids):
         session.exec(

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_base_delete_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_base_delete_annotations.py
@@ -4,11 +4,24 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
-from lightly_studio.resolvers import annotation_label_resolver, annotation_resolver
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import (
+    annotation_label_resolver,
+    annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+)
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
 from tests.conftest import AnnotationsTestData
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_delete_annotations(
@@ -36,3 +49,53 @@ def test_delete_annotations(
         session=db_session, filters=annotation_filter
     ).annotations
     assert len(filtered_annotations) == 0
+
+
+def test_delete_annotations__marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="gt",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    annotation_resolver.delete_annotations(
+        session=db_session,
+        annotation_label_ids=[label.annotation_label_id],
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None


### PR DESCRIPTION
## What has changed and why?

Replace eager evaluation metric deletion with marking evaluation runs as stale when annotations are deleted

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting annotations now correctly marks related evaluation runs as stale.
  * Evaluation results remain available for refresh instead of being deleted immediately.

* **Tests**
  * Added coverage to verify evaluation runs are marked stale when associated annotations are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->