### PR TITLE
Add RandomEmbedder implementing all capabilities

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -21,10 +21,6 @@ from lightly_studio.embed.embedder import (
 
 logger = logging.getLogger(__name__)
 
-# Maps each capability to the embedder subclass that implements it. Left
-# unannotated on purpose: annotating the values as ``type[Embedder]`` trips
-# mypy's ``type-abstract`` check, which assumes such types get instantiated. We
-# only use these classes for ``isinstance``.
 _CAPABILITY_TO_TYPE = {
     Capability.IMAGE_PATH: ImagePathEmbedder,
     Capability.CROP_PATH: CropPathEmbedder,
@@ -38,9 +34,9 @@ _CAPABILITY_TO_TYPE = {
 class EmbedderRegistry:
     """Stores embedders keyed by embedding space and capability.
 
-    An embedder can provide several capabilities. It is registered under one key
-    per capability it implements. Each ``(space_key, capability)`` pair maps to a
-    single embedder; registering another embedder for the same pair replaces it.
+    An embedder can provide several capabilities. For a given space, the registry
+    stores at most one embedder per capability. Registering an embedder for the same
+    space and capability replaces the old one.
     """
 
     def __init__(self) -> None:

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -18,6 +18,7 @@ from lightly_studio.embed.embedder import (
     TextEmbedder,
     VideoPathEmbedder,
 )
+from lightly_studio.embed.types import EmbeddingSpaceSpec
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class EmbedderRegistry:
     def __init__(self) -> None:
         """Create an empty registry."""
         self._by_space_and_capability: dict[tuple[str, Capability], Embedder] = {}
+        self._spec_by_space: dict[str, EmbeddingSpaceSpec] = {}
 
     def register(self, embedder: Embedder) -> None:
         """Register an embedder under every capability it implements.
@@ -53,9 +55,20 @@ class EmbedderRegistry:
             embedder: The embedder to register.
 
         Raises:
-            ValueError: If the embedder implements no capability.
+            ValueError: If the embedder's embedding space shares a ``space_key``
+                with an already registered space but does not match its spec, or
+                if the embedder implements no capability.
         """
-        space_key = embedder.embedding_space_spec().space_key
+        spec = embedder.embedding_space_spec()
+        space_key = spec.space_key
+        registered_spec = self._spec_by_space.get(space_key)
+        if registered_spec is not None and registered_spec != spec:
+            raise ValueError(
+                f"Embedding space {space_key!r} is already registered as {registered_spec}, "
+                f"cannot register the incompatible {spec}."
+            )
+        self._spec_by_space[space_key] = spec
+
         capabilities = _capabilities_of(embedder=embedder)
         if not capabilities:
             raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -1,7 +1,8 @@
-"""Registry that maps embedding spaces and capabilities to embedders.
+"""Registry that maps embedding spaces to embedders.
 
-Holds at most one embedder per ``(space_key, capability)`` pair. Callers look up
-an embedder by the capability they need with the matching typed getter.
+Holds at most one embedder per ``space_key``. Callers look up an embedder by the
+capability they need with the matching typed getter, which returns the space's
+embedder only when it implements that capability.
 """
 
 from __future__ import annotations
@@ -18,7 +19,6 @@ from lightly_studio.embed.embedder import (
     TextEmbedder,
     VideoPathEmbedder,
 )
-from lightly_studio.embed.types import EmbeddingSpaceSpec
 
 logger = logging.getLogger(__name__)
 
@@ -33,89 +33,76 @@ _CAPABILITY_TO_TYPE = {
 
 
 class EmbedderRegistry:
-    """Stores embedders keyed by embedding space and capability.
+    """Stores at most one embedder per embedding space.
 
-    An embedder can provide several capabilities. For a given space, the registry
-    stores at most one embedder per capability. Registering an embedder for the same
-    space and capability replaces the old one.
+    An embedder can provide several capabilities. The registry keeps one embedder
+    per ``space_key``; registering another embedder for the same space replaces
+    it. The typed getters return the space's embedder only when it implements the
+    requested capability.
     """
 
     def __init__(self) -> None:
         """Create an empty registry."""
-        self._by_space_and_capability: dict[tuple[str, Capability], Embedder] = {}
-        self._spec_by_space: dict[str, EmbeddingSpaceSpec] = {}
+        self._space_key_to_embedder: dict[str, Embedder] = {}
 
     def register(self, embedder: Embedder) -> None:
-        """Register an embedder under every capability it implements.
+        """Register an embedder for its embedding space.
 
-        The capabilities are inferred from the embedder's type. The embedding
-        space is read from ``embedder.embedding_space_spec()``.
+        The embedding space is read from ``embedder.embedding_space_spec()``. If an
+        embedder is already registered for the same space, it is replaced.
 
         Args:
             embedder: The embedder to register.
 
         Raises:
-            ValueError: If the embedder's embedding space shares a ``space_key``
-                with an already registered space but does not match its spec, or
-                if the embedder implements no capability.
+            ValueError: If the embedder implements no capability, or if it shares
+                a ``space_key`` with an already registered embedder but does not
+                match its spec.
         """
         spec = embedder.embedding_space_spec()
         space_key = spec.space_key
-        capabilities = _capabilities_of(embedder=embedder)
-        if not capabilities:
+        if not _capabilities_of(embedder=embedder):
             raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")
-        registered_spec = self._spec_by_space.get(space_key)
-        if registered_spec is not None and registered_spec != spec:
-            raise ValueError(
-                f"Embedding space {space_key!r} is already registered as {registered_spec}, "
-                f"cannot register the incompatible {spec}."
-            )
-        self._spec_by_space[space_key] = spec
-        for capability in capabilities:
-            key = (space_key, capability)
-            if key in self._by_space_and_capability:
-                logger.warning(
-                    "Replacing embedder for space %r and capability %s.",
-                    space_key,
-                    capability.value,
+        registered = self._space_key_to_embedder.get(space_key)
+        if registered is not None:
+            registered_spec = registered.embedding_space_spec()
+            if registered_spec != spec:
+                raise ValueError(
+                    f"Embedding space {space_key!r} is already registered as {registered_spec}, "
+                    f"cannot register the incompatible {spec}."
                 )
-            self._by_space_and_capability[key] = embedder
+            logger.warning("Replacing embedder for space %r.", space_key)
+        self._space_key_to_embedder[space_key] = embedder
 
     def get_image_path_embedder(self, space_key: str) -> ImagePathEmbedder | None:
-        """Get the embedder that embeds images by path for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.IMAGE_PATH))
-        assert embedder is None or isinstance(embedder, ImagePathEmbedder)
-        return embedder
+        """Get the space's embedder if it embeds images by path, else None."""
+        embedder = self._space_key_to_embedder.get(space_key)
+        return embedder if isinstance(embedder, ImagePathEmbedder) else None
 
     def get_crop_path_embedder(self, space_key: str) -> CropPathEmbedder | None:
-        """Get the embedder that embeds crops by path for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.CROP_PATH))
-        assert embedder is None or isinstance(embedder, CropPathEmbedder)
-        return embedder
+        """Get the space's embedder if it embeds crops by path, else None."""
+        embedder = self._space_key_to_embedder.get(space_key)
+        return embedder if isinstance(embedder, CropPathEmbedder) else None
 
     def get_video_path_embedder(self, space_key: str) -> VideoPathEmbedder | None:
-        """Get the embedder that embeds videos by path for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.VIDEO_PATH))
-        assert embedder is None or isinstance(embedder, VideoPathEmbedder)
-        return embedder
+        """Get the space's embedder if it embeds videos by path, else None."""
+        embedder = self._space_key_to_embedder.get(space_key)
+        return embedder if isinstance(embedder, VideoPathEmbedder) else None
 
     def get_image_pil_embedder(self, space_key: str) -> ImagePILEmbedder | None:
-        """Get the embedder that embeds PIL images for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.IMAGE_PIL))
-        assert embedder is None or isinstance(embedder, ImagePILEmbedder)
-        return embedder
+        """Get the space's embedder if it embeds PIL images, else None."""
+        embedder = self._space_key_to_embedder.get(space_key)
+        return embedder if isinstance(embedder, ImagePILEmbedder) else None
 
     def get_text_embedder(self, space_key: str) -> TextEmbedder | None:
-        """Get the embedder that embeds text for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.TEXT))
-        assert embedder is None or isinstance(embedder, TextEmbedder)
-        return embedder
+        """Get the space's embedder if it embeds text, else None."""
+        embedder = self._space_key_to_embedder.get(space_key)
+        return embedder if isinstance(embedder, TextEmbedder) else None
 
     def get_image_bytes_embedder(self, space_key: str) -> ImageBytesEmbedder | None:
-        """Get the embedder that embeds images by bytes for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.IMAGE_BYTES))
-        assert embedder is None or isinstance(embedder, ImageBytesEmbedder)
-        return embedder
+        """Get the space's embedder if it embeds images by bytes, else None."""
+        embedder = self._space_key_to_embedder.get(space_key)
+        return embedder if isinstance(embedder, ImageBytesEmbedder) else None
 
 
 def _capabilities_of(embedder: Embedder) -> list[Capability]:

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -12,9 +12,9 @@ from lightly_studio.embed.embedder import (
     Capability,
     CropPathEmbedder,
     Embedder,
-    FramePILEmbedder,
     ImageBytesEmbedder,
     ImagePathEmbedder,
+    ImagePILEmbedder,
     TextEmbedder,
     VideoPathEmbedder,
 )
@@ -26,7 +26,7 @@ _CAPABILITY_TO_TYPE = {
     Capability.IMAGE_PATH: ImagePathEmbedder,
     Capability.CROP_PATH: CropPathEmbedder,
     Capability.VIDEO_PATH: VideoPathEmbedder,
-    Capability.FRAME_PIL: FramePILEmbedder,
+    Capability.IMAGE_PIL: ImagePILEmbedder,
     Capability.TEXT: TextEmbedder,
     Capability.IMAGE_BYTES: ImageBytesEmbedder,
 }
@@ -99,10 +99,10 @@ class EmbedderRegistry:
         assert embedder is None or isinstance(embedder, VideoPathEmbedder)
         return embedder
 
-    def get_frame_pil_embedder(self, space_key: str) -> FramePILEmbedder | None:
-        """Get the embedder that embeds video frames for the space, if any."""
-        embedder = self._by_space_and_capability.get((space_key, Capability.FRAME_PIL))
-        assert embedder is None or isinstance(embedder, FramePILEmbedder)
+    def get_image_pil_embedder(self, space_key: str) -> ImagePILEmbedder | None:
+        """Get the embedder that embeds PIL images for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.IMAGE_PIL))
+        assert embedder is None or isinstance(embedder, ImagePILEmbedder)
         return embedder
 
     def get_text_embedder(self, space_key: str) -> TextEmbedder | None:

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -1,0 +1,117 @@
+"""Registry that maps embedding spaces and capabilities to embedders.
+
+Holds at most one embedder per ``(space_key, capability)`` pair. Callers look up
+an embedder by the capability they need with the matching typed getter.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from lightly_studio.embed.embedder import (
+    Capability,
+    CropPathEmbedder,
+    Embedder,
+    FramePILEmbedder,
+    ImageBytesEmbedder,
+    ImagePathEmbedder,
+    TextEmbedder,
+    VideoPathEmbedder,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maps each capability to the embedder subclass that implements it. Left
+# unannotated on purpose: annotating the values as ``type[Embedder]`` trips
+# mypy's ``type-abstract`` check, which assumes such types get instantiated. We
+# only use these classes for ``isinstance``.
+_CAPABILITY_TO_TYPE = {
+    Capability.IMAGE_PATH: ImagePathEmbedder,
+    Capability.CROP_PATH: CropPathEmbedder,
+    Capability.VIDEO_PATH: VideoPathEmbedder,
+    Capability.FRAME_PIL: FramePILEmbedder,
+    Capability.TEXT: TextEmbedder,
+    Capability.IMAGE_BYTES: ImageBytesEmbedder,
+}
+
+
+class EmbedderRegistry:
+    """Stores embedders keyed by embedding space and capability.
+
+    An embedder can provide several capabilities. It is registered under one key
+    per capability it implements. Each ``(space_key, capability)`` pair maps to a
+    single embedder; registering another embedder for the same pair replaces it.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self._by_space_and_capability: dict[tuple[str, Capability], Embedder] = {}
+
+    def register(self, embedder: Embedder) -> None:
+        """Register an embedder under every capability it implements.
+
+        The capabilities are inferred from the embedder's type. The embedding
+        space is read from ``embedder.embedding_space_spec()``.
+
+        Args:
+            embedder: The embedder to register.
+
+        Raises:
+            ValueError: If the embedder implements no capability.
+        """
+        space_key = embedder.embedding_space_spec().space_key
+        capabilities = _capabilities_of(embedder)
+        if not capabilities:
+            raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")
+        for capability in capabilities:
+            key = (space_key, capability)
+            if key in self._by_space_and_capability:
+                logger.warning(
+                    "Replacing embedder for space %r and capability %s.",
+                    space_key,
+                    capability.value,
+                )
+            self._by_space_and_capability[key] = embedder
+
+    def get_image_path_embedder(self, space_key: str) -> ImagePathEmbedder | None:
+        """Get the embedder that embeds images by path for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.IMAGE_PATH))
+        assert embedder is None or isinstance(embedder, ImagePathEmbedder)
+        return embedder
+
+    def get_crop_path_embedder(self, space_key: str) -> CropPathEmbedder | None:
+        """Get the embedder that embeds crops by path for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.CROP_PATH))
+        assert embedder is None or isinstance(embedder, CropPathEmbedder)
+        return embedder
+
+    def get_video_path_embedder(self, space_key: str) -> VideoPathEmbedder | None:
+        """Get the embedder that embeds videos by path for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.VIDEO_PATH))
+        assert embedder is None or isinstance(embedder, VideoPathEmbedder)
+        return embedder
+
+    def get_frame_pil_embedder(self, space_key: str) -> FramePILEmbedder | None:
+        """Get the embedder that embeds video frames for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.FRAME_PIL))
+        assert embedder is None or isinstance(embedder, FramePILEmbedder)
+        return embedder
+
+    def get_text_embedder(self, space_key: str) -> TextEmbedder | None:
+        """Get the embedder that embeds text for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.TEXT))
+        assert embedder is None or isinstance(embedder, TextEmbedder)
+        return embedder
+
+    def get_image_bytes_embedder(self, space_key: str) -> ImageBytesEmbedder | None:
+        """Get the embedder that embeds images by bytes for the space, if any."""
+        embedder = self._by_space_and_capability.get((space_key, Capability.IMAGE_BYTES))
+        assert embedder is None or isinstance(embedder, ImageBytesEmbedder)
+        return embedder
+
+
+def _capabilities_of(embedder: Embedder) -> list[Capability]:
+    """List the capabilities an embedder implements, inferred from its type."""
+    return [
+        capability for capability, cls in _CAPABILITY_TO_TYPE.items() if isinstance(embedder, cls)
+    ]

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -56,7 +56,7 @@ class EmbedderRegistry:
             ValueError: If the embedder implements no capability.
         """
         space_key = embedder.embedding_space_spec().space_key
-        capabilities = _capabilities_of(embedder)
+        capabilities = _capabilities_of(embedder=embedder)
         if not capabilities:
             raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")
         for capability in capabilities:

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -61,6 +61,9 @@ class EmbedderRegistry:
         """
         spec = embedder.embedding_space_spec()
         space_key = spec.space_key
