### PR TITLE
Expose set_default_embedding_space in the Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distributions as annotation class balancing.
 - Add the Metadata Balancing strategy to the sampling dialog, to balance a selection over the
   values of a categorical metadata field such as weather or city.
+- Python SDK: Explicitly set a collection's default embedding space with `set_default_embedding_space`.
 
 
 ### Changed

--- a/lightly_studio/src/lightly_studio/__init__.py
+++ b/lightly_studio/src/lightly_studio/__init__.py
@@ -27,7 +27,10 @@ from lightly_studio.dataset.embedding_generator import (
     ImageEmbeddingGenerator,
     VideoEmbeddingGenerator,
 )
-from lightly_studio.dataset.embedding_manager import set_default_embedding_model
+from lightly_studio.dataset.embedding_manager import (
+    set_default_embedding_model,
+    set_default_embedding_space,
+)
 from lightly_studio.models.collection import SampleType
 from lightly_studio.enterprise import connect
 from lightly_studio.core.lightly_train_helpers.generate_train_script import lt_train_script
@@ -54,6 +57,7 @@ __all__ = [
     "connect",
     "lt_train_script",
     "set_default_embedding_model",
+    "set_default_embedding_space",
     "start_gui",
     "start_gui_background",
     "stop_gui_background",

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -12,6 +12,7 @@ from PIL import Image
 from sqlmodel import Session
 from tqdm import tqdm
 
+from lightly_studio.database import db_manager
 from lightly_studio.dataset import env
 from lightly_studio.dataset.embedding_generator import (
     EmbeddingGenerator,
@@ -87,6 +88,26 @@ def set_default_embedding_model(embedding_generator: EmbeddingGenerator) -> None
     """
     EmbeddingManagerProvider.get_embedding_manager().set_default_embedding_model(
         embedding_generator=embedding_generator
+    )
+
+
+def set_default_embedding_space(collection_id: UUID, embedding_model_id: UUID) -> None:
+    """Explicitly set a collection's default embedding space.
+
+    Links the embedding model to the collection if it isn't already, then flags it as
+    the collection's default. Both steps commit internally, so call this after all
+    other pending writes on the session, typically as the last step of an import flow.
+
+    Args:
+        collection_id: The collection whose default embedding model is set.
+        embedding_model_id: The embedding model to make the default.
+    """
+    session = db_manager.persistent_session()
+    collection_embedding_model_resolver.get_or_add_collection_model(
+        session=session, collection_id=collection_id, embedding_model_id=embedding_model_id
+    )
+    collection_embedding_model_resolver.set_default(
+        session=session, collection_id=collection_id, embedding_model_id=embedding_model_id
     )
 
 

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -11,6 +11,7 @@ from PIL import Image
 from pytest_mock import MockerFixture
 from sqlmodel import Session, select
 
+from lightly_studio.database import db_manager
 from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import (
     EmbeddingSpaceSpec,
@@ -25,7 +26,7 @@ from lightly_studio.dataset.embedding_manager import (
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
@@ -38,9 +39,71 @@ from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_embedding_model,
     create_image,
 )
 from tests.resolvers.video.helpers import VideoStub, create_videos
+
+
+def test_set_default_embedding_space(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """A single call links an unlinked model to the collection and makes it default."""
+    session = db_manager.persistent_session()
+    collection = create_collection(session=session)
+    model = embedding_model_resolver.get_or_create(
+        session=session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="unlinked_model",
+            embedding_dimension=4,
+        ),
+    )
+
+    embedding_manager.set_default_embedding_space(
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=session, collection_id=collection.collection_id
+        )
+        == model.embedding_model_id
+    )
+
+
+def test_set_default_embedding_space__replaces_existing_default(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Setting a new default clears the old one, even if both models are already linked."""
+    session = db_manager.persistent_session()
+    collection = create_collection(session=session)
+    first_model = create_embedding_model(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_model_name="first_model",
+        set_as_default=True,
+    )
+    second_model = create_embedding_model(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_model_name="second_model",
+        set_as_default=False,
+    )
+
+    embedding_manager.set_default_embedding_space(
+        collection_id=collection.collection_id,
+        embedding_model_id=second_model.embedding_model_id,
+    )
+
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=session, collection_id=collection.collection_id
+        )
+        == second_model.embedding_model_id
+        != first_model.embedding_model_id
+    )
 
 
 def test_register_embedding_model(


### PR DESCRIPTION
## What has changed and why?

Adds a public, module-level `set_default_embedding_space(collection_id, embedding_model_id)` function to the Python SDK, next to `set_default_embedding_model`. It links the embedding model to the collection if needed (idempotent) and marks it as the collection's default, for callers who want to explicitly control a collection's default embedding space (e.g. as the last step of an import flow).

## How has it been tested?

Added two unit tests in `lightly_studio/tests/dataset/test_embedding_manager.py`:
- Setting the default when no default exists yet and the model isn't linked to the collection.
- Replacing an existing default with a different, already-linked model.

Ran `cd lightly_studio && make static-checks` (ruff, mypy) and `uv run pytest tests/dataset/test_embedding_manager.py` (43 passed). `make test` requires a full frontend build (`dist_lightly_studio_view_app`) unavailable in this environment, so the relevant test file was run directly instead, per repo guidance.

## Did you update CHANGELOG.md?

- [x] Yes

---

Suggested reviewer: @michal-lightly (most frequent recent author of `embedding_manager.py` and `collection_embedding_model_resolver.py`). Alternative: @JonasWurst.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly setting a collection’s default embedding space through the Python SDK.
  * Automatically links an embedding model to the collection when needed.
  * Selecting a new default embedding space replaces the previous default.

* **Documentation**
  * Documented the new capability in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->