### PR TITLE
Add annotation type filter to subpart diversity sampling

### DIFF
--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -46,6 +46,13 @@ class AnnotationType(str, Enum):
     OBJECT_DETECTION = "object_detection"
 
 
+# Annotation types that have a bounding box and can be cropped for embedding.
+CROPPABLE_ANNOTATION_TYPES = [
+    AnnotationType.OBJECT_DETECTION,
+    AnnotationType.SEGMENTATION_MASK,
+]
+
+
 class AnnotationBaseTable(SQLModel, table=True):
     """Base class for all annotation models."""
 

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_parent_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_parent_sample_ids.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm import joinedload
 from sqlmodel import Session, col, select
 
 from lightly_studio.database import db_array
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationType,
+)
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
@@ -19,9 +22,22 @@ from lightly_studio.resolvers.annotations import annotation_ordering
 def get_all_by_parent_sample_ids(
     session: Session,
     parent_sample_ids: Sequence[UUID],
+    annotation_types: Sequence[AnnotationType] | None = None,
 ) -> Sequence[AnnotationBaseTable]:
-    """Get all annotations belonging to the provided parent sample IDs."""
+    """Get all annotations belonging to the provided parent sample IDs.
+
+    Args:
+        session: Database session.
+        parent_sample_ids: Parent sample IDs to fetch annotations for.
+        annotation_types: Optional annotation types to filter by. ``None`` means
+            no filtering. An empty sequence returns no results.
+
+    Returns:
+        Annotations belonging to the given parent samples.
+    """
     if not parent_sample_ids:
+        return []
+    if annotation_types is not None and not annotation_types:
         return []
     annotations_statement = (
         select(AnnotationBaseTable)
@@ -48,4 +64,8 @@ def get_all_by_parent_sample_ids(
         )
         .options(joinedload(AnnotationBaseTable.sample).load_only(SampleTable.collection_id))  # type: ignore[arg-type]
     )
+    if annotation_types is not None:
+        annotations_statement = annotations_statement.where(
+            col(AnnotationBaseTable.annotation_type).in_(annotation_types)
+        )
     return session.exec(annotations_statement).all()

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_parent_sample_ids_and_annotation_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_parent_sample_ids_and_annotation_collection_id.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm import contains_eager
 from sqlmodel import Session, col, select
 
 from lightly_studio.database import db_array
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationType,
+)
 from lightly_studio.models.sample import SampleTable
 
 
@@ -17,6 +20,7 @@ def get_all_by_parent_sample_ids_and_annotation_collection_id(
     session: Session,
     parent_sample_ids: Sequence[UUID],
     annotation_collection_id: UUID,
+    annotation_types: Sequence[AnnotationType] | None = None,
 ) -> list[AnnotationBaseTable]:
     """Get annotations for parent samples filtered to a specific annotation collection.
 
@@ -29,11 +33,15 @@ def get_all_by_parent_sample_ids_and_annotation_collection_id(
         parent_sample_ids: Parent sample IDs to fetch annotations for.
         annotation_collection_id: ID of the collection that annotation crop samples
             must belong to.
+        annotation_types: Optional annotation types to filter by. ``None`` means
+            no filtering. An empty sequence returns no results.
 
     Returns:
         Annotations belonging to the given parent samples and annotation collection.
     """
     if not parent_sample_ids:
