### PR TITLE
Let the expanded confusion matrix fill the dialog height

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -9,6 +9,7 @@
         VisualMapComponent
     } from 'echarts/components';
     import { CanvasRenderer } from 'echarts/renderers';
+    import { cn } from '$lib/utils';
     import { buildEchartsOption } from './buildEchartsOption';
     import ConfusionMatrixLegend from './ConfusionMatrixLegend.svelte';
     import { OTHER_LABEL } from './topNMatrix';
@@ -109,7 +110,7 @@
 {:else}
     <div
         bind:this={container}
-        class="w-full {fillHeight ? 'min-h-0 flex-1' : ''}"
+        class={cn('w-full', fillHeight && 'min-h-0 flex-1')}
         style={fillHeight ? undefined : `height: ${heightPx}px;`}
         data-testid="confusion-matrix"
     ></div>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -33,6 +33,8 @@
         showLegend?: boolean;
         /** Enables inside (scroll/pinch) zoom on both axes. */
         zoomable?: boolean;
+        /** Fill the parent container height instead of using a calculated pixel value. */
+        fillHeight?: boolean;
         /** Color intensity multiplier (> 0, default 1). */
         colorIntensity?: number;
         /** Map color from log10(count) instead of the raw count (default true). */
@@ -50,6 +52,7 @@
         matrix,
         showLegend = false,
         zoomable = false,
+        fillHeight = false,
         colorIntensity = 1,
         logScale = true,
         onCellClick
@@ -106,8 +109,8 @@
 {:else}
     <div
         bind:this={container}
-        class="w-full"
-        style="height: {heightPx}px;"
+        class="w-full {fillHeight ? 'min-h-0 flex-1' : ''}"
+        style={fillHeight ? undefined : `height: ${heightPx}px;`}
         data-testid="confusion-matrix"
     ></div>
     {#if showLegend}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.svelte
@@ -26,13 +26,14 @@
                 Scroll or pinch inside the chart to zoom · hover a cell for details
             </Dialog.Description>
         </Dialog.Header>
-        <div class="min-h-0 flex-1 overflow-y-auto">
+        <div class="flex min-h-0 flex-1 flex-col">
             <ConfusionMatrix
                 {matrix}
                 {showLegend}
                 colorIntensity={color.intensity}
                 logScale={color.logScale}
                 zoomable
+                fillHeight
                 {onCellClick}
             />
         </div>


### PR DESCRIPTION
## What has changed and why?

Add a `fillHeight` prop to `ConfusionMatrix` that switches from a calculated pixel height to flex-based sizing, letting the chart stretch to fill its parent container.

<img width="1920" height="999" alt="Screenshot 2026-09-01 at 11 27 03" src="https://github.com/user-attachments/assets/995e268b-88b6-4c35-8ba6-d1f351e2e785" />


## How has it been tested?

Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confusion matrices can now optionally expand to fill the available panel height.
  * Expanded confusion matrix views provide improved layout and scrolling behavior.
  * Standard matrix sizing remains unchanged unless the expanded layout is enabled.

* **Bug Fixes**
  * Prevented unnecessary nested scrolling in the expanded matrix dialog.
  * Improved use of available space for charts within expanded views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->