### PR TITLE
Add the Publish Release workflow

### DIFF
--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -1,11 +1,11 @@
-"""Command-line entry point for the prepare-release tooling.
+"""Command-line entry point for the release tooling.
 
-Backs the "Prepare Release" GitHub Actions workflow
-(`.github/workflows/prepare_release.yml`). Each subcommand does one small,
-independently testable piece of preparing a release: promoting the
-changelog and guarding against a handful of ways that can quietly go
-wrong. Reading/bumping/writing the `[project]` version itself is left to
-`uv version --bump` directly in the workflow (see version.py's docstring).
+Backs the "Prepare Release" and "Publish Release" GitHub Actions workflows.
+Each subcommand does one small, independently testable piece of preparing or
+publishing a release: promoting the changelog, assembling the release notes,
+and guarding against a handful of ways those can quietly go wrong. Bumping
+and writing the `[project]` version is left to `uv version --bump` directly
+in the workflow (see version.py's docstring); `read-version` only reads it.
 
 Usage:
     python -m prepare_release promote-changelog --changelog CHANGELOG.md \
@@ -18,13 +18,15 @@ import argparse
 import sys
 from pathlib import Path
 
-from prepare_release import changelog, lock, pr_body, version
+from prepare_release import changelog, lock, pr_body, release_notes, version
 from prepare_release.errors import PrepareReleaseError
 
 CHECK_LABELFORMAT_PIN = "check-labelformat-pin"
 PROMOTE_CHANGELOG = "promote-changelog"
 ASSERT_LOCK_DIFF = "assert-lock-diff"
 RENDER_PR_BODY = "render-pr-body"
+READ_VERSION = "read-version"
+RENDER_RELEASE_NOTES = "render-release-notes"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,6 +58,24 @@ def main(argv: list[str] | None = None) -> int:
     pr_body_parser.add_argument("--version", required=True)
     pr_body_parser.add_argument("--output", type=Path, required=True)
 
+    read_version = subparsers.add_parser(
+        READ_VERSION, help="print the [project] version of a pyproject.toml"
+    )
+    read_version.add_argument("--pyproject", type=Path, required=True)
+
+    release_notes_parser = subparsers.add_parser(
+        RENDER_RELEASE_NOTES, help="assemble the GitHub release body"
+    )
+    release_notes_parser.add_argument("--changelog", type=Path, required=True)
+    release_notes_parser.add_argument("--version", required=True)
+    release_notes_parser.add_argument(
+        "--generated",
+        type=Path,
+        required=True,
+        help="body from the `releases/generate-notes` API",
+    )
+    release_notes_parser.add_argument("--output", type=Path, required=True)
+
     args = parser.parse_args(argv)
 
     try:
@@ -71,6 +91,8 @@ def _dispatch(args: argparse.Namespace) -> int:
         PROMOTE_CHANGELOG: _cmd_promote_changelog,
         ASSERT_LOCK_DIFF: _cmd_assert_lock_diff,
         RENDER_PR_BODY: _cmd_render_pr_body,
+        READ_VERSION: _cmd_read_version,
+        RENDER_RELEASE_NOTES: _cmd_render_release_notes,
     }
     handlers[args.command](args)
     return 0
@@ -104,6 +126,20 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
         changelog_text=args.changelog.read_text(), version=args.version
     )
     body = pr_body.render_pr_body(section_body=section_body, version=args.version)
+    args.output.write_text(body)
+
+
+def _cmd_read_version(args: argparse.Namespace) -> None:
+    print(version.read_project_version(args.pyproject.read_text()))
+
+
+def _cmd_render_release_notes(args: argparse.Namespace) -> None:
+    section = changelog.extract_released_section(
+        changelog_text=args.changelog.read_text(), version=args.version
+    )
+    body = release_notes.render_release_notes(
+        changelog_section=section, generated_notes=args.generated.read_text()
+    )
     args.output.write_text(body)
 
 

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -44,6 +44,7 @@ def render_pr_body(section_body: str, version: str) -> str:
         f"## Review checklist\n\n"
         f"{_GUARDS}\n\n"
         f"{_CHECKLIST}\n\n"
