### PR TITLE
Fix: Bug in percentage scaling for numeric tag distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.
 - Hide every bounding box and its annotation counts when all annotation sources are unchecked, instead of showing them all.
 - Keep long-lived PostgreSQL connections alive.
+- Numerical metadata distributions in percentage mode now scale each compared tag independently, so bars match the tooltip.
 
 ### Security
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/buildCategoricalComparisonSeries.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/buildCategoricalComparisonSeries.test.ts
@@ -59,6 +59,39 @@ describe('buildCategoricalComparisonSeries', () => {
             { label: 'Priority', data: [{ label: 'Missing (no value)', count: 3 }] }
         ]);
     });
+
+    it("carries each tag's own bucket total as the percentage denominator", () => {
+        const series = buildCategoricalComparisonSeries(
+            [
+                {
+                    id: 'tag-a',
+                    label: 'Reviewed',
+                    categorical: {
+                        city: [
+                            {
+                                id: 'value-bern',
+                                kind: 'value',
+                                value: 'Bern',
+                                label: 'Bern',
+                                count: 2
+                            },
+                            {
+                                id: 'value-zurich',
+                                kind: 'value',
+                                value: 'Zurich',
+                                label: 'Zurich',
+                                count: 8
+                            }
+                        ]
+                    }
+                },
+                { id: 'tag-b', label: 'Priority', categorical: {} }
+            ],
+            'city'
+        );
+
+        expect(series.map(({ totalCount }) => totalCount)).toEqual([10, 0]);
+    });
 });
 
 describe('buildCategoricalComparisonBuckets', () => {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/buildCategoricalComparisonSeries.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/buildCategoricalComparisonSeries.ts
@@ -31,15 +31,24 @@ export const buildCategoricalComparisonSeries = (
         (bucket) => bucket.kind === 'value' && bucket.value === 'Other'
     );
 
-    return comparisons.map(({ id, label, categorical }) => ({
-        id,
-        label,
-        data: (categorical[metadataKey] ?? []).map((bucket) => ({
-            id: bucket.id,
-            label: comparisonLabel(bucket, hasLiteralMissing, hasLiteralOther),
-            count: bucket.count
-        }))
-    }));
+    return comparisons.map(({ id, label, categorical }) => {
+        const buckets = categorical[metadataKey] ?? [];
+        return {
+            id,
+            label,
+            data: buckets.map((bucket) => ({
+                id: bucket.id,
+                label: comparisonLabel(bucket, hasLiteralMissing, hasLiteralOther),
+                count: bucket.count
+            })),
+            // The percentage denominator, set here so a top-N view cannot shrink
+            // it. The backend returns only the most frequent values per key
+            // (`_TOP_VALUE_COUNT` in `categorical_value_counts.py`), so this is
+            // the total over the values it returned for the tag, not the tag's
+            // sample count.
+            totalCount: buckets.reduce((sum, bucket) => sum + bucket.count, 0)
+        };
+    });
 };
 
 /**

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
@@ -96,6 +96,57 @@ describe('buildHistogramOption', () => {
         expect(yAxis.axisLabel.formatter(0.30000000000000004)).toBe('0.3%');
     });
 
+    it('normalizes each comparison series by its own total, not the base histogram', () => {
+        // Two tags with the same shape but a 10x count difference must draw
+        // identical bars: percentage mode compares distributions, and a shared
+        // denominator would just replot the raw counts.
+        const option = buildHistogramOption(
+            { binEdges: [0, 0.5, 1], counts: [1000, 1000] },
+            undefined,
+            {
+                showAxes: true,
+                valueMode: 'percentage',
+                series: [
+                    {
+                        id: 'tag-a',
+                        label: 'Small',
+                        data: { binEdges: [0, 0.5, 1], counts: [3, 7] }
+                    },
+                    {
+                        id: 'tag-b',
+                        label: 'Large',
+                        data: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+                    }
+                ]
+            }
+        );
+
+        const [small, large] = option.series as { data: BarDatum[] }[];
+        expect(small.data.map((bar) => bar.value)).toEqual([
+            [0.5, 30],
+            [1.5, 70]
+        ]);
+        expect(large.data.map((bar) => bar.value)).toEqual(small.data.map((bar) => bar.value));
+    });
+
+    it('reports the same share in the grouped tooltip as the bar it describes', () => {
+        const option = buildHistogramOption(
+            { binEdges: [0, 0.5, 1], counts: [1000, 1000] },
+            undefined,
+            {
+                showAxes: true,
+                valueMode: 'percentage',
+                series: [
+                    { id: 'tag-a', label: 'Small', data: { binEdges: [0, 0.5, 1], counts: [3, 7] } }
+                ]
+            }
+        );
+
+        const [small] = option.series as { data: BarDatum[] }[];
+        expect(small.data[1].value[1]).toBe(70);
+        expect(getTooltipFormatter(option)([{ dataIndex: 1, seriesIndex: 0 }])).toContain('70.0%');
+    });
+
     it('renders all bins in the accent color when no range is given', () => {
         expect(getColors(buildHistogramOption(normal)).every((c) => c === ACCENT)).toBe(true);
     });

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
@@ -35,7 +35,13 @@ export interface HistogramOptionOptions {
      * edges, the x-axis domain and the tooltip's interval labels.
      */
     series?: HistogramSeries[];
-    /** Whether bin heights show raw counts or their share of the histogram total. */
+    /**
+     * Whether bin heights show raw counts or their share of a total. Without
+     * comparison series that total is the histogram's own; with them, each series
+     * is normalized by *its own* total, so tags holding very different numbers of
+     * samples stay comparable by shape (the same rule `BarChart` applies to
+     * grouped category series).
+     */
     valueMode?: 'number' | 'percentage';
 }
 
