### PR TITLE
feat: add attach_embeddings to store precomputed vectors for existing samples

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -541,6 +541,38 @@ class EmbeddingManager:
         return model
 
 
+def attach_embeddings(
+    session: Session,
+    embedding_model_id: UUID,
+    sample_ids: list[UUID],
+    vectors: NDArray[np.float32],
+) -> None:
+    """Store precomputed embedding vectors for existing samples.
+
+    Use this to attach vectors that were computed outside of LightlyStudio (for
+    example, by an external model or a previous run) directly to samples that
+    already exist in the database. Prefer the generator-based paths
+    (`embed_images`, `embed_videos`, `embed_and_store_pil_images`,
+    `embed_annotations`) when embeddings still need to be computed from an
+    `EmbeddingGenerator`.
+
+    Args:
+        session: Database session for resolver operations.
+        embedding_model_id: ID of a registered embedding model the vectors belong to.
+        sample_ids: Sample IDs the vectors are stored for.
+        vectors: Embedding vectors to store, in the same order as sample_ids.
+
+    Raises:
+        ValueError: If the vectors fail validation. See `_validate_and_coerce_embeddings`.
+    """
+    _store_embeddings(
+        session=session,
+        model_id=embedding_model_id,
+        sample_ids=sample_ids,
+        embeddings=vectors,
+    )
+
+
 def _store_embeddings(
     session: Session,
     model_id: UUID,

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -40,6 +40,7 @@ from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_embedding_model,
     create_image,
 )
 from tests.resolvers.video.helpers import VideoStub, create_videos
@@ -912,6 +913,73 @@ def test_compute_image_embedding(
         select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
     ).all()
     assert len(stored_embeddings) == 0
+
+
+def test_attach_embeddings(
+    db_session: Session,
+    collection: CollectionTable,
+    samples: list[ImageTable],
+) -> None:
+    """attach_embeddings stores vectors keyed to the right sample and model."""
+    model_a = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_a",
+        embedding_model_hash="hash_a",
+        embedding_dimension=4,
+    )
+    model_b = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_b",
+        embedding_model_hash="hash_b",
+        embedding_dimension=4,
+    )
+    sample_ids = [sample.sample_id for sample in samples[:3]]
+    vectors_a = np.array(
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
+        dtype=np.float32,
+    )
+    vectors_b = np.array(
+        [[-1.0, -2.0, -3.0, -4.0], [-5.0, -6.0, -7.0, -8.0], [-9.0, -10.0, -11.0, -12.0]],
+        dtype=np.float32,
+    )
+
+    embedding_manager.attach_embeddings(
+        session=db_session,
+        embedding_model_id=model_a.embedding_model_id,
+        sample_ids=sample_ids,
+        vectors=vectors_a,
+    )
+    embedding_manager.attach_embeddings(
+        session=db_session,
+        embedding_model_id=model_b.embedding_model_id,
+        sample_ids=sample_ids,
+        vectors=vectors_b,
+    )
+
+    stored_a = sample_embedding_resolver.get_by_sample_ids(
+        session=db_session,
+        sample_ids=sample_ids,
+        embedding_model_id=model_a.embedding_model_id,
+    )
+    stored_b = sample_embedding_resolver.get_by_sample_ids(
+        session=db_session,
+        sample_ids=sample_ids,
+        embedding_model_id=model_b.embedding_model_id,
+    )
+
+    # Each model's rows are keyed to the right sample, in the requested order.
+    assert [row.sample_id for row in stored_a] == sample_ids
+    assert [row.sample_id for row in stored_b] == sample_ids
+
+    # Each model's rows carry its own vectors, not the other model's.
+    np.testing.assert_array_equal(
+        np.array([row.embedding for row in stored_a], dtype=np.float32), vectors_a
+    )
+    np.testing.assert_array_equal(
+        np.array([row.embedding for row in stored_b], dtype=np.float32), vectors_b
+    )
 
 
 # Dimension of the model registered by _register_random_model, used to build


### PR DESCRIPTION
## What has changed and why?

Adds `attach_embeddings(session, embedding_model_id, sample_ids, vectors)` to
`lightly_studio.dataset.embedding_manager`. It is a thin public wrapper around the
existing private `_store_embeddings`, for callers that already have precomputed
vectors and just need to attach them to existing samples. Previously the only way
to do this was to implement a 4-method `ImageEmbeddingGenerator` protocol with 3
no-op methods, just to supply vectors that were never computed by a generator.
Not exported from the top-level package; import it directly from
`lightly_studio.dataset.embedding_manager`.

## How has it been tested?

Added `test_attach_embeddings` to `tests/dataset/test_embedding_manager.py`: attaches
different vectors for the same batch of samples under two distinct embedding models,
then reads them back via `sample_embedding_resolver.get_by_sample_ids` and confirms
the correct vector values and correct `(sample_id, embedding_model_id)` pairing.

Ran `make static-checks` and `make test` in `lightly_studio/` (all passing except a
few pre-existing, unrelated failures caused by missing optional deps in this
environment: `tests/api/routes/api/test_enterprise.py`, `tests/dataset/test_fsspec_lister.py`,
`tests/test_enterprise.py`, `tests/test_cloud_credentials.py`, and `tests/api/test_server.py::test_server_static_webapp`,
none of which touch this change).

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: michal-lightly (most frequent recent author of `embedding_manager.py`). Alternative: JonasWurst.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching precomputed embedding vectors to existing samples.
  * Embeddings are validated for compatible dimensions, sample counts, numeric values, and finite values before storage.
  * Supports storing embeddings for multiple models while preserving the correct sample associations.

* **Tests**
  * Added coverage verifying embeddings are stored with the correct samples and models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->