+        return []
+    if annotation_types is not None and not annotation_types:
         return []
     statement = (
         select(AnnotationBaseTable)
@@ -50,4 +58,6 @@ def get_all_by_parent_sample_ids_and_annotation_collection_id(
         .where(col(SampleTable.collection_id) == annotation_collection_id)
         .options(contains_eager(AnnotationBaseTable.sample).load_only(SampleTable.collection_id))  # type: ignore[arg-type]
     )
+    if annotation_types is not None:
+        statement = statement.where(col(AnnotationBaseTable.annotation_type).in_(annotation_types))
     return list(session.exec(statement).all())

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_unembedded_annotation_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_unembedded_annotation_ids.py
@@ -6,17 +6,13 @@ from uuid import UUID
 
 from sqlmodel import Session, col, select
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation.annotation_base import (
+    CROPPABLE_ANNOTATION_TYPES,
+    AnnotationBaseTable,
+)
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
-
-# Annotation types whose crops are embedded. Both store a bounding box, so both are croppable;
-# classification-style annotations are excluded because they have no box.
-_CROPPABLE_ANNOTATION_TYPES = [
-    AnnotationType.OBJECT_DETECTION,
-    AnnotationType.SEGMENTATION_MASK,
-]
 
 
 def get_unembedded_annotation_ids(
@@ -48,7 +44,7 @@ def get_unembedded_annotation_ids(
         .join(SampleTable, col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id))
         .join(ImageTable, col(ImageTable.sample_id) == col(AnnotationBaseTable.parent_sample_id))
         .where(col(SampleTable.collection_id) == annotation_collection_id)
-        .where(col(AnnotationBaseTable.annotation_type).in_(_CROPPABLE_ANNOTATION_TYPES))
+        .where(col(AnnotationBaseTable.annotation_type).in_(CROPPABLE_ANNOTATION_TYPES))
         .where(col(AnnotationBaseTable.sample_id).notin_(embedded_ids_subquery))
         .order_by(col(ImageTable.file_path_abs))
     ).all()

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -14,7 +14,7 @@ from numpy.typing import NDArray
 from sqlmodel import Session, col, select
 
 from lightly_studio.database.db_vector import Embedding
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
@@ -486,12 +486,17 @@ def _get_subpart_embeddings(
             session=session,
             parent_sample_ids=input_sample_ids,
             annotation_collection_id=strat.annotation_source_id,
+            annotation_types=[AnnotationType.OBJECT_DETECTION, AnnotationType.SEGMENTATION_MASK],
         )
     else:
         annotations = list(
             annotation_resolver.get_all_by_parent_sample_ids(
                 session=session,
                 parent_sample_ids=input_sample_ids,
+                annotation_types=[
+                    AnnotationType.OBJECT_DETECTION,
+                    AnnotationType.SEGMENTATION_MASK,
+                ],
             )
         )
     if not annotations:

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -14,7 +14,10 @@ from numpy.typing import NDArray
 from sqlmodel import Session, col, select
 
 from lightly_studio.database.db_vector import Embedding
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation.annotation_base import (
+    CROPPABLE_ANNOTATION_TYPES,
+    AnnotationBaseTable,
+)
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
@@ -486,17 +489,14 @@ def _get_subpart_embeddings(
             session=session,
             parent_sample_ids=input_sample_ids,
             annotation_collection_id=strat.annotation_source_id,
-            annotation_types=[AnnotationType.OBJECT_DETECTION, AnnotationType.SEGMENTATION_MASK],
+            annotation_types=CROPPABLE_ANNOTATION_TYPES,
         )
     else:
         annotations = list(
             annotation_resolver.get_all_by_parent_sample_ids(
                 session=session,
                 parent_sample_ids=input_sample_ids,
-                annotation_types=[
-                    AnnotationType.OBJECT_DETECTION,
-                    AnnotationType.SEGMENTATION_MASK,
-                ],
+                annotation_types=CROPPABLE_ANNOTATION_TYPES,
             )
         )
     if not annotations:

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
     AnnotationDetails,
@@ -72,6 +73,172 @@ def test_get_all_by_parent_sample_ids_with_no_parent_sample_ids_returns_empty_re
 ) -> None:
     result = annotation_resolver.get_all_by_parent_sample_ids(
         session=db_session, parent_sample_ids=[]
+    )
+
+    assert result == []
+
+
+def test_get_all_by_parent_sample_ids__annotation_types_none_returns_all(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+        ],
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_types=None,
+    )
+
+    assert {r.sample_id for r in result} == {a.sample_id for a in annotations}
+
+
+def test_get_all_by_parent_sample_ids__annotation_types_single(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    classification = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+        ],
+    )
+    create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_types=[AnnotationType.CLASSIFICATION],
+    )
+
+    assert [r.sample_id for r in result] == [classification[0].sample_id]
+
+
+def test_get_all_by_parent_sample_ids__annotation_types_multiple(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    classification = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+        ],
+    )
+    object_detection = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+    )
+    create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                segmentation_mask=[0, 1, 0, 1],
+            ),
+        ],
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_types=[AnnotationType.CLASSIFICATION, AnnotationType.OBJECT_DETECTION],
+    )
+
+    assert {r.sample_id for r in result} == {
+        classification[0].sample_id,
+        object_detection[0].sample_id,
+    }
+
+
+def test_get_all_by_parent_sample_ids__annotation_types_empty_returns_empty(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_types=[],
     )
 
     assert result == []

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids_and_annotation_collection_id.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids_and_annotation_collection_id.py
@@ -173,7 +173,7 @@ def test_get_all_by_parent_sample_ids_and_annotation_collection_id__eager_loads_
     assert "sample" not in state.unloaded
 
 
