### PR TITLE
perf: remove the N+1 in the embed_videos video path fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDK (beta): Simplified embedding generator interface. Implement `embedding_space_spec`, returning the new `EmbeddingSpaceSpec` (`space_key`, `dimension`) instead of the former `get_embedding_model_input`.
 - Bump lightly-mundig to 0.1.15; its sampling algorithms are up to 7x faster.
 - Python SDK: Split a dataset into new sample tags with `DatasetQuery.split()`
+- Reduce the number of database queries when embedding videos by fetching the video paths in one query instead of one per video.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDK (beta): Simplified embedding generator interface. Implement `embedding_space_spec`, returning the new `EmbeddingSpaceSpec` (`space_key`, `dimension`) instead of the former `get_embedding_model_input`.
 - Bump lightly-mundig to 0.1.15; its sampling algorithms are up to 7x faster.
 - Python SDK: Split a dataset into new sample tags with `DatasetQuery.split()`
-- Reduce the number of database queries when embedding videos by fetching the video paths in a batched lookup instead of one query per video.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDK (beta): Simplified embedding generator interface. Implement `embedding_space_spec`, returning the new `EmbeddingSpaceSpec` (`space_key`, `dimension`) instead of the former `get_embedding_model_input`.
 - Bump lightly-mundig to 0.1.15; its sampling algorithms are up to 7x faster.
 - Python SDK: Split a dataset into new sample tags with `DatasetQuery.split()`
-- Reduce the number of database queries when embedding videos by fetching the video paths in one query instead of one per video.
+- Reduce the number of database queries when embedding videos by fetching the video paths in a batched lookup instead of one query per video.
 
 ### Deprecated
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -397,15 +397,11 @@ class EmbeddingManager:
         if not isinstance(model, VideoEmbeddingGenerator):
             raise ValueError("Embedding model not compatible with videos.")
 
-        # Get the samples
-        filepaths = []
-        for sample_id in sample_ids:
-            sample = video_resolver.get_by_id(session=session, sample_id=sample_id)
-            if sample is not None:
-                filepaths.append(sample.file_path_abs)
-
-        if len(filepaths) != len(sample_ids):
+        # One batched query for all video paths. A length mismatch means an id has no video.
+        videos = video_resolver.get_many_by_id(session=session, sample_ids=sample_ids)
+        if len(videos) != len(sample_ids):
             raise ValueError("Could not fetch all video paths for the provided IDs.")
+        filepaths = [video.file_path_abs for video in videos]
 
         # Generate embeddings for the samples.
         result = model.embed_videos(filepaths=filepaths)

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -815,12 +815,12 @@ def test_embed_videos__raises_when_a_video_is_missing(
         videos=[VideoStub(path="/videos/video_0.mp4", duration_s=1.0, fps=24.0)],
     )
     manager = EmbeddingManager()
-    manager.register_embedding_model(
+    model_id = manager.register_embedding_model(
         session=db_session,
         embedding_generator=RandomEmbeddingGenerator(),
         collection_id=collection_id,
         set_as_default=True,
-    )
+    ).embedding_model_id
 
     missing_id = UUID(int=1234567)
     with pytest.raises(ValueError, match="Could not fetch all video paths"):
@@ -829,6 +829,12 @@ def test_embed_videos__raises_when_a_video_is_missing(
             collection_id=collection_id,
             sample_ids=[*video_ids, missing_id],
         )
+
+    # A missing video must fail before any embedding is stored, so nothing is persisted.
+    stored_embeddings = db_session.exec(
+        select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
+    ).all()
+    assert not stored_embeddings
 
 
 def test_embed_videos_skips_broken_videos(

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -803,6 +803,34 @@ def test_embed_videos(
         assert embedding.sample_id in video_ids
 
 
+def test_embed_videos__raises_when_a_video_is_missing(
+    db_session: Session,
+) -> None:
+    """Raises a ValueError when a sample_id has no video, instead of embedding a subset."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    collection_id = video_collection.collection_id
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=collection_id,
+        videos=[VideoStub(path="/videos/video_0.mp4", duration_s=1.0, fps=24.0)],
+    )
+    manager = EmbeddingManager()
+    manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=collection_id,
+        set_as_default=True,
+    )
+
+    missing_id = UUID(int=1234567)
+    with pytest.raises(ValueError, match="Could not fetch all video paths"):
+        manager.embed_videos(
+            session=db_session,
+            collection_id=collection_id,
+            sample_ids=[*video_ids, missing_id],
+        )
+
+
 def test_embed_videos_skips_broken_videos(
     db_session: Session,
 ) -> None:


### PR DESCRIPTION
## What has changed and why?

`EmbeddingManager.embed_videos` fetched one video per query in a loop, an N+1: N video ids ran N separate database queries. It now uses the existing batched `video_resolver.get_many_by_id`, so the path fetch runs one query instead of N (a few for very large lists, since the helper batches at 8000). The returned paths and their order are unchanged.

This mainly reduces the query count and the database load of the path fetch, from N queries to about one. The wall-clock effect is small. In a measured run on a laptop GPU the full per-video embedding cost was about 65 ms and the path fetch was about 1.9 ms, so the fetch was about 3 percent of the end-to-end time. The embedding step, which decodes each video and runs a model forward pass, is the dominant cost. On a remote PostgreSQL the fetch share is somewhat higher, since each query pays a network round-trip.

The error path changes slightly. The old `get_by_id` used `.one()`, which raised `NoResultFound` on a missing id, so the `if sample is not None` branch was dead and a missing id never raised the `ValueError` the docstring promises. The batched version raises that documented `ValueError`. No test or caller depended on the old exception.

## How has it been tested?

- `ruff check`, `ruff format --check`, and `mypy` pass on the changed files.
- `pytest tests/dataset/test_embedding_manager.py` passes, 42 tests. This includes the existing `test_embed_videos` and a new `test_embed_videos__raises_when_a_video_is_missing`, which covers the missing-id error path that was previously unreachable.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes (a `### Changed` bullet under Unreleased)
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced database query overhead during video embedding by fetching video paths through a single batched lookup rather than individual queries.

* **Bug Fixes**
  * Embedding now clearly reports an error when a requested video cannot be found and avoids saving partial results.

* **Tests**
  * Added coverage for missing-video handling, error reporting, and preventing persisted embeddings after a failed operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->