+        capabilities = _capabilities_of(embedder=embedder)
+        if not capabilities:
+            raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")
         registered_spec = self._spec_by_space.get(space_key)
         if registered_spec is not None and registered_spec != spec:
             raise ValueError(
@@ -68,10 +71,6 @@ class EmbedderRegistry:
                 f"cannot register the incompatible {spec}."
             )
         self._spec_by_space[space_key] = spec
-
-        capabilities = _capabilities_of(embedder=embedder)
-        if not capabilities:
-            raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")
         for capability in capabilities:
             key = (space_key, capability)
             if key in self._by_space_and_capability:

--- a/lightly_studio/src/lightly_studio/embed/random_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/random_embedder.py
@@ -1,0 +1,77 @@
+"""Embedder that produces random vectors.
+
+Implements every capability so it can stand in for a real model in tests, demos
+and local development. The vectors carry no meaning, so search results are random.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL.Image import Image
+
+from lightly_studio.embed.embedder import (
+    CropPathEmbedder,
+    ImageBytesEmbedder,
+    ImagePathEmbedder,
+    ImagePILEmbedder,
+    TextEmbedder,
+    VideoPathEmbedder,
+)
+from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, ImageCrop
+
+
+class RandomEmbedder(
+    ImagePathEmbedder,
+    CropPathEmbedder,
+    VideoPathEmbedder,
+    ImagePILEmbedder,
+    TextEmbedder,
+    ImageBytesEmbedder,
+):
+    """Embedder that returns a random vector for every input.
+
+    Supports every capability. The vectors are meaningless, so it is meant for
+    tests, demos and local development, not for real search.
+    """
+
+    __slots__ = ("_dimension",)
+
+    def __init__(self, dimension: int = 3) -> None:
+        """Create a random embedder.
+
+        Args:
+            dimension: Length of each embedding vector.
+        """
+        self._dimension = dimension
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        """Describe the random embedding space."""
+        return EmbeddingSpaceSpec(space_key="random_model", dimension=self._dimension)
+
+    def embed_images(self, paths: list[str]) -> EmbeddingResult:
+        """Return a random vector for each image path."""
+        return self._random_result(count=len(paths))
+
+    def embed_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
+        """Return a random vector for each crop."""
+        return self._random_result(count=len(crops))
+
+    def embed_videos(self, paths: list[str]) -> EmbeddingResult:
+        """Return a random vector for each video path."""
+        return self._random_result(count=len(paths))
+
+    def embed_frames(self, frames: list[Image]) -> EmbeddingResult:
+        """Return a random vector for each frame."""
+        return self._random_result(count=len(frames))
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        """Return a random vector for each text string."""
+        return self._random_result(count=len(texts))
+
+    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
+        """Return a random vector for each image given as bytes."""
+        return self._random_result(count=len(images))
+
+    def _random_result(self, count: int) -> EmbeddingResult:
+        embeddings = np.random.rand(count, self._dimension).astype(np.float32)
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(count)))

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -42,27 +42,27 @@ class TestEmbedderRegistry:
         registry = EmbedderRegistry()
         embedder = _FakeTextImageEmbedder(space_key="space-a")
 
-        registry.register(embedder)
+        registry.register(embedder=embedder)
 
-        assert registry.get_text_embedder("space-a") is embedder
-        assert registry.get_image_path_embedder("space-a") is embedder
+        assert registry.get_text_embedder(space_key="space-a") is embedder
+        assert registry.get_image_path_embedder(space_key="space-a") is embedder
 
     def test_register__no_capability(self) -> None:
         registry = EmbedderRegistry()
 
         with pytest.raises(ValueError, match="no capability"):
-            registry.register(_FakeNoCapabilityEmbedder())
+            registry.register(embedder=_FakeNoCapabilityEmbedder())
 
     def test_register__replaces_existing(self, caplog: pytest.LogCaptureFixture) -> None:
         registry = EmbedderRegistry()
         first = _FakeTextImageEmbedder(space_key="space-a")
         second = _FakeTextImageEmbedder(space_key="space-a")
 
-        registry.register(first)
+        registry.register(embedder=first)
         with caplog.at_level(logging.WARNING):
-            registry.register(second)
+            registry.register(embedder=second)
 
-        assert registry.get_text_embedder("space-a") is second
+        assert registry.get_text_embedder(space_key="space-a") is second
         assert "Replacing embedder" in caplog.text
 
     def test_register__separate_spaces(self) -> None:
@@ -70,19 +70,19 @@ class TestEmbedderRegistry:
         embedder_a = _FakeTextImageEmbedder(space_key="space-a")
         embedder_b = _FakeTextImageEmbedder(space_key="space-b")
 
-        registry.register(embedder_a)
-        registry.register(embedder_b)
+        registry.register(embedder=embedder_a)
+        registry.register(embedder=embedder_b)
 
-        assert registry.get_text_embedder("space-a") is embedder_a
-        assert registry.get_text_embedder("space-b") is embedder_b
+        assert registry.get_text_embedder(space_key="space-a") is embedder_a
+        assert registry.get_text_embedder(space_key="space-b") is embedder_b
 
     def test_get_text_embedder__missing(self) -> None:
         registry = EmbedderRegistry()
 
-        assert registry.get_text_embedder("space-a") is None
+        assert registry.get_text_embedder(space_key="space-a") is None
 
     def test_get_image_bytes_embedder__capability_not_implemented(self) -> None:
         registry = EmbedderRegistry()
-        registry.register(_FakeTextImageEmbedder(space_key="space-a"))
+        registry.register(embedder=_FakeTextImageEmbedder(space_key="space-a"))
 
-        assert registry.get_image_bytes_embedder("space-a") is None
+        assert registry.get_image_bytes_embedder(space_key="space-a") is None

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -1,0 +1,88 @@
+import logging
+
+import numpy as np
+import pytest
+
+from lightly_studio.embed.embedder import (
+    Embedder,
+    ImagePathEmbedder,
+    TextEmbedder,
+)
+from lightly_studio.embed.embedder_registry import EmbedderRegistry
+from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec
+
+
+class _FakeTextImageEmbedder(TextEmbedder, ImagePathEmbedder):
+    def __init__(self, space_key: str) -> None:
+        self._space_key = space_key
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        return EmbeddingSpaceSpec(space_key=self._space_key, dimension=2)
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        return EmbeddingResult(
+            embeddings=np.zeros((len(texts), 2), dtype=np.float32),
+            kept_indices=list(range(len(texts))),
+        )
+
+    def embed_images(self, paths: list[str]) -> EmbeddingResult:
+        return EmbeddingResult(
+            embeddings=np.zeros((len(paths), 2), dtype=np.float32),
+            kept_indices=list(range(len(paths))),
+        )
+
+
+class _FakeNoCapabilityEmbedder(Embedder):
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        return EmbeddingSpaceSpec(space_key="none", dimension=2)
+
+
+class TestEmbedderRegistry:
+    def test_register(self) -> None:
+        registry = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a")
+
+        registry.register(embedder)
+
+        assert registry.get_text_embedder("space-a") is embedder
+        assert registry.get_image_path_embedder("space-a") is embedder
+
+    def test_register__no_capability(self) -> None:
+        registry = EmbedderRegistry()
+
+        with pytest.raises(ValueError, match="no capability"):
+            registry.register(_FakeNoCapabilityEmbedder())
+
+    def test_register__replaces_existing(self, caplog: pytest.LogCaptureFixture) -> None:
+        registry = EmbedderRegistry()
+        first = _FakeTextImageEmbedder(space_key="space-a")
+        second = _FakeTextImageEmbedder(space_key="space-a")
+
+        registry.register(first)
+        with caplog.at_level(logging.WARNING):
+            registry.register(second)
+
+        assert registry.get_text_embedder("space-a") is second
+        assert "Replacing embedder" in caplog.text
+
+    def test_register__separate_spaces(self) -> None:
+        registry = EmbedderRegistry()
+        embedder_a = _FakeTextImageEmbedder(space_key="space-a")
+        embedder_b = _FakeTextImageEmbedder(space_key="space-b")
+
+        registry.register(embedder_a)
+        registry.register(embedder_b)
+
+        assert registry.get_text_embedder("space-a") is embedder_a
+        assert registry.get_text_embedder("space-b") is embedder_b
+
+    def test_get_text_embedder__missing(self) -> None:
+        registry = EmbedderRegistry()
+
+        assert registry.get_text_embedder("space-a") is None
+
+    def test_get_image_bytes_embedder__capability_not_implemented(self) -> None:
+        registry = EmbedderRegistry()
+        registry.register(_FakeTextImageEmbedder(space_key="space-a"))
+
+        assert registry.get_image_bytes_embedder("space-a") is None

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -51,7 +51,7 @@ class TestEmbedderRegistry:
         # Getters for capabilities the embedder lacks return None.
         assert registry.get_crop_path_embedder(space_key="space-a") is None
         assert registry.get_video_path_embedder(space_key="space-a") is None
-        assert registry.get_frame_pil_embedder(space_key="space-a") is None
+        assert registry.get_image_pil_embedder(space_key="space-a") is None
         assert registry.get_image_bytes_embedder(space_key="space-a") is None
 
     def test_register__no_capability(self) -> None:

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -13,21 +13,22 @@ from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec
 
 
 class _FakeTextImageEmbedder(TextEmbedder, ImagePathEmbedder):
-    def __init__(self, space_key: str) -> None:
+    def __init__(self, space_key: str, dimension: int = 2) -> None:
         self._space_key = space_key
+        self._dimension = dimension
 
     def embedding_space_spec(self) -> EmbeddingSpaceSpec:
-        return EmbeddingSpaceSpec(space_key=self._space_key, dimension=2)
+        return EmbeddingSpaceSpec(space_key=self._space_key, dimension=self._dimension)
 
     def embed_text(self, texts: list[str]) -> EmbeddingResult:
         return EmbeddingResult(
-            embeddings=np.zeros((len(texts), 2), dtype=np.float32),
+            embeddings=np.zeros((len(texts), self._dimension), dtype=np.float32),
             kept_indices=list(range(len(texts))),
         )
 
     def embed_images(self, paths: list[str]) -> EmbeddingResult:
         return EmbeddingResult(
-            embeddings=np.zeros((len(paths), 2), dtype=np.float32),
+            embeddings=np.zeros((len(paths), self._dimension), dtype=np.float32),
             kept_indices=list(range(len(paths))),
         )
 
@@ -70,6 +71,13 @@ class TestEmbedderRegistry:
 
         assert registry.get_text_embedder(space_key="space-a") is second
         assert "Replacing embedder" in caplog.text
+
+    def test_register__conflicting_spec_raises(self) -> None:
+        registry = EmbedderRegistry()
+        registry.register(embedder=_FakeTextImageEmbedder(space_key="space-a", dimension=2))
+
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(embedder=_FakeTextImageEmbedder(space_key="space-a", dimension=3))
 
     def test_register__separate_spaces(self) -> None:
         registry = EmbedderRegistry()

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -44,8 +44,14 @@ class TestEmbedderRegistry:
 
         registry.register(embedder=embedder)
 
+        # Getters for implemented capabilities return the embedder.
         assert registry.get_text_embedder(space_key="space-a") is embedder
         assert registry.get_image_path_embedder(space_key="space-a") is embedder
+        # Getters for capabilities the embedder lacks return None.
+        assert registry.get_crop_path_embedder(space_key="space-a") is None
+        assert registry.get_video_path_embedder(space_key="space-a") is None
+        assert registry.get_frame_pil_embedder(space_key="space-a") is None
+        assert registry.get_image_bytes_embedder(space_key="space-a") is None
 
     def test_register__no_capability(self) -> None:
         registry = EmbedderRegistry()
@@ -80,9 +86,3 @@ class TestEmbedderRegistry:
         registry = EmbedderRegistry()
 
         assert registry.get_text_embedder(space_key="space-a") is None
-
-    def test_get_image_bytes_embedder__capability_not_implemented(self) -> None:
-        registry = EmbedderRegistry()
-        registry.register(embedder=_FakeTextImageEmbedder(space_key="space-a"))
-
-        assert registry.get_image_bytes_embedder(space_key="space-a") is None

--- a/lightly_studio/tests/embed/test_random_embedder.py
+++ b/lightly_studio/tests/embed/test_random_embedder.py
@@ -1,0 +1,66 @@
+import numpy as np
+from PIL import Image
+
+from lightly_studio.embed.random_embedder import RandomEmbedder
+from lightly_studio.embed.types import ImageCrop
+
+
+class TestRandomEmbedder:
+    def test_embedding_space_spec(self) -> None:
+        embedder = RandomEmbedder(dimension=5)
+
+        spec = embedder.embedding_space_spec()
+
+        assert spec.space_key == "random_model"
+        assert spec.dimension == 5
+
+    def test_embed_images(self) -> None:
+        embedder = RandomEmbedder(dimension=4)
+
+        result = embedder.embed_images(paths=["a.jpg", "b.jpg"])
+
+        assert result.embeddings.shape == (2, 4)
+        assert result.embeddings.dtype == np.float32
+        assert result.kept_indices == [0, 1]
+
+    def test_embed_crops(self) -> None:
+        embedder = RandomEmbedder(dimension=4)
+        crop = ImageCrop(filepath="a.jpg", x=0, y=0, width=1, height=1)
+
+        result = embedder.embed_crops(crops=[crop])
+
+        assert result.embeddings.shape == (1, 4)
+        assert result.kept_indices == [0]
+
+    def test_embed_videos(self) -> None:
+        embedder = RandomEmbedder(dimension=4)
+
+        result = embedder.embed_videos(paths=["a.mp4", "b.mp4", "c.mp4"])
+
+        assert result.embeddings.shape == (3, 4)
+        assert result.kept_indices == [0, 1, 2]
+
+    def test_embed_frames(self) -> None:
+        embedder = RandomEmbedder(dimension=4)
+        frames = [Image.new("RGB", (2, 2))]
+
+        result = embedder.embed_frames(frames=frames)
+
+        assert result.embeddings.shape == (1, 4)
+        assert result.kept_indices == [0]
+
+    def test_embed_text(self) -> None:
+        embedder = RandomEmbedder(dimension=4)
+
+        result = embedder.embed_text(texts=["cat", "dog"])
+
+        assert result.embeddings.shape == (2, 4)
+        assert result.kept_indices == [0, 1]
+
+    def test_embed_image_bytes(self) -> None:
+        embedder = RandomEmbedder(dimension=4)
+
+        result = embedder.embed_image_bytes(images=[b"data"])
+
+        assert result.embeddings.shape == (1, 4)
+        assert result.kept_indices == [0]


### PR DESCRIPTION
## What has changed and why?

New `RandomEmbedder` in `embed/` as part of deprecating `EmbeddingGenerator` in favor of `Embedder`.

- Implements every `Embedder` capability: image path, crop path, video path, frame PIL, text, image bytes.
- Returns random float32 vectors of configurable dimension (default 3).
- `space_key="random_model"`, matching the old `RandomEmbeddingGenerator`.
- Meant for tests, demos, and local development.

## How has it been tested?

- New unit tests cover every capability (shape, dtype, kept_indices).
- `make static-checks` and `make test` pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable random embedding provider for images, crops, videos, frames, text, and image bytes.
  * Supports custom embedding dimensions and reports a dedicated random embedding space.
  * Preserves all provided inputs in embedding results, making it suitable for demos and local testing.

* **Tests**
  * Added coverage validating embedding shapes, data types, dimensions, and input retention across supported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->