### PR TITLE
Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -34,7 +34,7 @@ jobs:
       file-hash: ${{ steps.file-hash.outputs.hash }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -279,7 +279,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/fast_track_bot.yml
+++ b/.github/workflows/fast_track_bot.yml
@@ -44,7 +44,7 @@ jobs:
       # No ref: checkout the trusted default branch, never the PR head. Checkout
       # must precede artifact download because it cleans the working tree.
       - name: Checkout Trusted Bot Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: fast_track
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Never pushes — keep the git token out of the checkout. This job runs PR code
         # (builds and tests) with the workflow token, and the job's `if` restricts it to
         # same-repo PRs, so untrusted fork code never runs in that context.

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -35,7 +35,7 @@ jobs:
       release_tooling: ${{ steps.filter.outputs.release_tooling || 'true' }}
     steps:
       - name: Checkout Code # Needed for merge_group event
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Filter changed paths
         id: filter
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -171,7 +171,7 @@ jobs:
             make_target: test-postgres
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -299,7 +299,7 @@ jobs:
         working-directory: fast_track
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Pin Node from .nvmrc, matching the local Makefile's nvm setup.
       - name: Set Up Node
@@ -334,7 +334,7 @@ jobs:
         working-directory: .github/scripts
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## What has changed and why?

- Bumps all 13 `actions/checkout@v6` uses to `@v7`, across five workflows. Nothing else changes - the whole diff is 13 lines, each the same substitution.
- v7 has been out since 20 July 2026 (currently v7.0.1). Its only breaking change blocks checking out a **fork** pull request head under `pull_request_target` or `workflow_run`.
- The only `workflow_run` workflow here is `fast_track_bot.yml`, and it deliberately checks out the trusted default branch rather than the PR head, so it is unaffected. No checkout in the repo passes a `ref` or `repository` that would trip the new restriction.

## How has it been tested?

Every touched workflow still parses. The real test is CI on this PR: `unit_test.yml` and `end2end_test.yml` account for 10 of the 13 uses, so a green run exercises them directly.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly, alternatively @JonasWurst.
