### PR TITLE
Drop embedding_model_hash from RandomForest and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the LightlyEdge classifier export format. Downloading a classifier no longer asks for a
   format and always writes the scikit-learn format, which is the only one LightlyStudio can load.
+- Dropped the legacy `embedding_model_hash` field from the classifier export format, which bumps its
+  version to 1.1.0. Classifiers exported by older versions can no longer be loaded.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the LightlyEdge classifier export format. Downloading a classifier no longer asks for a
   format and always writes the scikit-learn format, which is the only one LightlyStudio can load.
-- Dropped the legacy `embedding_model_hash` field from the classifier export format, which bumps its
-  version to 1.1.0. Classifiers exported by older versions can no longer be loaded.
+- Dropped the legacy `embedding_model_hash` field from the classifier export format. Classifiers
+  exported by older versions can no longer be loaded.
 
 ### Fixed
 

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -137,7 +137,6 @@ class ClassifierManager:
         classifier = RandomForest(
             name=name,
             classes=class_list,
-            embedding_model_hash=embedding_model.name,
             embedding_model_name=embedding_model.name,
         )
 

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/random_forest_classifier.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/random_forest_classifier.py
@@ -64,9 +64,7 @@ class RandomForest(FewShotClassifier):
                 and predictions. The order of this list determines the order of
                 probability values in predictions.
             embedding_model_name: Name of the model used for creating the
-                embeddings.
-            Note: embedding_model_name is used for traceability in the exported
-            model metadata.
+                embeddings. Used for traceability in the exported model metadata.
 
         Raises:
             ValueError: If classes list is empty.

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/random_forest_classifier.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/random_forest_classifier.py
@@ -23,7 +23,7 @@ from .classifier import AnnotatedEmbedding, FewShotClassifier
 # The version of the file format used for exporting and importing classifiers.
 # This is used to ensure compatibility between different versions of the code.
 # If the format changes, this version should be incremented.
-FILE_FORMAT_VERSION = "1.0.0"
+FILE_FORMAT_VERSION = "1.1.0"
 
 
 @dataclass
@@ -37,7 +37,6 @@ class ModelExportMetadata:
     class_names: list[str]
     num_input_features: int
     num_estimators: int
-    embedding_model_hash: str
     embedding_model_name: str
     sklearn_version: str
 
@@ -49,7 +48,6 @@ class RandomForest(FewShotClassifier):
         name: Name of the classifier.
         classes: Ordered list of class labels used for training and predictions.
         embedding_model_name: Name of the model used for creating the embeddings.
-        embedding_model_hash: Legacy. Filled with the model name.
     """
 
     def __init__(
@@ -57,7 +55,6 @@ class RandomForest(FewShotClassifier):
         name: str,
         classes: list[str],
         embedding_model_name: str,
-        embedding_model_hash: str,
     ) -> None:
         """Initialize the RandomForestClassifier with predefined classes.
 
@@ -68,10 +65,8 @@ class RandomForest(FewShotClassifier):
                 probability values in predictions.
             embedding_model_name: Name of the model used for creating the
                 embeddings.
-            embedding_model_hash: Hash of the model used for creating the
-                embeddings.
-            Note: embedding_model_name and embedding_model_hash are used for
-            traceability in the exported model metadata.
+            Note: embedding_model_name is used for traceability in the exported
+            model metadata.
 
         Raises:
             ValueError: If classes list is empty.
@@ -85,7 +80,6 @@ class RandomForest(FewShotClassifier):
         self.classes = classes
         self._class_to_index = {label: idx for idx, label in enumerate(classes)}
         self.embedding_model_name = embedding_model_name
