### PR TITLE
Fix: Update caption item view

### DIFF
--- a/lightly_studio_view/src/lib/components/Captions/CaptionsItem/CaptionsItem.svelte
+++ b/lightly_studio_view/src/lib/components/Captions/CaptionsItem/CaptionsItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { toast } from 'svelte-sonner';
-    import { Card, CardContent } from '$lib/components';
     import type { CaptionView, SampleView, VideoView } from '$lib/api/lightly_studio_local';
     import type { ImageSample } from '$lib/services/types';
     import { SampleType } from '$lib/api/lightly_studio_local';
@@ -118,9 +117,9 @@
     }
 </script>
 
-<div style={`height: ${maxHeight}; max-height: ${maxHeight};`}>
-    <Card className="h-full">
-        <CardContent className="h-full flex min-h-0 flex-row items-center dark:[color-scheme:dark]">
+<article style={`height: ${maxHeight}; max-height: ${maxHeight};`} data-testid="caption-row">
+    <div class="h-full border-b border-border-hard">
+        <div class="flex h-full min-h-0 flex-row items-center dark:[color-scheme:dark]">
             {#if isVideoView(item)}
                 {#if videoQuery.data}
                     <div class="sample-image">
@@ -165,26 +164,29 @@
                     data-testid="video-frame-image"
                 />
             {/if}
-            <div class="flex h-full w-full flex-1 flex-col overflow-auto px-4 py-2">
-                {#each captions as caption (caption.sample_id)}
-                    <CaptionField
-                        {caption}
-                        onDeleteCaption={() => onDeleteCaption(caption.sample_id)}
-                        {onUpdate}
-                    />
-                {/each}
-                {#if $isEditingMode}
-                    <CreateCaptionField
-                        onCreate={(text) => onCreateCaption(item.sample_id, text)}
-                        {isCreatingCaption}
-                        {onCreatingCaptionChange}
-                        {canStartDraft}
-                    />
-                {/if}
+            <div class="flex h-full min-w-0 flex-1 flex-col overflow-hidden px-4 py-4">
+                <h2 class="mb-2 text-sm font-medium">Captions</h2>
+                <div class="min-h-0 flex-1 overflow-y-auto pr-2" data-testid="caption-scroll-area">
+                    {#each captions as caption (caption.sample_id)}
+                        <CaptionField
+                            {caption}
+                            onDeleteCaption={() => onDeleteCaption(caption.sample_id)}
+                            {onUpdate}
+                        />
+                    {/each}
+                    {#if $isEditingMode}
+                        <CreateCaptionField
+                            onCreate={(text) => onCreateCaption(item.sample_id, text)}
+                            {isCreatingCaption}
+                            {onCreatingCaptionChange}
+                            {canStartDraft}
+                        />
+                    {/if}
+                </div>
             </div>
-        </CardContent>
-    </Card>
-</div>
+        </div>
+    </div>
+</article>
 
 <style>
     .sample-image {


### PR DESCRIPTION
## What has changed and why?

PR 1 out of 3 to redesign the captions view

- This PR makes the rendering of captions in the captions view a bit nicer. 
  - We give a clear legend that we show "captions"
  - Captions are aligned with the images 

Before:
<img width="1671" height="491" alt="image" src="https://github.com/user-attachments/assets/f2545329-70a6-4e1d-9a61-9f5a2958b834" />


After:
<img width="1320" height="651" alt="image" src="https://github.com/user-attachments/assets/1a14724a-c3df-4e6c-9e65-d4432db862ff" />


## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Redesigned the captions panel with a cleaner, simpler layout.
  - Added a visible “Captions” heading to clarify the section.
  - Improved spacing and padding around caption content.
  - Updated the caption list to scroll vertically within its dedicated area.
  - Preserved existing caption editing and creation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->