-        f"Merging publishes nothing - tagging, the GitHub release, PyPI and the docs are still "
-        f"manual.\n"
+        f"Merging tags this commit and opens a **draft** GitHub release. Nothing is public "
+        f"until the wheel is on PyPI and someone runs Undraft Release; PyPI and the docs are "
+        f"still manual.\n"
     )

--- a/.github/scripts/prepare_release/release_notes.py
+++ b/.github/scripts/prepare_release/release_notes.py
@@ -1,0 +1,66 @@
+"""Assemble the GitHub release body: the changelog section, then GitHub's own notes.
+
+Backs the "Publish Release" workflow. The `CHANGELOG.md` section leads because
+it is the text the team edited and reviewed on the release PR; GitHub's
+auto-generated notes follow as the full commit-level record.
+
+Those generated notes are built from PR titles, which carry internal ticket
+ids. `RELEASE.md` says to strip them by hand before publishing; this does it
+as a regex.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Discord caps a message body at 4096 characters, so the marker sits before the
+# generated section rather than at the end of the notes.
+DISCORD_STOP_MARKER = "<!-- STOP DISCORD MESSAGE -->"
+
+# Ticket ids as they occur in this repo's PR titles: leading "LIG-10603: ",
+# leading "LIG-10374 ", and trailing "(LIG-10323)" or "(LIG-10089, 2/3)". A
+# bare id mid-title is stripped too - it reads worse than the anchored cases,
+# but an internal ticket id in public release notes is worse still. The
+# trailing rule takes only the two shapes that occur, "(LIG-1)" and
+# "(LIG-1, 2/3)", so a parenthetical carrying anything else keeps its text.
+_LEADING_TICKET_RE = re.compile(r"^LIG[\s-]?\d+\s*:?\s+", re.IGNORECASE)
+_TRAILING_TICKET_RE = re.compile(r"\s*\(LIG[\s-]?\d+(?:,\s*\d+/\d+)?\)", re.IGNORECASE)
+_BARE_TICKET_RE = re.compile(r"\bLIG[\s-]?\d+\b", re.IGNORECASE)
+_ORPHANED_COMMA_RE = re.compile(r"\(\s*,\s*")
+_REPEATED_SPACE_RE = re.compile(r"  +")
+
+# GitHub renders each pull request as "* <title> by @user in <url>".
+_BULLET_RE = re.compile(r"^(?P<bullet>[*-] )(?P<title>.*)$")
+
+
+def render_release_notes(changelog_section: str, generated_notes: str) -> str:
+    """Assembles the release body from the changelog section and GitHub's notes.
+
+    Args:
+        changelog_section: The `[X.Y.Z]` block from `CHANGELOG.md`.
+        generated_notes: The body returned by the releases/generate-notes API.
+
+    Returns:
+        The Markdown body for the GitHub release.
+    """
+    return (
+        f"{changelog_section.strip()}\n\n"
+        f"{DISCORD_STOP_MARKER}\n\n"
+        f"{sanitize_generated_notes(generated_notes).strip()}\n"
+    )
+
+
+def sanitize_generated_notes(notes: str) -> str:
+    """Strips internal ticket ids from the pull request titles in GitHub's notes."""
+    return "\n".join(_sanitize_line(line) for line in notes.splitlines())
+
+
+def _sanitize_line(line: str) -> str:
+    """Strips ticket ids from one bullet, leaving headings and prose untouched."""
+    match = _BULLET_RE.match(line)
+    if match is None:
+        return line
+    title = _LEADING_TICKET_RE.sub("", match["title"])
+    title = _TRAILING_TICKET_RE.sub("", title)
+    title = _ORPHANED_COMMA_RE.sub("(", _BARE_TICKET_RE.sub("", title))
+    return f"{match['bullet']}{_REPEATED_SPACE_RE.sub(' ', title).strip()}"

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -1,12 +1,15 @@
-"""Labelformat git-pin guard.
+"""Version guards and the release version reader.
 
-Reading, bumping, and writing the `[project]` version is left to
+Bumping and writing the `[project]` version is left to
 `uv version --bump` (see the Prepare Release workflow) rather than
 reimplemented here - it already parses/writes real TOML and handles more
 than plain X.Y.Z (alpha/beta/rc/post/dev), which regex-based text editing