@@ -210,7 +216,7 @@ function buildTooltip(
                 const values = comparisonSeries
                     .map((series, index) => {
                         const count = series.data.counts[dataIndex] ?? 0;
-                        const total = series.data.counts.reduce((sum, value) => sum + value, 0);
+                        const total = seriesTotal(series);
                         const percent = total > 0 ? ` (${formatPercent(count / total)})` : '';
                         return `${markers.get(index) ?? ''}${escape(series.label)}: <b>${formatInteger(count)}</b>${percent}`;
                     })
@@ -284,18 +290,27 @@ function buildYAxis(
 }
 
 /**
+ * Total count of a comparison series - the denominator for its percentage bars.
+ * Shared by the bar heights and the tooltip so the two cannot drift apart.
+ */
+function seriesTotal(series: HistogramSeries): number {
+    return series.data.counts.reduce((sum, count) => sum + count, 0);
+}
+
+/**
  * The custom bar series: one pixel-snapped rect per bin (see
  * `renderHistogramBin`), each colored by whether it falls in the range.
  */
 function buildSeries(options: HistogramSeriesOptions): Record<string, unknown>[] {
     const comparisonSeries = options.comparisonSeries ?? [];
-    const totalCount = options.bins.reduce((sum, bin) => sum + bin.count, 0);
-    const toChartValue = (count: number): number =>
-        options.valueMode === 'percentage' && totalCount > 0 ? (count / totalCount) * 100 : count;
+    const binsTotal = options.bins.reduce((sum, bin) => sum + bin.count, 0);
+    const toChartValue = (count: number, total: number): number =>
+        options.valueMode === 'percentage' && total > 0 ? (count / total) * 100 : count;
     if (comparisonSeries.length > 0) {
         const colors = assignSeriesColors(comparisonSeries.map(({ id }) => id));
         return comparisonSeries.map((series, seriesIndex) => {
             const seriesColor = colors.get(series.id);
+            const total = seriesTotal(series);
             return {
                 type: 'custom',
                 name: series.label,
@@ -313,7 +328,7 @@ function buildSeries(options: HistogramSeriesOptions): Record<string, unknown>[]
                     const dimmed =
                         options.range && bin && !isBinInRange(bin.start, bin.end, options.range);
                     return {
-                        value: [index + 0.5, toChartValue(count)],
+                        value: [index + 0.5, toChartValue(count, total)],
                         itemStyle: { color: dimmed ? BAR_COLOR_DIMMED : seriesColor }
                     };
                 })
@@ -331,7 +346,7 @@ function buildSeries(options: HistogramSeriesOptions): Record<string, unknown>[]
                 // actually over. A left-edge point would snap to the next bin once
                 // the cursor passed a bar's midpoint. `renderHistogramBin` steps
                 // back half a band to recover the left edge for drawing.
-                value: [index + 0.5, toChartValue(bin.count)],
+                value: [index + 0.5, toChartValue(bin.count, binsTotal)],
                 itemStyle: {
                     color:
                         !options.range || isBinInRange(bin.start, bin.end, options.range)


### PR DESCRIPTION
## What has changed and why?

Fixes two bugs where the Distribution panel showed the wrong percentages when comparing sample tags.

When you compare two tags, each tag should be measured against its own size. That is the whole point of percentages here: it lets you compare a small tag with a big one fairly.

- Numeric fields (histograms): every tag was divided by the total of the whole view instead of its own total. So a small tag looked almost empty even when its distribution was identical to a big one. Worse, the tooltip already did the maths correctly, so the tooltip and the bar it described disagreed.
- Text fields (categorical metadata): the chart only shows the most frequent values (e.g. top 3 of 10). The small panel divided by just those 3 visible values, while the full-screen view divided by all 10. So the same bar showed two different percentages depending on where you looked.

|        | reviewed bar       | all_data bar |
|--------|--------------------|--------------|
| Before | 3% (30 ÷ 1,000) ❌ | 30% ✅       |
| Now    | 30% (30 ÷ 100) ✅  | 30% ✅       |

## How has it been tested?

- Manual testing and updated unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed percentage-based numerical metadata comparisons so each tag’s distribution is normalized using its own total.
  * Updated comparison bars to remain accurate when tags contain different numbers of samples.
  * Fixed grouped tooltips so displayed percentages consistently match their corresponding bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->