-def test_get_all_by_parent_sample_ids_and_collection__annotation_types_none_returns_all(
+def test_get_all_by_parent_sample_ids_and_annotation_collection_id__annotation_types_none_returns_all(  # noqa: E501
     db_session: Session,
 ) -> None:
     collection = create_collection(session=db_session)
@@ -295,7 +295,7 @@ def test_get_all_by_parent_sample_ids_and_annotation_collection_id__annotation_t
     }
 
 
-def test_get_all_by_parent_sample_ids_and_collection__annotation_types_empty_returns_empty(
+def test_get_all_by_parent_sample_ids_and_annotation_collection_id__annotation_types_empty_returns_empty(  # noqa: E501
     db_session: Session,
 ) -> None:
     collection = create_collection(session=db_session)

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids_and_annotation_collection_id.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids_and_annotation_collection_id.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlalchemy import inspect
 from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
     create_annotation,
@@ -170,3 +171,152 @@ def test_get_all_by_parent_sample_ids_and_annotation_collection_id__eager_loads_
     state = inspect(result[0])
     assert state is not None
     assert "sample" not in state.unloaded
+
+
+def test_get_all_by_parent_sample_ids_and_collection__annotation_types_none_returns_all(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    od_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    cls_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids_and_annotation_collection_id(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=od_annotation.sample.collection_id,
+        annotation_types=None,
+    )
+
+    assert {r.sample_id for r in result} == {
+        od_annotation.sample_id,
+        cls_annotation.sample_id,
+    }
+
+
+def test_get_all_by_parent_sample_ids_and_annotation_collection_id__annotation_types_single(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    cls_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids_and_annotation_collection_id(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=cls_annotation.sample.collection_id,
+        annotation_types=[AnnotationType.CLASSIFICATION],
+    )
+
+    assert [r.sample_id for r in result] == [cls_annotation.sample_id]
+
+
+def test_get_all_by_parent_sample_ids_and_annotation_collection_id__annotation_types_multiple(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    cls_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+    od_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_data={"segmentation_mask": [0, 1, 0, 1]},
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids_and_annotation_collection_id(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=cls_annotation.sample.collection_id,
+        annotation_types=[AnnotationType.CLASSIFICATION, AnnotationType.OBJECT_DETECTION],
+    )
+
+    assert {r.sample_id for r in result} == {
+        cls_annotation.sample_id,
+        od_annotation.sample_id,
+    }
+
+
+def test_get_all_by_parent_sample_ids_and_collection__annotation_types_empty_returns_empty(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids_and_annotation_collection_id(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=annotation.sample.collection_id,
+        annotation_types=[],
+    )
+
+    assert result == []

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from pytest_mock import MockerFixture
 from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import (
     image_resolver,
@@ -1849,6 +1850,166 @@ def test_get_subpart_embeddings__inconsistent_dimensions_across_collections(
             strat=strat,
             input_sample_ids=[img.sample_id for img in parent_images],
         )
+
+
+def test_get_subpart_embeddings__excludes_classification_annotations(
+    db_session: Session,
+) -> None:
+    """Classification annotations are excluded — only OD and segmentation contribute."""
+    parent_collection = create_collection(session=db_session, collection_name="parent")
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=parent_collection.collection_id,
+        label_name="obj",
+    )
+    parent_images = create_images(
+        db_session=db_session,
+        collection_id=parent_collection.collection_id,
+        images=[
+            ImageStub(path="p0.jpg"),
+            ImageStub(path="p1.jpg"),
+        ],
+    )
+    # p0 → object detection crop (should be included).
+    od_annotations = create_annotations(
+        session=db_session,
+        collection_id=parent_collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=parent_images[0].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+    )
+    # p1 → classification crop (should be excluded).
+    cls_annotations = create_annotations(
+        session=db_session,
+        collection_id=parent_collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=parent_images[1].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+        ],
+    )
+    annotation_collection_id = od_annotations[0].annotation_collection_id
+
+    crop_model = create_embedding_model(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_model_name="crop_model",
+    )
+    emb_od = [1.0, 0.0]
+    emb_cls = [0.0, 1.0]
+    create_sample_embedding(
+        session=db_session,
+        sample_id=od_annotations[0].sample_id,
+        embedding_model_id=crop_model.embedding_model_id,
+        embedding=emb_od,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=cls_annotations[0].sample_id,
+        embedding_model_id=crop_model.embedding_model_id,
+        embedding=emb_cls,
+    )
+
+    strat = SubpartDiversityStrategy(embedding_model_name="crop_model")
+    result = _get_subpart_embeddings(
+        session=db_session,
+        strat=strat,
+        input_sample_ids=[img.sample_id for img in parent_images],
+    )
+
+    # p0 (OD): included — its crop embedding is returned.
+    assert len(result[0]) == 1
+    np.testing.assert_array_equal(result[0][0], emb_od)
+    # p1 (classification): excluded — even though its crop has an embedding.
+    assert result[1] == []
+
+
+def test_get_subpart_embeddings__excludes_classification__with_annotation_source(
+    db_session: Session,
+) -> None:
+    """Classification annotations are excluded even when annotation_source_id is set."""
+    parent_collection = create_collection(session=db_session, collection_name="parent")
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=parent_collection.collection_id,
+        label_name="obj",
+    )
+    parent_images = create_images(
+        db_session=db_session,
+        collection_id=parent_collection.collection_id,
+        images=[
+            ImageStub(path="p0.jpg"),
+            ImageStub(path="p1.jpg"),
+        ],
+    )
+    # Both annotations go into the same named collection.
+    od_annotations = create_annotations(
+        session=db_session,
+        collection_id=parent_collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=parent_images[0].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+        collection_name="source",
+    )
+    cls_annotations = create_annotations(
+        session=db_session,
+        collection_id=parent_collection.collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=parent_images[1].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+        ],
+        collection_name="source",
+    )
+    annotation_collection_id = od_annotations[0].annotation_collection_id
+
+    crop_model = create_embedding_model(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_model_name="crop_model",
+    )
+    emb_od = [1.0, 0.0]
+    emb_cls = [0.0, 1.0]
+    create_sample_embedding(
+        session=db_session,
+        sample_id=od_annotations[0].sample_id,
+        embedding_model_id=crop_model.embedding_model_id,
+        embedding=emb_od,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=cls_annotations[0].sample_id,
+        embedding_model_id=crop_model.embedding_model_id,
+        embedding=emb_cls,
+    )
+
+    strat = SubpartDiversityStrategy(
+        annotation_source_id=annotation_collection_id,
+        embedding_model_name="crop_model",
+    )
+    result = _get_subpart_embeddings(
+        session=db_session,
+        strat=strat,
+        input_sample_ids=[img.sample_id for img in parent_images],
+    )
+
+    # p0 (OD): included — its crop embedding is returned.
+    assert len(result[0]) == 1
+    np.testing.assert_array_equal(result[0][0], emb_od)
+    # p1 (classification): excluded — even though its crop has an embedding.
+    assert result[1] == []
 
 
 def _all_sample_ids(session: Session, collection_id: UUID) -> list[UUID]:


### PR DESCRIPTION
## What has changed and why?

Subpart diversity computes diversity over annotation crop embeddings, but classification annotations don't have embeddings; only object detection and segmentation masks produce embeddings. This PR filters subpart diversity sampling by annotation type.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering by annotation type when retrieving annotations.
  * Added support for identifying crop-compatible annotation types.

* **Improvements**
  * Embedding generation now excludes classification annotations and processes only object detection and segmentation annotations.

* **Tests**
  * Added coverage for annotation-type filtering, empty filters, and embedding behavior across supported annotation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->