-kept getting subtly wrong in review. This module keeps only the guard that
-`uv` has no way to know about: whether Labelformat itself needs a release
-first.
+kept getting subtly wrong in review. This module keeps the guard that `uv`
+has no way to know about - whether Labelformat itself needs a release first -
+and a plain reader for the Publish Release workflow, which must learn the
+version to tag without resolving the project environment first. That reader
+matches a line rather than parsing TOML: `tomllib` is 3.11+, and this CLI has
+to stay importable on whatever `python3` a runner or a laptop provides.
 """
 
 from __future__ import annotations
@@ -14,6 +17,27 @@ from __future__ import annotations
 import re
 
 from prepare_release.errors import PrepareReleaseError
+
+_PROJECT_HEADER_RE = re.compile(r"^\[project\][ \t]*$", re.MULTILINE)
+_ANY_HEADER_RE = re.compile(r"^\[", re.MULTILINE)
+_VERSION_RE = re.compile(r"^version[ \t]*=[ \t]*[\"'](?P<version>[^\"']+)[\"']", re.MULTILINE)
+
+
+def read_project_version(pyproject_text: str) -> str:
+    """Reads the version out of the `[project]` table of a pyproject.toml.
+
+    The tag comes from the package rather than from workflow input, so the two
+    can never disagree. Only the `[project]` table is searched, so a `version`
+    in a later table cannot be picked up by mistake.
+
+    Raises:
+        PrepareReleaseError: There is no `[project]` table, or it declares no
+            plain `version = "..."`.
+    """
+    match = _VERSION_RE.search(_project_table(pyproject_text))
+    if match is None:
+        raise PrepareReleaseError('no plain `version = "..."` found in the [project] table')
+    return match["version"]
 
 
 def check_labelformat_pin(pyproject_text: str) -> None:
@@ -52,3 +76,13 @@ def _strip_comment(line: str) -> str:
         elif char == "#":
             return line[:i]
     return line
+
+
+def _project_table(pyproject_text: str) -> str:
+    """Returns the body of the `[project]` table, up to the next table header."""
+    header = _PROJECT_HEADER_RE.search(pyproject_text)
+    if header is None:
+        raise PrepareReleaseError("no [project] table found in pyproject.toml")
+    next_header = _ANY_HEADER_RE.search(pyproject_text, header.end())
+    end = next_header.start() if next_header else len(pyproject_text)
+    return pyproject_text[header.end() : end]

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -15,4 +15,4 @@ def test_render_pr_body__review_checklist():
 
 def test_render_pr_body__says_merging_publishes_nothing():
     body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
-    assert "Merging publishes nothing" in body
+    assert "opens a **draft** GitHub release" in body

--- a/.github/scripts/tests/test_release_notes.py
+++ b/.github/scripts/tests/test_release_notes.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from prepare_release import release_notes
+
+GENERATED = """\
+## What's Changed
+* LIG-10603: Compare metadata distributions by sample tags by @dev in https://x/pull/2096
+* LIG-10374 Add GCS cloud credential runtime support by @dev in https://x/pull/1844
+* Backend, Part 0: Fix typo in parameter test filename (LIG-10323) by @dev in https://x/pull/1797
+* Show an image preview when hovering (LIG-10089, 3/3) by @dev in https://x/pull/1561
+* Fix: Update caption item view by @dev in https://x/pull/2151
+
+**Full Changelog**: https://x/compare/v1.0.4...v1.0.5
+"""
+
+
+def test_render_release_notes():
+    body = release_notes.render_release_notes(
+        changelog_section="### Added\n\n- A thing.", generated_notes="## What's Changed\n* A by @d"
+    )
+
+    assert body == (
+        "### Added\n\n- A thing.\n\n<!-- STOP DISCORD MESSAGE -->\n\n## What's Changed\n* A by @d\n"
+    )
+
+
+# Discord caps the message body, so the marker must precede the generated notes.
+def test_render_release_notes__marker_precedes_the_generated_notes():
+    body = release_notes.render_release_notes(
+        changelog_section="### Added\n\n- A thing.", generated_notes="## What's Changed\n* A by @d"
+    )
+
+    assert body.index(release_notes.DISCORD_STOP_MARKER) < body.index("What's Changed")
+
+
+def test_sanitize_generated_notes():
+    sanitized = release_notes.sanitize_generated_notes(GENERATED)
+
+    assert "LIG" not in sanitized
+    assert sanitized.splitlines()[1].startswith("* Compare metadata distributions by sample tags")
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("LIG-10603: Compare distributions", "Compare distributions"),
+        ("LIG-10374 Add GCS support", "Add GCS support"),
+        ("lig 10374 Add GCS support", "Add GCS support"),
+        ("Fix typo in filename (LIG-10323)", "Fix typo in filename"),
+        ("Show a preview (LIG-10089, 3/3)", "Show a preview"),
+        ("Fix: Update caption item view", "Fix: Update caption item view"),
+        ("Add support for LIGHTLY tokens", "Add support for LIGHTLY tokens"),
+        # A bare id mid-title is not anchored at either end, so it needs its
+        # own rule; the result reads a little thin, which beats leaking it.
+        ("Fix the LIG-10603 regression", "Fix the regression"),
+        ("Revert LIG 10374 and retry", "Revert and retry"),
+        # Only "(LIG-1)" and "(LIG-1, 2/3)" are dropped whole; a parenthetical
+        # carrying anything else keeps the rest of its text.
+        ("Document migration (LIG-123, breaking change)", "Document migration (breaking change)"),
+        ("Show a preview (LIG-10089, 1/3)", "Show a preview"),
+    ],
+)
+def test_sanitize_generated_notes__pull_request_titles(title: str, expected: str):
+    line = f"* {title} by @dev in https://x/pull/1"
+
+    assert (
+        release_notes.sanitize_generated_notes(line) == f"* {expected} by @dev in https://x/pull/1"
+    )
+
+
+# Headings and the trailing "Full Changelog" line are not pull request titles.
+def test_sanitize_generated_notes__leaves_non_bullet_lines_alone():
+    notes = "## What's Changed\n**Full Changelog**: https://x/compare/v1.0.4...v1.0.5"
+
+    assert release_notes.sanitize_generated_notes(notes) == notes

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -52,3 +52,24 @@ def test_check_labelformat_pin__git_sha_raises(replacement):
     text = SAMPLE_PYPROJECT.replace('"labelformat>=0.1.17"', replacement)
     with pytest.raises(PrepareReleaseError, match="git sha"):
         version.check_labelformat_pin(text)
+
+
+def test_read_project_version():
+    assert version.read_project_version(SAMPLE_PYPROJECT) == "1.0.5"
+
+
+def test_read_project_version__release_candidate():
+    assert version.read_project_version('[project]\nversion = "1.0.0rc1"\n') == "1.0.0rc1"
+
+
+# A `version` in a later table must not be mistaken for the project's own.
+def test_read_project_version__ignores_other_tables():
+    pyproject = '[project]\nname = "lightly-studio"\n\n[tool.uv]\nversion = "9.9.9"\n'
+
+    with pytest.raises(PrepareReleaseError):
+        version.read_project_version(pyproject)
+
+
+def test_read_project_version__missing_project_table_is_refused():
+    with pytest.raises(PrepareReleaseError):
+        version.read_project_version('[tool.uv]\nversion = "1.0.0"\n')

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,223 @@
+name: Publish Release
+
+on:
+  # Merging the "Bump version to X.Y.Z" pull request is the decision to
+  # release, so it is what starts this. The path filter is only a cheap
+  # pre-filter; what is released is worked out below.
+  push:
+    branches: [main]
+    paths: ["lightly_studio/pyproject.toml"]
+  # Retry hatch for a run that failed on something transient. It reaches the
+  # same commit as the push would, so it is safe to run at any time.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PYTHONPATH: ${{ github.workspace }}/.github/scripts
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # The tooling is taken from main, never from the released commit: running
+      # that commit's own release code would execute it with a write token.
+      - name: Checkout the release tooling
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Find the version and the commit that set it
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUSHED: ${{ github.sha }}
+        # A merge queue batch lands as a single push, so the commit that
+        # triggered this run is the tip of the batch and not necessarily the
+        # version bump - which is how a release ends up containing more than
+        # its changelog section describes. Walk back through the commits that
+        # touched pyproject.toml to the one that introduced this version, and
+        # release that. Between releases only a handful of commits touch the
+        # file, so one page is ample; not finding the bump is an error rather
+        # than a guess.
+        run: |
+          set -euo pipefail
+          version_at() {
+            gh api "repos/${GITHUB_REPOSITORY}/contents/lightly_studio/pyproject.toml?ref=$1" \
+              -H "Accept: application/vnd.github.raw" > "${RUNNER_TEMP}/pyproject-$1.toml"
+            python3 -m prepare_release read-version --pyproject "${RUNNER_TEMP}/pyproject-$1.toml"
+          }
+
+          # A dispatch can be started from any branch, so it is pinned to main
+          # rather than trusting the ref it was launched from.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            tip="${PUSHED}"
+          else
+            tip="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
+            echo "Dispatched run: releasing from main (${tip})."
+          fi
+
+          version="$(version_at "${tip}")"
+          bump=""
+          reached_previous_version=false
+          for commit in $(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits?path=lightly_studio/pyproject.toml&sha=${tip}&per_page=100" \
+            --jq '.[].sha'); do
+            if [ "$(version_at "${commit}")" = "${version}" ]; then
+              bump="${commit}"
+            else
+              reached_previous_version=true
+              break
+            fi
+          done
+
+          if [ -z "${bump}" ] || [ "${reached_previous_version}" = false ]; then
+            echo "::error::Could not identify the commit that set version ${version}."
+            exit 1
+          fi
+
+          {
+            echo "sha=${bump}"
+            echo "version=${version}"
+            echo "tag=v${version}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Version ${version} was set by ${bump}."
+
+      - name: Decide whether there is a release to cut
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+        # Whether this version is already released is the whole question, so it
+        # is asked directly. Absence is an answer and is matched on the status
+        # code, not on the message: a missing tag and a missing release do not
+        # report it the same way. Anything else is a failure to read and must
+        # not be mistaken for absence.
+        run: |
+          set -euo pipefail
+          absent_or_fail() {
+            if grep -q "(HTTP 404)" "$1"; then
+              return 0
+            fi
+            echo "::error::Could not read $2:"
+            cat "$1"
+            exit 1
+          }
+
+          # git/ref/tags answers a missing tag with 404, where commits/<tag>
+          # answers 422; an annotated tag points at a tag object, so it has to
+          # be dereferenced to reach the commit.
+          tag_commit=""
+          if ref="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
+                     --jq '"\(.object.type) \(.object.sha)"' 2>"${RUNNER_TEMP}/tag-err")"; then
+            if [ "${ref% *}" = "tag" ]; then
+              tag_commit="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${ref#* }" --jq .object.sha)"
+            else
+              tag_commit="${ref#* }"
+            fi
+          else
+            absent_or_fail "${RUNNER_TEMP}/tag-err" "tag ${TAG}"
+          fi
+
+          state=none
+          if draft="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .draft \
+                       2>"${RUNNER_TEMP}/release-err")"; then
+            if [ "${draft}" = "true" ]; then state=draft; else state=published; fi
+          else
+            absent_or_fail "${RUNNER_TEMP}/release-err" "release ${TAG}"
+          fi
+
+          # A draft is left strictly alone. It is the one place a person edits
+          # the notes by hand, and a later pyproject.toml change must not
+          # rewrite that.
+          if [ "${state}" != "none" ]; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${TAG} already has a ${state} release; nothing to do."
+            exit 0
+          fi
+
+          if [ -n "${tag_commit}" ] && [ "${tag_commit}" != "${SHA}" ]; then
+            echo "::error::${TAG} already exists on ${tag_commit}, not on ${SHA}."
+            exit 1
+          fi
+
+          {
+            echo "release=true"
+            echo "tag_exists=$([ -n "${tag_commit}" ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+      # TODO(Iunir, 09/2026): Enable once the check-release-ci action lands
+      # (#2125, #2126). Until then whoever merges the bump PR confirms CI.
+      # - name: Require green CI on the release commit
+      #   if: steps.decide.outputs.release == 'true'
+      #   uses: ./.github/actions/check-release-ci
+      #   with:
+      #     ref: ${{ steps.resolve.outputs.sha }}
+      #     github-token: ${{ github.token }}
+
+      # Before the tag, so a failure here leaves nothing to clean up.
+      - name: Assemble the release notes
+        if: steps.decide.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=${SHA}" \
+            -H "Accept: application/vnd.github.raw" > "${RUNNER_TEMP}/CHANGELOG.md"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="${TAG}" \
+            -f target_commitish="${SHA}" \
+            --jq .body > "${RUNNER_TEMP}/generated-notes.md"
+          python3 -m prepare_release render-release-notes \
+            --changelog "${RUNNER_TEMP}/CHANGELOG.md" \
+            --version "${VERSION}" \
+            --generated "${RUNNER_TEMP}/generated-notes.md" \
+            --output "${RUNNER_TEMP}/release-notes.md"
+          cat "${RUNNER_TEMP}/release-notes.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create the annotated tag
+        if: steps.decide.outputs.release == 'true' && steps.decide.outputs.tag_exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        # Created through the API so the checkout keeps `persist-credentials: false`;
+        # `gh release create` would only make a lightweight tag.
+        run: |
+          set -euo pipefail
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags" \
+            -f tag="${TAG}" \
+            -f message="LightlyStudio ${VERSION}" \
+            -f object="${SHA}" \
+            -f type=commit \
+            --jq .sha)"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${tag_sha}" >/dev/null
+          echo "Tagged ${SHA} as ${TAG}."
+
+      - name: Create the draft release
+        if: steps.decide.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release create "${TAG}" --repo "${REPO}" \
+            --draft \
+            --title "${TAG}" \
+            --notes-file "${RUNNER_TEMP}/release-notes.md"
+          echo "::notice::Draft release ${TAG} ready. Publish to PyPI, then un-draft it."


### PR DESCRIPTION
Automates tagging and drafting the GitHub release, which is done by hand today.

## What has changed and why?

- **`Publish Release` starts on its own when the version bump PR is merged.** Merging that PR is already the decision to release, so it is what triggers this. There is no `ref` parameter to get wrong.
- **It releases the commit that set the version, not the commit that triggered the run.** A merge queue batch lands as a single push, so the triggering commit is the tip of the batch and can sit past the bump - which is how a release ends up containing more than its changelog section describes. The workflow walks back through the commits touching `pyproject.toml` to the one that introduced the version. `workflow_dispatch`, the retry hatch, takes the same path, so it cannot drift to a branch tip either.
- **Whether there is anything to do is one question**: is this version already released? An ordinary dependency change to `pyproject.toml` resolves to an already-published version and ends the run green rather than failing it. A "not found" is treated as an answer; any other API error fails the run instead of being mistaken for one.
- **The version is read from the package** on that commit, so the tag can never disagree with what is released.
- **Release notes are assembled instead of hand-edited**: the `CHANGELOG.md` section first, then GitHub's generated notes with internal ticket ids stripped out of the pull request titles.
- **The release is created as a draft.** PyPI publishing happens afterwards, and if it fails, a published release is one users can see but cannot install. A draft can simply be deleted, which keeps that failure recoverable - and now that the trigger is automatic, un-drafting is the one human checkpoint left.
- **Un-drafting is a separate workflow**, added in #2174 on top of this one, so it can be re-run on its own once the wheel is up.
- **The CI gate step is included but commented out** (TODO points at #2125 / #2126). Until it is enabled, whoever dispatches the workflow confirms CI is green, exactly as today.

## How has it been tested?

`make static-checks` and `make test` pass (52 tests). The notes pipeline was dry-run against the real `v1.0.5` data: both ticket ids were stripped and the Discord marker landed before the generated section.

The resolve and decide steps were extracted from the workflow file itself and run against a stubbed `gh`, so the tests cannot drift from what ships. Resolve: a merge queue batch whose tip is not the bump (picks the bump), a later dependency change (still picks the bump), and a window where the version never changes (refuses to guess). Decide: fresh bump, retry onto an existing draft, dependency push after publication (green no-op), tag on a different commit (fails), and a 502 on either lookup (fails rather than reading it as "not found").

The workflow cannot be dispatched until it is on `main`, so it has not run yet.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly, alternatively @JonasWurst.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release publishing when a new project version reaches the main branch.
  * Releases now include an annotated version tag and a draft GitHub release.
  * Release notes combine changelog content with generated notes.
  * Generated note titles are cleaned up for clearer presentation while preserving headings and links.
  * Added safeguards to prevent duplicate or conflicting version tags.

* **Tests**
  * Added coverage for release-note formatting and project-version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->