### PR TITLE
Add backend routes for bulk classification labeling

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -50,6 +50,7 @@ from lightly_studio.services.annotations_service.update_annotation import (
 annotations_router = APIRouter(prefix="/collections/{collection_id}", tags=["annotations"])
 annotations_router.include_router(annotations_module.create_annotation_router)
 annotations_router.include_router(annotations_module.annotation_metrics_info_router)
+annotations_router.include_router(annotations_module.create_classification_annotations_router)
 
 
 @annotations_router.get(

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotations/__init__.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotations/__init__.py
@@ -4,8 +4,12 @@ from .annotation_metrics_info import (
 from .create_annotation import (
     create_annotation_router,
 )
+from .create_classification_annotations import (
+    create_classification_annotations_router,
+)
 
 __all__ = [
     "annotation_metrics_info_router",
     "create_annotation_router",
+    "create_classification_annotations_router",
 ]

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotations/create_classification_annotations.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotations/create_classification_annotations.py
@@ -1,0 +1,93 @@
+"""Routes for bulk-creating classification annotations."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Path
+from fastapi.params import Body
+from pydantic import BaseModel
+
+from lightly_studio.api.routes.api.status import HTTP_STATUS_CREATED
+from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.resolvers.grid_filter import GridFilter
+from lightly_studio.services import annotations_service
+from lightly_studio.services.annotations_service.create_classification_annotations import (
+    ClassificationAnnotationsCreated,
+)
+
+create_classification_annotations_router = APIRouter()
+
+
+class ClassificationAnnotationsBulkInput(BaseModel):
+    """API interface to create one classification annotation per listed sample.
+
+    If annotation_collection_name is None, a default name is set.
+    """
+
+    sample_ids: list[UUID]
+    class_name: str
+    annotation_collection_name: str | None = None
+
+
+class ClassificationAnnotationsBulkByFilterInput(BaseModel):
+    """API interface to create one classification annotation per matched sample.
+
+    The caller must supply a filter to determine the sample type. The filter itself
+    can have no conditions, e.g. ``{"filter_type": "image"}``.
+    If annotation_collection_name is None, a default name is set.
+    """
+
+    filter: GridFilter
+    class_name: str
+    annotation_collection_name: str | None = None
+
+
+@create_classification_annotations_router.post(
+    "/annotations/classifications/bulk",
+    status_code=HTTP_STATUS_CREATED,
+)
+def create_classification_annotations(
+    collection_id: Annotated[
+        UUID, Path(title="collection Id", description="The ID of the collection")
+    ],
+    session: SessionDep,
+    body: Annotated[ClassificationAnnotationsBulkInput, Body()],
+) -> ClassificationAnnotationsCreated:
+    """Create a classification annotation on each of the given samples.
+
+    Samples that already have the annotation class are reported as skipped. Other
+    annotation classes on a sample are kept.
+    """
+    return annotations_service.create_classification_annotations(
+        session=session,
+        collection_id=collection_id,
+        class_name=body.class_name,
+        sample_ids=body.sample_ids,
+        annotation_collection_name=body.annotation_collection_name,
+    )
+
+
+@create_classification_annotations_router.post(
+    "/annotations/classifications/bulk_by_filter",
+    status_code=HTTP_STATUS_CREATED,
+)
+def create_classification_annotations_by_filter(
+    collection_id: Annotated[
+        UUID, Path(title="collection Id", description="The ID of the collection")
+    ],
+    session: SessionDep,
+    body: Annotated[ClassificationAnnotationsBulkByFilterInput, Body()],
+) -> ClassificationAnnotationsCreated:
+    """Create a classification annotation on every sample the filter matches.
+
+    Behaves like the bulk route, but resolves the samples server-side.
+    """
+    return annotations_service.create_classification_annotations_by_filter(
+        session=session,
+        collection_id=collection_id,
+        class_name=body.class_name,
+        grid_filter=body.filter,
+        annotation_collection_name=body.annotation_collection_name,
+    )

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -26,10 +26,8 @@ from lightly_studio.models.tag import (
     TagTable,
     TagView,
 )
-from lightly_studio.resolvers import embedding_region_resolver, tag_resolver
-from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers import grid_filter_region, tag_resolver
 from lightly_studio.resolvers.grid_filter import GridFilter
-from lightly_studio.resolvers.image_filter import ImageFilter
 
 tag_router = APIRouter()
 
@@ -236,27 +234,10 @@ def add_samples_to_tag_by_filter(
             detail=f"Tag {tag_id} not found in collection {collection_id}.",
         )
 
-    # Resolve any embedding-plot region selection to concrete sample ids before building
-    # the query (the point-in-polygon test needs the session, which `apply` lacks).
     grid_filter = body.filter
-    if (
-        isinstance(grid_filter, ImageFilter)
-        and grid_filter.sample_filter is not None
-        and grid_filter.sample_filter.embedding_region is not None
-    ):
-        grid_filter.sample_filter.region_sample_ids = (
-            embedding_region_resolver.get_sample_ids_in_region(
-                session=session,
-                collection_id=collection_id,
-                region=grid_filter.sample_filter.embedding_region,
-            )
-        )
-    elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
-        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
-            session=session,
-            collection_id=collection_id,
-            region=grid_filter.embedding_region,
-        )
+    grid_filter_region.resolve_region_sample_ids(
+        session=session, collection_id=collection_id, grid_filter=grid_filter
+    )
     sample_ids_query = grid_filter.build_sample_ids_query(collection_id=collection_id)
     tag_resolver.add_samples_to_tag_from_query(
         session=session, tag_id=tag_id, sample_ids_query=sample_ids_query

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -41,6 +41,9 @@ from lightly_studio.resolvers.annotation_resolver.get_by_id_with_payload import 
 from lightly_studio.resolvers.annotation_resolver.get_label_ids_by_sample_ids import (
     get_label_ids_by_sample_ids,
 )
+from lightly_studio.resolvers.annotation_resolver.get_parent_sample_ids_with_label import (
+    get_parent_sample_ids_with_label,
+)
 from lightly_studio.resolvers.annotation_resolver.get_sample_ids import (
     build_sample_ids_query,
     get_sample_ids,
@@ -81,6 +84,7 @@ __all__ = [
     "get_by_id_with_payload",
     "get_by_ids",
     "get_label_ids_by_sample_ids",
+    "get_parent_sample_ids_with_label",
     "get_sample_ids",
     "get_unembedded_annotation_ids",
     "update_annotation_label",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_parent_sample_ids_with_label.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_parent_sample_ids_with_label.py
@@ -8,7 +8,10 @@ from uuid import UUID
 from sqlmodel import Session, col, select
 
 from lightly_studio.database import db_array
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationType,
+)
 from lightly_studio.models.sample import SampleTable
 
 
@@ -17,8 +20,13 @@ def get_parent_sample_ids_with_label(
     parent_sample_ids: Sequence[UUID],
     annotation_label_id: UUID,
     annotation_collection_id: UUID,
+    annotation_type: AnnotationType,
 ) -> set[UUID]:
-    """Return the parent samples that already have an annotation with the given label.
+    """Return the parent samples that already have such an annotation.
+
+    An annotation matches when it has the given label, type, and annotation collection.
+    Annotations of another type are not matches: a box and a whole-image classification
+    carrying the same annotation class are different annotations.
 
     The collection filter is applied on the annotation's own sample
     (``AnnotationBaseTable.sample_id -> SampleTable.collection_id``), not on the
@@ -29,6 +37,7 @@ def get_parent_sample_ids_with_label(
         parent_sample_ids: Parent sample IDs to check.
         annotation_label_id: ID of the annotation label to look for.
         annotation_collection_id: ID of the collection the annotation samples must belong to.
+        annotation_type: Type the annotation must have.
 
     Returns:
         The subset of ``parent_sample_ids`` that already have such an annotation.
@@ -44,6 +53,7 @@ def get_parent_sample_ids_with_label(
         )
         .where(col(SampleTable.collection_id) == annotation_collection_id)
         .where(col(AnnotationBaseTable.annotation_label_id) == annotation_label_id)
+        .where(col(AnnotationBaseTable.annotation_type) == annotation_type)
         .where(
             db_array.in_array(
                 column=col(AnnotationBaseTable.parent_sample_id),

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_parent_sample_ids_with_label.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_parent_sample_ids_with_label.py
@@ -1,0 +1,55 @@
+"""Find parent samples that already carry a given annotation label."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.database import db_array
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.sample import SampleTable
+
+
+def get_parent_sample_ids_with_label(
+    session: Session,
+    parent_sample_ids: Sequence[UUID],
+    annotation_label_id: UUID,
+    annotation_collection_id: UUID,
+) -> set[UUID]:
+    """Return the parent samples that already have an annotation with the given label.
+
+    The collection filter is applied on the annotation's own sample
+    (``AnnotationBaseTable.sample_id -> SampleTable.collection_id``), not on the
+    parent sample's collection.
+
+    Args:
+        session: Database session.
+        parent_sample_ids: Parent sample IDs to check.
+        annotation_label_id: ID of the annotation label to look for.
+        annotation_collection_id: ID of the collection the annotation samples must belong to.
+
+    Returns:
+        The subset of ``parent_sample_ids`` that already have such an annotation.
+    """
+    if not parent_sample_ids:
+        return set()
+
+    statement = (
+        select(AnnotationBaseTable.parent_sample_id)
+        .join(
+            SampleTable,
+            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+        )
+        .where(col(SampleTable.collection_id) == annotation_collection_id)
+        .where(col(AnnotationBaseTable.annotation_label_id) == annotation_label_id)
+        .where(
+            db_array.in_array(
+                column=col(AnnotationBaseTable.parent_sample_id),
+                values=list(parent_sample_ids),
+            )
+        )
+        .distinct()
+    )
+    return set(session.exec(statement).all())

--- a/lightly_studio/src/lightly_studio/resolvers/grid_filter_region.py
+++ b/lightly_studio/src/lightly_studio/resolvers/grid_filter_region.py
@@ -1,0 +1,49 @@
+"""Server-side resolution of a grid filter's embedding-plot region selection."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import embedding_region_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.grid_filter_base import GridFilterBase
+from lightly_studio.resolvers.image_filter import ImageFilter
+
+
+def resolve_region_sample_ids(
+    session: Session, collection_id: UUID, grid_filter: GridFilterBase
+) -> None:
+    """Replace a region selection on ``grid_filter`` with the sample ids it covers.
+
+    The point-in-polygon test needs a session, which ``GridFilterBase.apply`` does not
+    have. Callers must therefore run this before building a query from the filter.
+    The filter is updated in place.
+
+    Args:
+        session: Database session.
+        collection_id: ID of the collection the region selection was made in.
+        grid_filter: The filter to resolve the region of. Filters without a region
+            selection are left untouched.
+    """
+    if isinstance(grid_filter, AnnotationsFilter):
+        if grid_filter.embedding_region is None:
+            return
+        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+            session=session,
+            collection_id=collection_id,
+            region=grid_filter.embedding_region,
+        )
+        return
+
+    if not isinstance(grid_filter, ImageFilter):
+        return
+    sample_filter = grid_filter.sample_filter
+    if sample_filter is None or sample_filter.embedding_region is None:
+        return
+    sample_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+        session=session,
+        collection_id=collection_id,
+        region=sample_filter.embedding_region,
+    )

--- a/lightly_studio/src/lightly_studio/services/annotations_service/__init__.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/__init__.py
@@ -3,6 +3,10 @@
 from lightly_studio.services.annotations_service.create_annotation import (
     create_annotation,
 )
+from lightly_studio.services.annotations_service.create_classification_annotations import (
+    create_classification_annotations,
+    create_classification_annotations_by_filter,
+)
 from lightly_studio.services.annotations_service.delete_annotation import (
     delete_annotation,
 )
@@ -30,6 +34,8 @@ from lightly_studio.services.annotations_service.update_temporal_span import (
 
 __all__ = [
     "create_annotation",
+    "create_classification_annotations",
+    "create_classification_annotations_by_filter",
     "delete_annotation",
     "get_annotation_by_id",
     "update_annotation",

--- a/lightly_studio/src/lightly_studio/services/annotations_service/create_classification_annotations.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/create_classification_annotations.py
@@ -1,0 +1,207 @@
+"""Bulk creation of classification annotations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationCreate, AnnotationType
+from lightly_studio.models.annotation_label import AnnotationLabelCreate
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import (
+    annotation_label_resolver,
+    annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+    grid_filter_region,
+)
+from lightly_studio.resolvers.grid_filter_base import GridFilterBase
+
+# Number of annotations inserted per `annotation_resolver.create_many` call. Bounds the
+# size of the dedupe query and of a single bulk insert for large selections.
+CREATE_BATCH_SIZE = 500
+
+
+class ClassificationAnnotationsCreated(BaseModel):
+    """Outcome of a bulk classification annotation creation.
+
+    Attributes:
+        created_annotation_ids: IDs of the annotations that were created.
+        created_count: Number of annotations that were created.
+        skipped_count: Number of samples that already had the annotation class and
+            were therefore left untouched.
+    """
+
+    created_annotation_ids: list[UUID]
+    created_count: int
+    skipped_count: int
+
+
+def create_classification_annotations(
+    session: Session,
+    collection_id: UUID,
+    class_name: str,
+    sample_ids: Sequence[UUID],
+    annotation_collection_name: str | None = None,
+) -> ClassificationAnnotationsCreated:
+    """Create a classification annotation on each of the given samples.
+
+    The annotation class is created if the dataset does not have it yet. Existing
+    annotations are never modified: samples that already have the annotation class in
+    the target annotation source are skipped, other annotation classes are kept
+    alongside the new one.
+
+    Args:
+        session: Database session.
+        collection_id: ID of the collection the samples belong to.
+        class_name: Name of the annotation class to assign.
+        sample_ids: IDs of the samples to annotate. Duplicates are collapsed.
+        annotation_collection_name: Name of the annotation source to create the
+            annotations in. If `None`, a default name is used.
+
+    Returns:
+        The created annotation IDs together with the created and skipped counts.
+    """
+    return _create_classifications(
+        session=session,
+        collection_id=collection_id,
+        class_name=class_name,
+        # Collapse duplicates, otherwise a repeated id would be annotated twice.
+        parent_sample_ids=list(dict.fromkeys(sample_ids)),
+        annotation_collection_name=annotation_collection_name,
+    )
+
+
+def create_classification_annotations_by_filter(
+    session: Session,
+    collection_id: UUID,
+    class_name: str,
+    grid_filter: GridFilterBase,
+    annotation_collection_name: str | None = None,
+) -> ClassificationAnnotationsCreated:
+    """Create a classification annotation on every sample a grid filter matches.
+
+    The filter is resolved to sample IDs server-side and then handled exactly like
+    `create_classification_annotations`.
+
+    Args:
+        session: Database session.
+        collection_id: ID of the collection to match samples in.
+        class_name: Name of the annotation class to assign.
+        grid_filter: Filter selecting the samples to annotate.
+        annotation_collection_name: Name of the annotation source to create the
+            annotations in. If `None`, a default name is used.
+
+    Returns:
+        The created annotation IDs together with the created and skipped counts.
+    """
+    grid_filter_region.resolve_region_sample_ids(
+        session=session, collection_id=collection_id, grid_filter=grid_filter
+    )
+    sample_ids_query = grid_filter.build_sample_ids_query(collection_id=collection_id)
+    return _create_classifications(
+        session=session,
+        collection_id=collection_id,
+        class_name=class_name,
+        parent_sample_ids=list(session.exec(sample_ids_query).all()),
+        annotation_collection_name=annotation_collection_name,
+    )
+
+
+def _create_classifications(
+    session: Session,
+    collection_id: UUID,
+    class_name: str,
+    parent_sample_ids: Sequence[UUID],
+    annotation_collection_name: str | None,
+) -> ClassificationAnnotationsCreated:
+    annotation_label_id = _get_or_create_annotation_label_id(
+        session=session, collection_id=collection_id, class_name=class_name
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=session,
+        collection_id=collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name=annotation_collection_name,
+    )
+
+    created_annotation_ids: list[UUID] = []
+    skipped_count = 0
+    for start in range(0, len(parent_sample_ids), CREATE_BATCH_SIZE):
+        batch = parent_sample_ids[start : start + CREATE_BATCH_SIZE]
+        missing = _parent_sample_ids_without_label(
+            session=session,
+            parent_sample_ids=batch,
+            annotation_label_id=annotation_label_id,
+            annotation_collection_id=annotation_collection_id,
+        )
+        skipped_count += len(batch) - len(missing)
+        if not missing:
+            continue
+        created_annotation_ids.extend(
+            annotation_resolver.create_many(
+                session=session,
+                parent_collection_id=collection_id,
+                annotations=[
+                    AnnotationCreate(
+                        annotation_label_id=annotation_label_id,
+                        annotation_type=AnnotationType.CLASSIFICATION,
+                        parent_sample_id=parent_sample_id,
+                    )
+                    for parent_sample_id in missing
+                ],
+                collection_name=annotation_collection_name,
+            )
+        )
+
+    if created_annotation_ids:
+        evaluation_run_resolver.mark_stale_by_collection_id(
+            session=session, collection_id=annotation_collection_id
+        )
+    return ClassificationAnnotationsCreated(
+        created_annotation_ids=created_annotation_ids,
+        created_count=len(created_annotation_ids),
+        skipped_count=skipped_count,
+    )
+
+
+def _parent_sample_ids_without_label(
+    session: Session,
+    parent_sample_ids: Sequence[UUID],
+    annotation_label_id: UUID,
+    annotation_collection_id: UUID,
+) -> list[UUID]:
+    existing = annotation_resolver.get_parent_sample_ids_with_label(
+        session=session,
+        parent_sample_ids=parent_sample_ids,
+        annotation_label_id=annotation_label_id,
+        annotation_collection_id=annotation_collection_id,
+    )
+    return [
+        parent_sample_id
+        for parent_sample_id in parent_sample_ids
+        if parent_sample_id not in existing
+    ]
+
+
+def _get_or_create_annotation_label_id(
+    session: Session, collection_id: UUID, class_name: str
+) -> UUID:
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(f"Collection with id {collection_id} not found.")
+
+    label = annotation_label_resolver.get_by_label_name(
+        session=session, dataset_id=collection.dataset_id, label_name=class_name
+    )
+    if label is None:
+        label = annotation_label_resolver.create(
+            session=session,
+            label=AnnotationLabelCreate(
+                dataset_id=collection.dataset_id, annotation_label_name=class_name
+            ),
+        )
+    return label.annotation_label_id

--- a/lightly_studio/src/lightly_studio/services/annotations_service/create_classification_annotations.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/create_classification_annotations.py
@@ -128,6 +128,11 @@ def _create_classifications(
         name=annotation_collection_name,
     )
 
+    # `annotation_resolver.create_many` commits, so every batch lands in its own
+    # transaction. That is deliberate: the dedupe above makes the whole operation
+    # idempotent, so a run that fails halfway is recovered by re-running it, which
+    # skips whatever already landed. Do not collapse this into one transaction
+    # expecting all-or-nothing semantics that nothing here relies on.
     created_annotation_ids: list[UUID] = []
     skipped_count = 0
     for start in range(0, len(parent_sample_ids), CREATE_BATCH_SIZE):
@@ -179,6 +184,7 @@ def _parent_sample_ids_without_label(
         parent_sample_ids=parent_sample_ids,
         annotation_label_id=annotation_label_id,
         annotation_collection_id=annotation_collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
     )
     return [
         parent_sample_id

--- a/lightly_studio/tests/api/routes/api/annotations/test_create_classification_annotations.py
+++ b/lightly_studio/tests/api/routes/api/annotations/test_create_classification_annotations.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from lightly_studio.api.routes.api.status import HTTP_STATUS_CREATED
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.models.image import ImageTable
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from tests.helpers_resolvers import (
+    ImageStub,
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_images,
+)
+
+
+@pytest.fixture
+def collection(db_session: Session) -> CollectionTable:
+    return create_collection(session=db_session)
+
+
+@pytest.fixture
+def images(db_session: Session, collection: CollectionTable) -> list[ImageTable]:
+    return create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path=f"image_{i}.png") for i in range(3)],
+    )
+
+
+def test_create_classification_annotations(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    response = test_client.post(
+        _bulk_route(collection),
+        json={
+            "sample_ids": [str(image.sample_id) for image in images],
+            "class_name": "cat",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    body = response.json()
+    assert body["created_count"] == 3
+    assert body["skipped_count"] == 0
+    assert len(body["created_annotation_ids"]) == 3
+    assert _class_names_by_sample_id(session=db_session, images=images) == {
+        image.sample_id: {"cat"} for image in images
+    }
+
+
+def test_create_classification_annotations__skips_already_annotated(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=images[0].sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+
+    response = test_client.post(
+        _bulk_route(collection),
+        json={
+            "sample_ids": [str(image.sample_id) for image in images],
+            "class_name": "cat",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert response.json()["created_count"] == 2
+    assert response.json()["skipped_count"] == 1
+
+
+def test_create_classification_annotations__adds_second_class_alongside_first(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    route = _bulk_route(collection)
+    body = {"sample_ids": [str(images[0].sample_id)]}
+
+    test_client.post(route, json={**body, "class_name": "cat"})
+    response = test_client.post(route, json={**body, "class_name": "dog"})
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert response.json()["created_count"] == 1
+    assert _class_names_by_sample_id(session=db_session, images=images[:1]) == {
+        images[0].sample_id: {"cat", "dog"}
+    }
+
+
+def test_create_classification_annotations__creates_annotation_class_on_the_fly(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    response = test_client.post(
+        _bulk_route(collection),
+        json={"sample_ids": [str(images[0].sample_id)], "class_name": "brand_new"},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _class_names_by_sample_id(session=db_session, images=images[:1]) == {
+        images[0].sample_id: {"brand_new"}
+    }
+
+
+def test_create_classification_annotations__default_annotation_collection(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    response = test_client.post(
+        _bulk_route(collection),
+        json={"sample_ids": [str(images[0].sample_id)], "class_name": "cat"},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _annotation_collection_ids(session=db_session, response_body=response.json()) == {
+        collection_resolver.get_by_name(
+            session=db_session,
+            name=SampleType.ANNOTATION.value.lower(),
+            parent_collection_id=collection.collection_id,
+        )
+    }
+
+
+def test_create_classification_annotations__named_annotation_collection(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    response = test_client.post(
+        _bulk_route(collection),
+        json={
+            "sample_ids": [str(images[0].sample_id)],
+            "class_name": "cat",
+            "annotation_collection_name": "ground_truth",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    named_collection_id = collection_resolver.get_by_name(
+        session=db_session,
+        name="ground_truth",
+        parent_collection_id=collection.collection_id,
+    )
+    assert named_collection_id is not None
+    assert _annotation_collection_ids(session=db_session, response_body=response.json()) == {
+        named_collection_id
+    }
+
+
+def test_create_classification_annotations_by_filter(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    response = test_client.post(
+        _bulk_by_filter_route(collection),
+        json={"filter": {"filter_type": "image"}, "class_name": "cat"},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert response.json()["created_count"] == 3
+    assert _class_names_by_sample_id(session=db_session, images=images) == {
+        image.sample_id: {"cat"} for image in images
+    }
+
+
+def test_create_classification_annotations_by_filter__matches_id_list_result(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    by_ids = test_client.post(
+        _bulk_route(collection),
+        json={"sample_ids": [str(image.sample_id) for image in images], "class_name": "cat"},
+    )
+    by_filter = test_client.post(
+        _bulk_by_filter_route(collection),
+        json={"filter": {"filter_type": "image"}, "class_name": "dog"},
+    )
+
+    assert by_ids.json()["created_count"] == by_filter.json()["created_count"]
+    assert by_ids.json()["skipped_count"] == by_filter.json()["skipped_count"]
+    assert _class_names_by_sample_id(session=db_session, images=images) == {
+        image.sample_id: {"cat", "dog"} for image in images
+    }
+
+
+def test_create_classification_annotations_by_filter__matches_subset(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+) -> None:
+    wide, narrow = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[
+            ImageStub(path="wide.png", width=1920, height=1080),
+            ImageStub(path="narrow.png", width=10, height=10),
+        ],
+    )
+
+    response = test_client.post(
+        _bulk_by_filter_route(collection),
+        json={
+            "filter": {"filter_type": "image", "width": {"min": 100}},
+            "class_name": "cat",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert response.json()["created_count"] == 1
+    assert _class_names_by_sample_id(session=db_session, images=[wide, narrow]) == {
+        wide.sample_id: {"cat"},
+        narrow.sample_id: set(),
+    }
+
+
+@pytest.mark.usefixtures("images")
+def test_create_classification_annotations_by_filter__named_annotation_collection(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+) -> None:
+    response = test_client.post(
+        _bulk_by_filter_route(collection),
+        json={
+            "filter": {"filter_type": "image"},
+            "class_name": "cat",
+            "annotation_collection_name": "ground_truth",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    named_collection_id = collection_resolver.get_by_name(
+        session=db_session,
+        name="ground_truth",
+        parent_collection_id=collection.collection_id,
+    )
+    assert named_collection_id is not None
+    assert _annotation_collection_ids(session=db_session, response_body=response.json()) == {
+        named_collection_id
+    }
+
+
+def _bulk_route(collection: CollectionTable) -> str:
+    return f"/api/collections/{collection.collection_id!s}/annotations/classifications/bulk"
+
+
+def _bulk_by_filter_route(collection: CollectionTable) -> str:
+    return (
+        f"/api/collections/{collection.collection_id!s}/annotations/classifications/bulk_by_filter"
+    )
+
+
+def _class_names_by_sample_id(session: Session, images: list[ImageTable]) -> dict[UUID, set[str]]:
+    annotations = annotation_resolver.get_all_by_parent_sample_ids(
+        session=session, parent_sample_ids=[image.sample_id for image in images]
+    )
+    class_names: dict[UUID, set[str]] = {image.sample_id: set() for image in images}
+    for annotation in annotations:
+        class_names[annotation.parent_sample_id].add(
+            annotation.annotation_label.annotation_label_name
+        )
+    return class_names
+
+
+def _annotation_collection_ids(session: Session, response_body: dict[str, object]) -> set[UUID]:
+    annotation_ids = response_body["created_annotation_ids"]
+    assert isinstance(annotation_ids, list)
+    annotations = annotation_resolver.get_by_ids(
+        session=session, annotation_ids=[UUID(annotation_id) for annotation_id in annotation_ids]
+    )
+    return {annotation.sample.collection_id for annotation in annotations}

--- a/lightly_studio/tests/api/routes/api/annotations/test_create_classification_annotations.py
+++ b/lightly_studio/tests/api/routes/api/annotations/test_create_classification_annotations.py
@@ -89,6 +89,43 @@ def test_create_classification_annotations__skips_already_annotated(
     assert response.json()["skipped_count"] == 1
 
 
+def test_create_classification_annotations__object_detection_of_same_class_not_skipped(
+    db_session: Session,
+    test_client: TestClient,
+    collection: CollectionTable,
+    images: list[ImageTable],
+) -> None:
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="car"
+    )
+    detection = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=images[0].sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_collection_name="ground_truth",
+    )
+
+    response = test_client.post(
+        _bulk_route(collection),
+        json={
+            "sample_ids": [str(images[0].sample_id)],
+            "class_name": "car",
+            "annotation_collection_name": "ground_truth",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert response.json()["created_count"] == 1
+    assert response.json()["skipped_count"] == 0
+    unchanged = annotation_resolver.get_by_id(session=db_session, annotation_id=detection.sample_id)
+    assert unchanged is not None
+    assert unchanged.annotation_type == AnnotationType.OBJECT_DETECTION
+    assert unchanged.annotation_label_id == label.annotation_label_id
+    assert unchanged.object_detection_details is not None
+
+
 def test_create_classification_annotations__adds_second_class_alongside_first(
     db_session: Session,
     test_client: TestClient,

--- a/lightly_studio/tests/resolvers/annotations/test_get_parent_sample_ids_with_label.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_parent_sample_ids_with_label.py
@@ -1,0 +1,127 @@
+"""Tests for the get_parent_sample_ids_with_label resolver."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.resolvers import annotation_resolver
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+
+
+def test_get_parent_sample_ids_with_label(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    labeled = create_image(
+        session=db_session, collection_id=collection.collection_id, file_path_abs="a.png"
+    )
+    unlabeled = create_image(
+        session=db_session, collection_id=collection.collection_id, file_path_abs="b.png"
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=labeled.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+
+    result = annotation_resolver.get_parent_sample_ids_with_label(
+        session=db_session,
+        parent_sample_ids=[labeled.sample_id, unlabeled.sample_id],
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_id=annotation.sample.collection_id,
+    )
+
+    assert result == {labeled.sample_id}
+
+
+def test_get_parent_sample_ids_with_label__filters_by_label(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    cat = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    dog = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="dog"
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=cat.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+
+    result = annotation_resolver.get_parent_sample_ids_with_label(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_label_id=dog.annotation_label_id,
+        annotation_collection_id=annotation.sample.collection_id,
+    )
+
+    assert result == set()
+
+
+def test_get_parent_sample_ids_with_label__filters_by_annotation_collection(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    in_ground_truth = create_image(
+        session=db_session, collection_id=collection.collection_id, file_path_abs="a.png"
+    )
+    in_predictions = create_image(
+        session=db_session, collection_id=collection.collection_id, file_path_abs="b.png"
+    )
+    ground_truth_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=in_ground_truth.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+        annotation_collection_name="ground_truth",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=in_predictions.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+        annotation_collection_name="predictions",
+    )
+
+    result = annotation_resolver.get_parent_sample_ids_with_label(
+        session=db_session,
+        parent_sample_ids=[in_ground_truth.sample_id, in_predictions.sample_id],
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_id=ground_truth_annotation.sample.collection_id,
+    )
+
+    assert result == {in_ground_truth.sample_id}
+
+
+def test_get_parent_sample_ids_with_label__empty_parent_sample_ids(db_session: Session) -> None:
+    result = annotation_resolver.get_parent_sample_ids_with_label(
+        session=db_session,
+        parent_sample_ids=[],
+        annotation_label_id=uuid.uuid4(),
+        annotation_collection_id=uuid.uuid4(),
+    )
+
+    assert result == set()

--- a/lightly_studio/tests/resolvers/annotations/test_get_parent_sample_ids_with_label.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_parent_sample_ids_with_label.py
@@ -41,6 +41,7 @@ def test_get_parent_sample_ids_with_label(db_session: Session) -> None:
         parent_sample_ids=[labeled.sample_id, unlabeled.sample_id],
         annotation_label_id=label.annotation_label_id,
         annotation_collection_id=annotation.sample.collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
     )
 
     assert result == {labeled.sample_id}
@@ -69,6 +70,7 @@ def test_get_parent_sample_ids_with_label__filters_by_label(db_session: Session)
         parent_sample_ids=[image.sample_id],
         annotation_label_id=dog.annotation_label_id,
         annotation_collection_id=annotation.sample.collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
     )
 
     assert result == set()
@@ -111,9 +113,37 @@ def test_get_parent_sample_ids_with_label__filters_by_annotation_collection(
         parent_sample_ids=[in_ground_truth.sample_id, in_predictions.sample_id],
         annotation_label_id=label.annotation_label_id,
         annotation_collection_id=ground_truth_annotation.sample.collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
     )
 
     assert result == {in_ground_truth.sample_id}
+
+
+def test_get_parent_sample_ids_with_label__filters_by_annotation_type(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="car"
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    detection = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+
+    result = annotation_resolver.get_parent_sample_ids_with_label(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_id=detection.sample.collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    assert result == set()
 
 
 def test_get_parent_sample_ids_with_label__empty_parent_sample_ids(db_session: Session) -> None:
@@ -122,6 +152,7 @@ def test_get_parent_sample_ids_with_label__empty_parent_sample_ids(db_session: S
         parent_sample_ids=[],
         annotation_label_id=uuid.uuid4(),
         annotation_collection_id=uuid.uuid4(),
+        annotation_type=AnnotationType.CLASSIFICATION,
     )
 
     assert result == set()

--- a/lightly_studio/tests/services/annotations_service/test_create_classification_annotations.py
+++ b/lightly_studio/tests/services/annotations_service/test_create_classification_annotations.py
@@ -144,6 +144,44 @@ def test_create_classification_annotations__skips_samples_that_already_have_the_
     }
 
 
+def test_create_classification_annotations__object_detection_of_same_class_not_skipped(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="car"
+    )
+    detection = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=images[0].sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_collection_name="ground_truth",
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="car",
+        sample_ids=[images[0].sample_id],
+        annotation_collection_name="ground_truth",
+    )
+
+    assert result.created_count == 1
+    assert result.skipped_count == 0
+    unchanged = annotation_resolver.get_by_id(session=db_session, annotation_id=detection.sample_id)
+    assert unchanged is not None
+    assert unchanged.annotation_type == AnnotationType.OBJECT_DETECTION
+    assert unchanged.annotation_label_id == label.annotation_label_id
+    assert unchanged.object_detection_details is not None
+    assert _annotation_types_by_sample_id(session=db_session, images=images[:1]) == {
+        images[0].sample_id: {
+            AnnotationType.OBJECT_DETECTION,
+            AnnotationType.CLASSIFICATION,
+        }
+    }
+
+
 def test_create_classification_annotations__rerun_creates_nothing(
     db_session: Session, collection: CollectionTable, images: list[ImageTable]
 ) -> None:
@@ -377,6 +415,18 @@ def _class_names_by_sample_id(session: Session, images: list[ImageTable]) -> dic
             annotation.annotation_label.annotation_label_name
         )
     return class_names
+
+
+def _annotation_types_by_sample_id(
+    session: Session, images: list[ImageTable]
+) -> dict[UUID, set[AnnotationType]]:
+    annotations = annotation_resolver.get_all_by_parent_sample_ids(
+        session=session, parent_sample_ids=[image.sample_id for image in images]
+    )
+    types: dict[UUID, set[AnnotationType]] = {image.sample_id: set() for image in images}
+    for annotation in annotations:
+        types[annotation.parent_sample_id].add(annotation.annotation_type)
+    return types
 
 
 def _annotation_collection_id(session: Session, annotation_id: UUID) -> UUID:

--- a/lightly_studio/tests/services/annotations_service/test_create_classification_annotations.py
+++ b/lightly_studio/tests/services/annotations_service/test_create_classification_annotations.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import sys
+from uuid import UUID
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.models.image import ImageTable
+from lightly_studio.resolvers import (
+    annotation_label_resolver,
+    annotation_resolver,
+    collection_resolver,
+)
+from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.services import annotations_service
+from tests.helpers_resolvers import (
+    ImageStub,
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_images,
+)
+
+
+@pytest.fixture
+def collection(db_session: Session) -> CollectionTable:
+    return create_collection(session=db_session)
+
+
+@pytest.fixture
+def images(db_session: Session, collection: CollectionTable) -> list[ImageTable]:
+    return create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path=f"image_{i}.png") for i in range(3)],
+    )
+
+
+def test_create_classification_annotations(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[image.sample_id for image in images],
+    )
+
+    assert result.created_count == 3
+    assert result.skipped_count == 0
+    assert len(result.created_annotation_ids) == 3
+    assert _class_names_by_sample_id(session=db_session, images=images) == {
+        image.sample_id: {"cat"} for image in images
+    }
+
+
+def test_create_classification_annotations__creates_only_classifications(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+    )
+
+    annotation = annotation_resolver.get_by_id(
+        session=db_session, annotation_id=result.created_annotation_ids[0]
+    )
+    assert annotation is not None
+    assert annotation.annotation_type == AnnotationType.CLASSIFICATION
+    assert annotation.object_detection_details is None
+    assert annotation.segmentation_details is None
+
+
+def test_create_classification_annotations__creates_annotation_class_on_the_fly(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="brand_new",
+        sample_ids=[images[0].sample_id],
+    )
+
+    label = annotation_label_resolver.get_by_label_name(
+        session=db_session, dataset_id=collection.dataset_id, label_name="brand_new"
+    )
+    assert label is not None
+
+
+def test_create_classification_annotations__reuses_existing_annotation_class(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    existing = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+    )
+
+    annotation = annotation_resolver.get_by_id(
+        session=db_session, annotation_id=result.created_annotation_ids[0]
+    )
+    assert annotation is not None
+    assert annotation.annotation_label_id == existing.annotation_label_id
+
+
+def test_create_classification_annotations__skips_samples_that_already_have_the_class(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    existing = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=images[0].sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={},
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[image.sample_id for image in images],
+    )
+
+    assert result.created_count == 2
+    assert result.skipped_count == 1
+    assert existing.sample_id not in result.created_annotation_ids
+    assert _class_names_by_sample_id(session=db_session, images=images) == {
+        image.sample_id: {"cat"} for image in images
+    }
+
+
+def test_create_classification_annotations__rerun_creates_nothing(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    sample_ids = [image.sample_id for image in images]
+    annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=sample_ids,
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=sample_ids,
+    )
+
+    assert result.created_count == 0
+    assert result.skipped_count == 3
+
+
+def test_create_classification_annotations__duplicate_sample_ids_annotated_once(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id, images[0].sample_id],
+    )
+
+    assert result.created_count == 1
+    assert result.skipped_count == 0
+
+
+def test_create_classification_annotations__adds_second_class_alongside_first(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="dog",
+        sample_ids=[images[0].sample_id],
+    )
+
+    assert result.created_count == 1
+    assert result.skipped_count == 0
+    assert _class_names_by_sample_id(session=db_session, images=images[:1]) == {
+        images[0].sample_id: {"cat", "dog"}
+    }
+
+
+def test_create_classification_annotations__default_annotation_collection(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+    )
+
+    default_collection_id = collection_resolver.get_by_name(
+        session=db_session,
+        name=SampleType.ANNOTATION.value.lower(),
+        parent_collection_id=collection.collection_id,
+    )
+    assert (
+        _annotation_collection_id(
+            session=db_session, annotation_id=result.created_annotation_ids[0]
+        )
+        == default_collection_id
+    )
+
+
+def test_create_classification_annotations__named_annotation_collection(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+        annotation_collection_name="ground_truth",
+    )
+
+    named_collection_id = collection_resolver.get_by_name(
+        session=db_session,
+        name="ground_truth",
+        parent_collection_id=collection.collection_id,
+    )
+    assert named_collection_id is not None
+    assert (
+        _annotation_collection_id(
+            session=db_session, annotation_id=result.created_annotation_ids[0]
+        )
+        == named_collection_id
+    )
+
+
+def test_create_classification_annotations__dedupe_is_per_annotation_collection(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+        annotation_collection_name="ground_truth",
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+        annotation_collection_name="predictions",
+    )
+
+    assert result.created_count == 1
+    assert result.skipped_count == 0
+
+
+def test_create_classification_annotations__batches(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    # The service package re-exports the function under the module's own name, so the
+    # module has to be looked up in sys.modules to patch its constant.
+    service_module = sys.modules[
+        "lightly_studio.services.annotations_service.create_classification_annotations"
+    ]
+    mocker.patch.object(service_module, "CREATE_BATCH_SIZE", 2)
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path=f"batched_{i}.png") for i in range(5)],
+    )
+
+    result = annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[image.sample_id for image in images],
+    )
+
+    assert result.created_count == 5
+    assert len(set(result.created_annotation_ids)) == 5
+
+
+def test_create_classification_annotations_by_filter(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    result = annotations_service.create_classification_annotations_by_filter(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        grid_filter=ImageFilter(),
+    )
+
+    assert result.created_count == 3
+    assert result.skipped_count == 0
+    assert _class_names_by_sample_id(session=db_session, images=images) == {
+        image.sample_id: {"cat"} for image in images
+    }
+
+
+def test_create_classification_annotations_by_filter__matches_subset(
+    db_session: Session, collection: CollectionTable
+) -> None:
+    wide, narrow = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[
+            ImageStub(path="wide.png", width=1920, height=1080),
+            ImageStub(path="narrow.png", width=10, height=10),
+        ],
+    )
+
+    result = annotations_service.create_classification_annotations_by_filter(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        grid_filter=ImageFilter.model_validate({"width": {"min": 100}}),
+    )
+
+    assert result.created_count == 1
+    assert _class_names_by_sample_id(session=db_session, images=[wide, narrow]) == {
+        wide.sample_id: {"cat"},
+        narrow.sample_id: set(),
+    }
+
+
+def test_create_classification_annotations_by_filter__skips_already_annotated(
+    db_session: Session, collection: CollectionTable, images: list[ImageTable]
+) -> None:
+    annotations_service.create_classification_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        sample_ids=[images[0].sample_id],
+    )
+
+    result = annotations_service.create_classification_annotations_by_filter(
+        session=db_session,
+        collection_id=collection.collection_id,
+        class_name="cat",
+        grid_filter=ImageFilter(),
+    )
+
+    assert result.created_count == 2
+    assert result.skipped_count == 1
+
+
+def _class_names_by_sample_id(session: Session, images: list[ImageTable]) -> dict[UUID, set[str]]:
+    annotations = annotation_resolver.get_all_by_parent_sample_ids(
+        session=session, parent_sample_ids=[image.sample_id for image in images]
+    )
+    class_names: dict[UUID, set[str]] = {image.sample_id: set() for image in images}
+    for annotation in annotations:
+        class_names[annotation.parent_sample_id].add(
+            annotation.annotation_label.annotation_label_name
+        )
+    return class_names
+
+
+def _annotation_collection_id(session: Session, annotation_id: UUID) -> UUID:
+    annotation = annotation_resolver.get_by_id(session=session, annotation_id=annotation_id)
+    assert annotation is not None
+    return annotation.sample.collection_id


### PR DESCRIPTION
## What has changed and why?

Backend groundwork for assigning one annotation class to many images at once. Nothing is user-visible yet; the GUI arrives later in this stack.

- Adds `POST /collections/{collection_id}/annotations/classifications/bulk` (a list of sample ids) and `.../bulk_by_filter` (a grid filter), mirroring how tagging already offers both. The filter variant means "apply to everything currently selected" never has to send tens of thousands of ids over the wire.
- Both return how many annotations were created and how many were skipped, so the GUI can tell the user "added to 28 of 40".
- Images that already carry the picked class in the target annotation source are skipped instead of getting a duplicate. There is no database constraint that could express this, so the check lives in the resolver.
- The skip check is deliberately limited to classifications: a sample that already has a *bounding box* of class "car" still gets a whole-image "car" classification, because those are different annotations.
- A missing annotation class is created on the fly, as the single-annotation path already does.
- Annotations are added alongside whatever is already there and nothing is ever overwritten or deleted.

Part of LIG-10438. Stack: **this PR** → panel component → wiring.

## How has it been tested?

- 32 new tests across resolver, service and route: fresh creation, the skip path and its counts, a second different class kept alongside the first, a bounding box of the same class *not* blocking the classification, on-the-fly class creation, default vs named annotation source, per-source scoping, duplicate ids collapsed, batching, and the filter path matching the id-list result.
- The bounding-box regression test was verified to have signal by removing the fix and confirming exactly those tests fail.
- `make static-checks` clean (ruff, mypy over 932 files, format check). `make test` passes except `test_server_static_webapp`, which needs a real frontend build and fails identically on a checkout without one.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @horatiualmasan (most history on these files). Alternative: @LeonardoRosaa.



---

**Stack (review bottom-up):**
1. #2184 Backend routes for bulk classification labeling
2. #2185 Bulk annotation class panel component
3. #2186 Wire the panel into the image grid


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk creation of classification annotations by sample IDs or grid filters.
  * Reports created and skipped annotations, while preserving existing annotation classes.
  * Supports default or named annotation collections and creates missing labels automatically.
  * Grid-filter actions now correctly resolve embedding-region selections to matching samples.

* **Bug Fixes**
  * Improved detection of samples that already have a specified annotation class, preventing duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->