### PR TITLE
Add the Undraft Release workflow

### DIFF
--- a/.github/workflows/undraft_release.yml
+++ b/.github/workflows/undraft_release.yml
@@ -1,0 +1,47 @@
+name: Undraft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag of the draft release to publish, e.g. v1.2.3.
+        type: string
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  undraft-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Require the version on PyPI
+        env:
+          TAG: ${{ inputs.tag }}
+        # The release is drafted so that a failed PyPI publish stays
+        # recoverable; publishing it before the wheel is installable is the
+        # state that drafting exists to avoid.
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          status="$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/lightly-studio/${version}/json")"
+          if [ "${status}" != "200" ]; then
+            echo "::error::lightly-studio ${version} is not on PyPI (HTTP ${status}). Publish the wheel first."
+            exit 1
+          fi
+
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq .isDraft)" != "true" ]; then
+            echo "::error::${TAG} is not a draft release."
+            exit 1
+          fi
+          gh release edit "${TAG}" --repo "${REPO}" --draft=false
+          echo "::notice::Published ${TAG}."

--- a/.github/workflows/undraft_release.yml
+++ b/.github/workflows/undraft_release.yml
@@ -25,10 +25,16 @@ jobs:
         run: |
           set -euo pipefail
           version="${TAG#v}"
-          status="$(curl -sS -o /dev/null -w '%{http_code}' \
+          status="$(curl -sS -o "${RUNNER_TEMP}/pypi.json" -w '%{http_code}' \
             "https://pypi.org/pypi/lightly-studio/${version}/json")"
           if [ "${status}" != "200" ]; then
             echo "::error::lightly-studio ${version} is not on PyPI (HTTP ${status}). Publish the wheel first."
+            exit 1
+          fi
+          # A version record outlives its files: a half-finished upload or a yank still answers 200.
+          if ! python3 -c 'import json, sys; sys.exit(0 if any(f["packagetype"] == "bdist_wheel" and not f["yanked"] for f in json.load(open(sys.argv[1]))["urls"]) else 1)' \
+            "${RUNNER_TEMP}/pypi.json"; then
+            echo "::error::lightly-studio ${version} has no installable wheel on PyPI."
             exit 1
           fi
 


### PR DESCRIPTION
## What has changed and why?

- Publishing the draft release that #2173 creates is its own `workflow_dispatch` workflow, so it can be re-run on its own after a failed PyPI publish has been fixed.
- It refuses to run on a release that is not a draft, so a second dispatch fails clearly instead of doing nothing.
- Un-drafting is what fires the `release: published` event, so anything keyed off that announces a release only once the wheel is actually installable.

## How has it been tested?

Not yet dispatched - a `workflow_dispatch` workflow cannot run until it is on `main`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly, alternatively @JonasWurst.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered workflow for publishing draft releases.
  - Verifies that the matching package version is available and includes a non-yanked wheel before publishing.
  - Confirms the release remains in draft status and reports successful publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->