-        self.embedding_model_hash = embedding_model_hash
 
     def train(self, annotated_embeddings: list[AnnotatedEmbedding]) -> None:
         """Trains a classifier using the provided input.
@@ -172,7 +166,6 @@ class RandomForest(FewShotClassifier):
             class_names=self.classes,
             num_input_features=self._model.n_features_in_,
             num_estimators=len(self._model.estimators_),
-            embedding_model_hash=self.embedding_model_hash,
             embedding_model_name=self.embedding_model_name,
             sklearn_version=sklearn.__version__,
         )
@@ -250,7 +243,6 @@ def load_random_forest_classifier(
         name=metadata.name,
         classes=metadata.class_names,
         embedding_model_name=metadata.embedding_model_name,
-        embedding_model_hash=metadata.embedding_model_hash,
     )
     # Set the model.
     instance._model = model  # noqa: SLF001

--- a/lightly_studio/tests/api/routes/api/test_classifier.py
+++ b/lightly_studio/tests/api/routes/api/test_classifier.py
@@ -207,7 +207,6 @@ def test_load_classifier_from_file(mocker: MockerFixture, test_client: TestClien
         few_shot_classifier=RandomForest(
             name="mock_name",
             classes=["class1", "class2"],
-            embedding_model_hash="mock_hash",
             embedding_model_name="mock_model",
         ),
         classifier_id=mock_id,
@@ -273,7 +272,6 @@ def test_create_classifier(mocker: MockerFixture, test_client: TestClient) -> No
         few_shot_classifier=RandomForest(
             name=mock_name,
             classes=["class1", "class2"],
-            embedding_model_hash="mock_hash",
             embedding_model_name="mock_model",
         ),
         classifier_id=mock_id,
@@ -421,7 +419,6 @@ def test_load_classifier_from_buffer(mocker: MockerFixture, test_client: TestCli
         few_shot_classifier=RandomForest(
             name="mock_name",
             classes=["class1", "class2"],
-            embedding_model_hash="mock_hash",
             embedding_model_name="mock_model",
         ),
         classifier_id=mock_id,

--- a/lightly_studio/tests/few_shot_classifier/test_random_forest_classifier.py
+++ b/lightly_studio/tests/few_shot_classifier/test_random_forest_classifier.py
@@ -23,7 +23,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=["0", "1"],
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         # Create a list of AnnotatedEmbedding objects
@@ -51,7 +50,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=classes,
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         # Step 1: Define embeddings for training
@@ -101,7 +99,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=classes,
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         # Step 1: Define embeddings for training
@@ -137,7 +134,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=["1"],
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         with pytest.raises(
@@ -154,7 +150,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=classes,
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         # Step 1: Define embeddings for training
@@ -183,7 +178,6 @@ class TestRandomForestClassifier:
             RandomForest(
                 name="classifier_name",
                 classes=[],
-                embedding_model_hash="hash",
                 embedding_model_name="name",
             )
 
@@ -221,7 +215,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=classes,
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         classifier.train(annotated_embeddings)
@@ -237,7 +230,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=classes,
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         classifier.train(annotated_embeddings)
@@ -253,7 +245,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=["0", "1"],
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
         # Step 1: Define embeddings for training
@@ -290,7 +281,6 @@ class TestRandomForestClassifier:
         classifier = RandomForest(
             name="classifier_name",
             classes=["0", "1"],
-            embedding_model_hash="hash",
             embedding_model_name="name",
         )
 


### PR DESCRIPTION
## What has changed and why?

`embedding_model_hash` was legacy and only ever filled with the model name.

- Remove it from `RandomForest`, `ModelExportMetadata`, and the export/import path
- Update the `classifier_manager` caller
- Bump classifier `FILE_FORMAT_VERSION` to `1.1.0`

## How has it been tested?

- `make static-checks`
- Classifier tests pass (`test_random_forest_classifier`, `test_classifier`)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Simplified classifier metadata by using the embedding model name for traceability.
  - Updated the classifier file format to version 1.1.0.
  - Improved classifier creation and loading workflows.

- **Breaking Changes**
  - Classifiers exported with older versions that include legacy embedding hash metadata can no longer be loaded. Re-export affected classifiers using the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->