### PR TITLE
Add the bulk annotation class panel component

### DIFF
--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.helpers.test.ts
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeApply, withSelectedOption } from './BulkAnnotationClassPanel.helpers';
+
+describe('summarizeApply', () => {
+    const selectionClassCounts = [
+        { className: 'dog', sampleCount: 3 },
+        { className: 'cat', sampleCount: 1 }
+    ];
+
+    it('skips the images that already have the annotation class', () => {
+        expect(
+            summarizeApply({ className: 'dog', selectedCount: 10, selectionClassCounts })
+        ).toEqual({ skippedCount: 3, affectedCount: 7 });
+    });
+
+    it('skips nothing for a class that is not in the selection', () => {
+        expect(
+            summarizeApply({ className: 'horse', selectedCount: 10, selectionClassCounts })
+        ).toEqual({ skippedCount: 0, affectedCount: 10 });
+    });
+
+    it('clamps a count larger than the selection so affectedCount stays non-negative', () => {
+        expect(
+            summarizeApply({ className: 'dog', selectedCount: 2, selectionClassCounts })
+        ).toEqual({ skippedCount: 2, affectedCount: 0 });
+    });
+});
+
+describe('withSelectedOption', () => {
+    it('appends a selected name that is not in the options', () => {
+        expect(withSelectedOption(['dog'], 'cat')).toEqual(['dog', 'cat']);
+    });
+
+    it('keeps the options unchanged for a known or empty selection', () => {
+        expect(withSelectedOption(['dog'], 'dog')).toEqual(['dog']);
+        expect(withSelectedOption(['dog'], '')).toEqual(['dog']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.helpers.ts
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.helpers.ts
@@ -1,0 +1,43 @@
+interface SelectionClassCount {
+    className: string;
+    sampleCount: number;
+}
+
+interface ApplySummaryParams {
+    className: string;
+    selectedCount: number;
+    selectionClassCounts: SelectionClassCount[];
+}
+
+interface ApplySummary {
+    /** Selected images that already carry `className` and are therefore left untouched. */
+    skippedCount: number;
+    /** Selected images that gain the annotation class. */
+    affectedCount: number;
+}
+
+/**
+ * Split the selection into the images an apply would change and the ones it skips.
+ *
+ * The skip count comes from the entry of `selectionClassCounts` matching `className`
+ * (counted in distinct-samples mode), clamped to the selection size so a stale count
+ * can never produce a negative number of affected images.
+ */
+export function summarizeApply({
+    className,
+    selectedCount,
+    selectionClassCounts
+}: ApplySummaryParams): ApplySummary {
+    const match = selectionClassCounts.find((entry) => entry.className === className);
+    const skippedCount = Math.min(Math.max(match?.sampleCount ?? 0, 0), selectedCount);
+    return { skippedCount, affectedCount: selectedCount - skippedCount };
+}
+
+/**
+ * Merge `selected` into `options` so a name the user just typed stays listed and
+ * selected until the (later) data layer reports it back.
+ */
+export function withSelectedOption(options: string[], selected: string): string[] {
+    if (!selected) return options;
+    return [...new Set([...options, selected])];
+}

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.stories.svelte
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.stories.svelte
@@ -1,0 +1,60 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import BulkAnnotationClassPanel from './BulkAnnotationClassPanel.svelte';
+
+    const annotationClasses = [
+        { id: '1', name: 'dog' },
+        { id: '2', name: 'cat' },
+        { id: '3', name: 'horse' }
+    ];
+
+    const { Story } = defineMeta({
+        title: 'Components/BulkAnnotationClassPanel',
+        component: BulkAnnotationClassPanel,
+        tags: ['autodocs'],
+        args: {
+            selectedCount: 12,
+            annotationClasses,
+            annotationSources: ['ground_truth', 'predictions'],
+            selectedSource: 'ground_truth',
+            selectionClassCounts: [],
+            isLoadingCounts: false,
+            isApplying: false,
+            onSourceChange: () => {},
+            onApply: () => {}
+        }
+    });
+</script>
+
+{#snippet sidePanel(args)}
+    <!-- Mimics the right side-panel width from the collection layout. -->
+    <div class="w-[320px]">
+        <BulkAnnotationClassPanel {...args} />
+    </div>
+{/snippet}
+
+<Story name="No selection" args={{ selectedCount: 0 }} template={sidePanel} />
+
+<Story name="Selection without existing classes" template={sidePanel} />
+
+<Story
+    name="Selection where some images already have the class"
+    args={{
+        selectionClassCounts: [
+            { className: 'dog', sampleCount: 4 },
+            { className: 'cat', sampleCount: 2 }
+        ]
+    }}
+    template={sidePanel}
+/>
+
+<Story name="Loading existing classes" args={{ isLoadingCounts: true }} template={sidePanel} />
+
+<Story
+    name="Applying"
+    args={{
+        isApplying: true,
+        selectionClassCounts: [{ className: 'dog', sampleCount: 4 }]
+    }}
+    template={sidePanel}
+/>

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.svelte
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+    import Segment from '$lib/components/Segment/Segment.svelte';
+    import { Button } from '$lib/components';
+    import NamePicker from './NamePicker/NamePicker.svelte';
+    import ExistingClassCounts from './ExistingClassCounts/ExistingClassCounts.svelte';
+    import ConfirmApplyDialog from './ConfirmApplyDialog/ConfirmApplyDialog.svelte';
+    import { summarizeApply, withSelectedOption } from './BulkAnnotationClassPanel.helpers';
+
+    interface AnnotationClassOption {
+        id: string;
+        name: string;
+    }
+
+    interface SelectionClassCount {
+        className: string;
+        sampleCount: number;
+    }
+
+    interface Props {
+        /** Number of selected images the annotation class is added to. */
+        selectedCount: number;
+        /** Annotation classes to choose from; a new name can also be typed. */
+        annotationClasses: AnnotationClassOption[];
+        /** Annotation sources to choose from; a new name can also be typed. */
+        annotationSources: string[];
+        /** Annotation source the new annotations are written to. */
+        selectedSource: string;
+        /** Annotation classes the selected images already have in `selectedSource`. */
+        selectionClassCounts: SelectionClassCount[];
+        isLoadingCounts: boolean;
+        isApplying: boolean;
+        onSourceChange: (source: string) => void;
+        onApply: (args: { className: string; source: string }) => void;
+    }
+
+    const {
+        selectedCount,
+        annotationClasses,
+        annotationSources,
+        selectedSource,
+        selectionClassCounts,
+        isLoadingCounts,
+        isApplying,
+        onSourceChange,
+        onApply
+    }: Props = $props();
+
+    let className = $state('');
+    let isConfirming = $state(false);
+
+    const sourceOptions = $derived(withSelectedOption(annotationSources, selectedSource));
+    const classOptions = $derived(
+        withSelectedOption(
+            annotationClasses.map((option) => option.name),
+            className
+        )
+    );
+    const summary = $derived(summarizeApply({ className, selectedCount, selectionClassCounts }));
+    const canApply = $derived(className.length > 0 && selectedSource.length > 0 && !isApplying);
+    // The target source stays on the action itself: there is no undo for this anywhere.
+    const applyLabel = $derived(
+        selectedSource ? `Add annotation class to ${selectedSource}` : 'Add annotation class'
+    );
+</script>
+
+{#if selectedCount > 0}
+    <Segment title={`Selected images: ${selectedCount}`}>
+        <div class="flex flex-col gap-3" data-testid="bulk-annotation-class-panel">
+            <p class="text-sm text-muted-foreground">
+                Add one annotation class to every selected image. Existing annotations are kept —
+                change or remove them in the annotation view.
+            </p>
+
+            <div class="space-y-1">
+                <p class="text-xs font-medium">Annotation source</p>
+                <NamePicker
+                    value={selectedSource}
+                    options={sourceOptions}
+                    placeholder="Select an annotation source"
+                    searchPlaceholder="Search or create a source…"
+                    ariaLabel="Annotation source"
+                    onPick={onSourceChange}
+                    disabled={isApplying}
+                    testId="bulk-source-picker"
+                />
+            </div>
+
+            <div class="space-y-1">
+                <p class="text-xs font-medium">Annotation class</p>
+                <NamePicker
+                    value={className}
+                    options={classOptions}
+                    placeholder="Select an annotation class"
+                    searchPlaceholder="Search or create a class…"
+                    ariaLabel="Annotation class"
+                    onPick={(name) => (className = name)}
+                    disabled={isApplying}
+                    testId="bulk-class-picker"
+                />
+            </div>
+
+            <ExistingClassCounts
+                source={selectedSource}
+                counts={selectionClassCounts}
+                isLoading={isLoadingCounts}
+            />
+
+            <Button
+                variant="default"
+                isPending={isApplying}
+                buttonProps={{
+                    type: 'button',
+                    disabled: !canApply,
+                    class: 'w-full min-w-0',
+                    onclick: () => (isConfirming = true),
+                    'data-testid': 'bulk-annotation-class-apply'
+                }}
+            >
+                <span class="min-w-0 truncate">{applyLabel}</span>
+            </Button>
+        </div>
+    </Segment>
+
+    <ConfirmApplyDialog
+        open={isConfirming}
+        {className}
+        source={selectedSource}
+        affectedCount={summary.affectedCount}
+        skippedCount={summary.skippedCount}
+        {isApplying}
+        onOpenChange={(open) => (isConfirming = open)}
+        onConfirm={() => {
+            isConfirming = false;
+            onApply({ className, source: selectedSource });
+        }}
+    />
+{/if}

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/BulkAnnotationClassPanel.test.ts
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BulkAnnotationClassPanel from './BulkAnnotationClassPanel.svelte';
+
+const onApply = vi.fn();
+const onSourceChange = vi.fn();
+
+const defaultProps = {
+    selectedCount: 10,
+    annotationClasses: [
+        { id: '1', name: 'dog' },
+        { id: '2', name: 'cat' }
+    ],
+    annotationSources: ['ground_truth', 'predictions'],
+    selectedSource: 'ground_truth',
+    selectionClassCounts: [{ className: 'dog', sampleCount: 3 }],
+    isLoadingCounts: false,
+    isApplying: false,
+    onSourceChange,
+    onApply
+};
+
+const pickClass = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
+    await user.click(screen.getByTestId('bulk-class-picker-trigger'));
+    await user.click(await screen.findByTestId(`bulk-class-picker-option-${name}`));
+};
+
+describe('BulkAnnotationClassPanel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('renders nothing without a selection', () => {
+        render(BulkAnnotationClassPanel, { props: { ...defaultProps, selectedCount: 0 } });
+
+        expect(screen.queryByTestId('bulk-annotation-class-panel')).not.toBeInTheDocument();
+    });
+
+    it('shows the selection size, the target source on the action, and the existing classes', () => {
+        render(BulkAnnotationClassPanel, { props: defaultProps });
+
+        expect(screen.getByText('Selected images: 10')).toBeInTheDocument();
+        expect(screen.getByTestId('bulk-annotation-class-apply')).toHaveTextContent(
+            'Add annotation class to ground_truth'
+        );
+        expect(screen.getByTestId('existing-class-counts')).toHaveTextContent('dog');
+    });
+
+    it('shows a loading state for the existing classes', () => {
+        render(BulkAnnotationClassPanel, { props: { ...defaultProps, isLoadingCounts: true } });
+
+        expect(screen.getByTestId('existing-class-counts-loading')).toBeInTheDocument();
+    });
+
+    it('reports a picked annotation source', async () => {
+        const user = userEvent.setup();
+        render(BulkAnnotationClassPanel, { props: defaultProps });
+
+        await user.click(screen.getByTestId('bulk-source-picker-trigger'));
+        await user.click(await screen.findByTestId('bulk-source-picker-option-predictions'));
+
+        expect(onSourceChange).toHaveBeenCalledWith('predictions');
+    });
+
+    it('asks for confirmation before applying and derives the skip count from the counts', async () => {
+        const user = userEvent.setup();
+        render(BulkAnnotationClassPanel, { props: defaultProps });
+
+        await pickClass(user, 'dog');
+        await user.click(screen.getByTestId('bulk-annotation-class-apply'));
+
+        expect(onApply).not.toHaveBeenCalled();
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog).toHaveTextContent('7 images');
+        expect(dialog).toHaveTextContent('ground_truth');
+        expect(screen.getByTestId('confirm-apply-skipped')).toHaveTextContent(
+            '3 images already have this annotation class and are skipped.'
+        );
+    });
+
+    it('applies the picked annotation class and source on confirmation', async () => {
+        const user = userEvent.setup();
+        render(BulkAnnotationClassPanel, { props: defaultProps });
+
+        await pickClass(user, 'cat');
+        await user.click(screen.getByTestId('bulk-annotation-class-apply'));
+        await user.click(await screen.findByTestId('confirm-apply-submit'));
+
+        expect(onApply).toHaveBeenCalledWith({ className: 'cat', source: 'ground_truth' });
+    });
+
+    it('disables the apply action while applying', () => {
+        render(BulkAnnotationClassPanel, { props: { ...defaultProps, isApplying: true } });
+
+        expect(screen.getByTestId('bulk-annotation-class-apply')).toBeDisabled();
+    });
+
+    it('disables the apply action until an annotation class is picked', () => {
+        render(BulkAnnotationClassPanel, { props: defaultProps });
+
+        expect(screen.getByTestId('bulk-annotation-class-apply')).toBeDisabled();
+    });
+});

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/ConfirmApplyDialog/ConfirmApplyDialog.svelte
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/ConfirmApplyDialog/ConfirmApplyDialog.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+    import * as Dialog from '$lib/components/ui/dialog';
+    import { Button } from '$lib/components';
+
+    interface Props {
+        open: boolean;
+        /** Annotation class about to be added to the selection. */
+        className: string;
+        /** Annotation source the new annotations are written to. */
+        source: string;
+        /** Selected images that gain the annotation class. */
+        affectedCount: number;
+        /** Selected images that already have the annotation class. */
+        skippedCount: number;
+        isApplying: boolean;
+        onOpenChange: (open: boolean) => void;
+        onConfirm: () => void;
+    }
+
+    const {
+        open,
+        className,
+        source,
+        affectedCount,
+        skippedCount,
+        isApplying,
+        onOpenChange,
+        onConfirm
+    }: Props = $props();
+
+    const images = (count: number) => `${count} ${count === 1 ? 'image' : 'images'}`;
+</script>
+
+<Dialog.Root {open} {onOpenChange}>
+    <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content class="border-border bg-background sm:max-w-[440px]">
+            <Dialog.Header>
+                <Dialog.Title class="text-foreground">Add annotation class</Dialog.Title>
+                <Dialog.Description class="text-foreground">
+                    Add the annotation class <span class="font-semibold">{className}</span> to
+                    {images(affectedCount)} in the annotation source
+                    <span class="font-semibold">{source}</span>.
+                </Dialog.Description>
+            </Dialog.Header>
+
+            <p class="text-sm text-muted-foreground" data-testid="confirm-apply-skipped">
+                {#if skippedCount > 0}
+                    {images(skippedCount)} already have this annotation class and are skipped.
+                {:else}
+                    None of the selected images have this annotation class yet.
+                {/if}
+            </p>
+            <p class="text-xs text-muted-foreground">
+                Existing annotations are kept. This cannot be undone.
+            </p>
+
+            <Dialog.Footer>
+                <Button
+                    variant="outline"
+                    buttonProps={{
+                        type: 'button',
+                        onclick: () => onOpenChange(false),
+                        disabled: isApplying,
+                        'data-testid': 'confirm-apply-cancel'
+                    }}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    variant="default"
+                    isPending={isApplying}
+                    buttonProps={{
+                        type: 'button',
+                        onclick: onConfirm,
+                        disabled: isApplying || affectedCount === 0,
+                        'data-testid': 'confirm-apply-submit'
+                    }}
+                >
+                    Add annotation class
+                </Button>
+            </Dialog.Footer>
+        </Dialog.Content>
+    </Dialog.Portal>
+</Dialog.Root>

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/ExistingClassCounts/ExistingClassCounts.svelte
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/ExistingClassCounts/ExistingClassCounts.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import Spinner from '$lib/components/Spinner/Spinner.svelte';
+
+    interface Props {
+        /** Annotation source the counts were taken from. */
+        source: string;
+        /** Classification annotations the selected images already have, per annotation class. */
+        counts: { className: string; sampleCount: number }[];
+        isLoading: boolean;
+    }
+
+    const { source, counts, isLoading }: Props = $props();
+</script>
+
+<div class="space-y-1.5" data-testid="existing-class-counts">
+    <p class="text-xs font-medium text-muted-foreground">
+        Annotation classes already in {source}
+    </p>
+    {#if isLoading}
+        <div class="flex items-center gap-2 text-xs text-muted-foreground">
+            <Spinner size="small" />
+            <span data-testid="existing-class-counts-loading">Loading annotation classes…</span>
+        </div>
+    {:else if counts.length === 0}
+        <p class="text-xs text-muted-foreground" data-testid="existing-class-counts-empty">
+            The selected images have no annotations in this annotation source.
+        </p>
+    {:else}
+        <ul class="max-h-32 space-y-0.5 overflow-y-auto text-xs">
+            {#each counts as { className, sampleCount } (className)}
+                <li class="flex items-center justify-between gap-2">
+                    <span class="min-w-0 truncate">{className}</span>
+                    <span class="shrink-0 tabular-nums text-muted-foreground">{sampleCount}</span>
+                </li>
+            {/each}
+        </ul>
+    {/if}
+</div>

--- a/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/NamePicker/NamePicker.svelte
+++ b/lightly_studio_view/src/lib/components/BulkAnnotationClassPanel/NamePicker/NamePicker.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+    import { Check as CheckIcon, ChevronsUpDown as ChevronsUpDownIcon } from '@lucide/svelte';
+    import * as Command from '$lib/components/ui/command/index.js';
+    import * as Popover from '$lib/components/ui/popover/index.js';
+    import { Button } from '$lib/components';
+    import { cn } from '$lib/utils';
+
+    interface Props {
+        /** Currently picked name, or an empty string when nothing is picked yet. */
+        value: string;
+        /** Names to choose from. */
+        options: string[];
+        /** Trigger text shown while `value` is empty. */
+        placeholder: string;
+        /** Search input placeholder. */
+        searchPlaceholder: string;
+        /** Accessible name of the trigger. */
+        ariaLabel: string;
+        onPick: (name: string) => void;
+        disabled?: boolean;
+        testId: string;
+    }
+
+    const {
+        value,
+        options,
+        placeholder,
+        searchPlaceholder,
+        ariaLabel,
+        onPick,
+        disabled = false,
+        testId
+    }: Props = $props();
+
+    let open = $state(false);
+    let inputValue = $state('');
+    let highlightedValue = $state('');
+
+    $effect(() => {
+        if (!open) {
+            inputValue = '';
+            highlightedValue = '';
+        }
+    });
+
+    const typedName = $derived(inputValue.trim());
+    const canCreate = $derived(typedName.length > 0 && !options.includes(typedName));
+
+    const pick = (name: string) => {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        onPick(trimmed);
+        open = false;
+    };
+
+    // Mirror SelectList: Enter with no highlighted item takes the typed name.
+    const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' && !highlightedValue && typedName) {
+            pick(typedName);
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+</script>
+
+<Popover.Root bind:open>
+    <Popover.Trigger>
+        {#snippet child({ props }: { props: Record<string, unknown> })}
+            <Button
+                variant="secondary"
+                {ariaLabel}
+                buttonProps={{
+                    ...props,
+                    disabled,
+                    class: 'w-full min-w-0 justify-between',
+                    role: 'combobox',
+                    'aria-expanded': open,
+                    'data-testid': `${testId}-trigger`
+                }}
+            >
+                <span class={cn('min-w-0 flex-1 truncate text-left', !value && 'opacity-60')}>
+                    {value || placeholder}
+                </span>
+                <ChevronsUpDownIcon class="size-4 shrink-0 opacity-50" />
+            </Button>
+        {/snippet}
+    </Popover.Trigger>
+    <Popover.Content class="w-[240px] p-0" align="start">
+        <Command.Root bind:value={highlightedValue}>
+            <Command.Input
+                placeholder={searchPlaceholder}
+                onkeydown={handleKeyDown}
+                bind:value={inputValue}
+                data-testid={`${testId}-input`}
+            />
+            <Command.List class="dark:[color-scheme:dark]">
+                <Command.Group>
+                    {#each options as name (name)}
+                        <Command.Item
+                            value={name}
+                            onSelect={() => pick(name)}
+                            data-testid={`${testId}-option-${name}`}
+                        >
+                            <CheckIcon class={cn(value !== name && 'text-transparent')} />
+                            <span class="min-w-0 flex-1 truncate">{name}</span>
+                        </Command.Item>
+                    {/each}
+                </Command.Group>
+                {#if canCreate}
+                    <div class="border-t">
+                        <Command.Item
+                            value="__create__"
+                            onSelect={() => pick(typedName)}
+                            forceMount
+                            keywords={[]}
+                            data-testid={`${testId}-create`}
+                        >
+                            <span class="opacity-50">Create:</span>
+                            <span class="ml-1 min-w-0 flex-1 truncate font-semibold">
+                                {typedName}
+                            </span>
+                        </Command.Item>
+                    </div>
+                {/if}
+            </Command.List>
+        </Command.Root>
+    </Popover.Content>
+</Popover.Root>


### PR DESCRIPTION
## What has changed and why?

The panel that lets a labeler add one annotation class to a whole selection of images, built on its own so it can be reviewed without the data plumbing. It makes no API calls and touches no existing component — everything is new files.

- A picker for the annotation source and one for the annotation class, both of which also accept a name that does not exist yet.
- Applying always goes through a confirmation, because this action has no undo.
- A short hint pointing at the annotation view for changing or removing annotations, since this panel only ever adds.
- Renders nothing when nothing is selected.

`AnnotationSourcePill` could not be reused: it reads four different contexts and hooks, so it cannot be driven from props. A small presentational `NamePicker` serves both pickers instead. Worth a look during review — consolidating the two pickers later is a reasonable follow-up.

Part of LIG-10438. Stack: backend routes → **this PR** → wiring.

## How has it been tested?

- 13 colocated unit tests: nothing rendered at an empty selection, the confirmation appearing before anything is applied, the chosen class and source being handed back, and the apply control disabled while in flight.
- A Storybook story covering the empty, populated, single-image and applying states.
- `make static-checks` and `make test` pass.

Reviewer note: this is a UI change, so **a screenshot would normally belong here** — the panel cannot be rendered meaningfully until the wiring PR on top of this one, so the screenshots live there instead.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @horatiualmasan (same reviewer across the stack). Alternative: @LeonardoRosaa.



---

**Stack (review bottom-up):**
1. #2184 Backend routes for bulk classification labeling
2. #2185 Bulk annotation class panel component
3. #2186 Wire the panel into the image grid
