### PR TITLE
Fix `effect_update_depth_exceeded` errors for high precision metadata sliders

### DIFF
--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.test.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.test.ts
@@ -1,79 +1,110 @@
 import { describe, expect, it } from 'vitest';
-import { SLIDER_TICKS, fromTick, toTick } from './MetadataFilterItem.helpers';
+import {
+    FLOAT_SLIDER_TICKS,
+    fromTick,
+    getSliderTickCount,
+    toTick
+} from './MetadataFilterItem.helpers';
 
 describe('MetadataFilterItem.helpers', () => {
     const solarAngle = { min: -75.89126551973673, max: 87.50941362154188 };
+    const floatTicks = getSliderTickCount(solarAngle, false);
+
+    describe('getSliderTickCount', () => {
+        it('uses the fixed float resolution for float fields', () => {
+            expect(getSliderTickCount(solarAngle, false)).toBe(FLOAT_SLIDER_TICKS);
+        });
+
+        it('uses one tick per integer for integer fields', () => {
+            expect(getSliderTickCount({ min: 0, max: 1712 }, true)).toBe(1712);
+        });
+
+        it('never returns fewer than one tick for a degenerate range', () => {
+            expect(getSliderTickCount({ min: 5, max: 5 }, true)).toBe(1);
+        });
+    });
 
     describe('toTick', () => {
         it('maps the bounds to the tick endpoints', () => {
-            expect(toTick(solarAngle.min, solarAngle)).toBe(0);
-            expect(toTick(solarAngle.max, solarAngle)).toBe(SLIDER_TICKS);
+            expect(toTick(solarAngle.min, solarAngle, floatTicks)).toBe(0);
+            expect(toTick(solarAngle.max, solarAngle, floatTicks)).toBe(floatTicks);
         });
 
         it('maps the midpoint to the middle tick', () => {
             const mid = (solarAngle.min + solarAngle.max) / 2;
 
-            expect(toTick(mid, solarAngle)).toBe(SLIDER_TICKS / 2);
-        });
-
-        it('is monotonic across the range', () => {
-            expect(toTick(solarAngle.min, solarAngle)).toBeLessThanOrEqual(
-                toTick(solarAngle.max, solarAngle)
-            );
+            expect(toTick(mid, solarAngle, floatTicks)).toBe(floatTicks / 2);
         });
 
         it('clamps values outside the bounds into the tick domain', () => {
-            expect(toTick(solarAngle.min - 100, solarAngle)).toBe(0);
-            expect(toTick(solarAngle.max + 100, solarAngle)).toBe(SLIDER_TICKS);
+            expect(toTick(solarAngle.min - 100, solarAngle, floatTicks)).toBe(0);
+            expect(toTick(solarAngle.max + 100, solarAngle, floatTicks)).toBe(floatTicks);
         });
 
         it('returns 0 for a degenerate range instead of dividing by zero', () => {
-            expect(toTick(5, { min: 5, max: 5 })).toBe(0);
+            expect(toTick(5, { min: 5, max: 5 }, 1)).toBe(0);
         });
     });
 
     describe('fromTick', () => {
         it('returns the exact bounds at the tick endpoints', () => {
-            expect(fromTick(0, solarAngle, false)).toBe(solarAngle.min);
-            expect(fromTick(SLIDER_TICKS, solarAngle, false)).toBe(solarAngle.max);
+            expect(fromTick(0, solarAngle, floatTicks, false)).toBe(solarAngle.min);
+            expect(fromTick(floatTicks, solarAngle, floatTicks, false)).toBe(solarAngle.max);
         });
 
         it('clamps ticks outside the domain to the bounds', () => {
-            expect(fromTick(-10, solarAngle, false)).toBe(solarAngle.min);
-            expect(fromTick(SLIDER_TICKS + 10, solarAngle, false)).toBe(solarAngle.max);
-        });
-
-        it('rounds to whole numbers for integer metadata fields', () => {
-            const bound = { min: 0, max: 1712 };
-            const value = fromTick(500, bound, true);
-
-            expect(Number.isInteger(value)).toBe(true);
+            expect(fromTick(-10, solarAngle, floatTicks, false)).toBe(solarAngle.min);
+            expect(fromTick(floatTicks + 10, solarAngle, floatTicks, false)).toBe(solarAngle.max);
         });
 
         it('keeps fractional precision for float metadata fields', () => {
-            const value = fromTick(500, solarAngle, false);
-
-            expect(Number.isInteger(value)).toBe(false);
+            expect(Number.isInteger(fromTick(500, solarAngle, floatTicks, false))).toBe(false);
         });
     });
 
     describe('round-trip', () => {
-        it('recovers interior values within one tick of granularity', () => {
-            const tickSize = (solarAngle.max - solarAngle.min) / SLIDER_TICKS;
+        it('recovers interior float values within one tick of granularity', () => {
+            const tickSize = (solarAngle.max - solarAngle.min) / floatTicks;
             const original = 12.3456;
 
-            const recovered = fromTick(toTick(original, solarAngle), solarAngle, false);
+            const recovered = fromTick(
+                toTick(original, solarAngle, floatTicks),
+                solarAngle,
+                floatTicks,
+                false
+            );
 
             expect(Math.abs(recovered - original)).toBeLessThanOrEqual(tickSize);
         });
 
-        it('recovers the bounds exactly', () => {
-            expect(fromTick(toTick(solarAngle.min, solarAngle), solarAngle, false)).toBe(
-                solarAngle.min
-            );
-            expect(fromTick(toTick(solarAngle.max, solarAngle), solarAngle, false)).toBe(
-                solarAngle.max
-            );
+        it('recovers the float bounds exactly', () => {
+            expect(
+                fromTick(
+                    toTick(solarAngle.min, solarAngle, floatTicks),
+                    solarAngle,
+                    floatTicks,
+                    false
+                )
+            ).toBe(solarAngle.min);
+            expect(
+                fromTick(
+                    toTick(solarAngle.max, solarAngle, floatTicks),
+                    solarAngle,
+                    floatTicks,
+                    false
+                )
+            ).toBe(solarAngle.max);
+        });
+
+        // Regression: a fixed 1000-tick domain dropped integers once the span exceeded it
+        // (e.g. 0..1712 could not select 1). Per-integer ticks must keep every integer selectable.
+        it('makes every integer selectable for a wide integer field', () => {
+            const bound = { min: 0, max: 1712 };
+            const ticks = getSliderTickCount(bound, true);
+
+            for (let value = bound.min; value <= bound.max; value++) {
+                expect(fromTick(toTick(value, bound, ticks), bound, ticks, true)).toBe(value);
+            }
         });
     });
 });

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.test.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.test.ts
@@ -1,65 +1,79 @@
 import { describe, expect, it } from 'vitest';
-import {
-    clampMetadataValuesToMax,
-    getMetadataSliderMax,
-    getMetadataSliderStep,
-    getSliderDisplayMaxValue
-} from './MetadataFilterItem.helpers';
+import { SLIDER_TICKS, fromTick, toTick } from './MetadataFilterItem.helpers';
 
 describe('MetadataFilterItem.helpers', () => {
-    describe('getMetadataSliderStep', () => {
-        it('returns rounded integer step for integer metadata', () => {
-            const step = getMetadataSliderStep(0, 4500, true);
+    const solarAngle = { min: -75.89126551973673, max: 87.50941362154188 };
 
-            expect(step).toBe(5);
+    describe('toTick', () => {
+        it('maps the bounds to the tick endpoints', () => {
+            expect(toTick(solarAngle.min, solarAngle)).toBe(0);
+            expect(toTick(solarAngle.max, solarAngle)).toBe(SLIDER_TICKS);
         });
 
-        it('returns a minimum step of 1 when integer range is non-positive', () => {
-            const step = getMetadataSliderStep(12, 12, true);
+        it('maps the midpoint to the middle tick', () => {
+            const mid = (solarAngle.min + solarAngle.max) / 2;
 
-            expect(step).toBe(1);
+            expect(toTick(mid, solarAngle)).toBe(SLIDER_TICKS / 2);
         });
 
-        it('returns precise float step for float metadata', () => {
-            const step = getMetadataSliderStep(0, 1, false);
-
-            expect(step).toBe(0.001);
+        it('is monotonic across the range', () => {
+            expect(toTick(solarAngle.min, solarAngle)).toBeLessThanOrEqual(
+                toTick(solarAngle.max, solarAngle)
+            );
         });
 
-        it('returns fallback float step when float range is non-positive', () => {
-            const step = getMetadataSliderStep(3.5, 3.5, false);
-
-            expect(step).toBe(0.001);
-        });
-    });
-
-    describe('getMetadataSliderMax', () => {
-        it('keeps max when it is on the step grid', () => {
-            expect(getMetadataSliderMax(0, 10, 2)).toBe(10);
+        it('clamps values outside the bounds into the tick domain', () => {
+            expect(toTick(solarAngle.min - 100, solarAngle)).toBe(0);
+            expect(toTick(solarAngle.max + 100, solarAngle)).toBe(SLIDER_TICKS);
         });
 
-        it('extends max by one step when it is off-grid', () => {
-            expect(getMetadataSliderMax(0, 10, 3)).toBe(13);
+        it('returns 0 for a degenerate range instead of dividing by zero', () => {
+            expect(toTick(5, { min: 5, max: 5 })).toBe(0);
         });
     });
 
-    describe('getSliderDisplayMaxValue', () => {
-        it('uses virtual slider max when selected value reached bound max', () => {
-            expect(getSliderDisplayMaxValue(10, 10, 13)).toBe(13);
+    describe('fromTick', () => {
+        it('returns the exact bounds at the tick endpoints', () => {
+            expect(fromTick(0, solarAngle, false)).toBe(solarAngle.min);
+            expect(fromTick(SLIDER_TICKS, solarAngle, false)).toBe(solarAngle.max);
         });
 
-        it('keeps selected value when below bound max', () => {
-            expect(getSliderDisplayMaxValue(9, 10, 13)).toBe(9);
+        it('clamps ticks outside the domain to the bounds', () => {
+            expect(fromTick(-10, solarAngle, false)).toBe(solarAngle.min);
+            expect(fromTick(SLIDER_TICKS + 10, solarAngle, false)).toBe(solarAngle.max);
+        });
+
+        it('rounds to whole numbers for integer metadata fields', () => {
+            const bound = { min: 0, max: 1712 };
+            const value = fromTick(500, bound, true);
+
+            expect(Number.isInteger(value)).toBe(true);
+        });
+
+        it('keeps fractional precision for float metadata fields', () => {
+            const value = fromTick(500, solarAngle, false);
+
+            expect(Number.isInteger(value)).toBe(false);
         });
     });
 
-    describe('clampMetadataValuesToMax', () => {
-        it('clamps values above the bound max', () => {
-            expect(clampMetadataValuesToMax([12, 15], 10)).toEqual([10, 10]);
+    describe('round-trip', () => {
+        it('recovers interior values within one tick of granularity', () => {
+            const tickSize = (solarAngle.max - solarAngle.min) / SLIDER_TICKS;
+            const original = 12.3456;
+
+            const recovered = fromTick(toTick(original, solarAngle), solarAngle, false);
+
+            expect(Math.abs(recovered - original)).toBeLessThanOrEqual(tickSize);
         });
 
-        it('keeps values that are already below bound max', () => {
-            expect(clampMetadataValuesToMax([5, 9], 10)).toEqual([5, 9]);
+        it('recovers the bounds exactly', () => {
+            expect(fromTick(toTick(solarAngle.min, solarAngle), solarAngle, false)).toBe(
+                solarAngle.min
+            );
+            expect(fromTick(toTick(solarAngle.max, solarAngle), solarAngle, false)).toBe(
+                solarAngle.max
+            );
         });
     });
 });

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.ts
@@ -10,7 +10,6 @@ type MetadataBound = MetadataBounds[string];
 // and commit.
 export const SLIDER_TICKS = 1000; // tick granularity: 0.1% of the range
 
-
 /** Map a real metadata value onto the slider's integer tick domain, clamped to [0, SLIDER_TICKS]. */
 export const toTick = (realValue: number, bound: MetadataBound): number => {
     if (bound.max === bound.min) {

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.ts
@@ -8,25 +8,39 @@ type MetadataBound = MetadataBounds[string];
 // effect loops forever (effect_update_depth_exceeded). An integer tick domain (step 1) is always
 // on-grid, so the snap is a no-op and the loop can't start. Real values are used only for display
 // and commit.
-export const SLIDER_TICKS = 1000; // tick granularity: 0.1% of the range
+export const FLOAT_SLIDER_TICKS = 1000; // float granularity: 0.1% of the range
 
-/** Map a real metadata value onto the slider's integer tick domain, clamped to [0, SLIDER_TICKS]. */
-export const toTick = (realValue: number, bound: MetadataBound): number => {
+/**
+ * Number of slider ticks (integer domain 0..ticks, step 1) for a field.
+ * Integer fields get one tick per integer so every value stays selectable even for wide ranges.
+ * Float fields use a fixed resolution since their real values aren't enumerable anyway.
+ */
+export const getSliderTickCount = (bound: MetadataBound, isInteger: boolean): number => {
+    return isInteger ? Math.max(1, bound.max - bound.min) : FLOAT_SLIDER_TICKS;
+};
+
+/** Map a real metadata value onto the slider's integer tick domain, clamped to [0, ticks]. */
+export const toTick = (realValue: number, bound: MetadataBound, ticks: number): number => {
     if (bound.max === bound.min) {
         return 0;
     }
-    const tick = Math.round(((realValue - bound.min) / (bound.max - bound.min)) * SLIDER_TICKS);
-    return Math.min(SLIDER_TICKS, Math.max(0, tick));
+    const tick = Math.round(((realValue - bound.min) / (bound.max - bound.min)) * ticks);
+    return Math.min(ticks, Math.max(0, tick));
 };
 
-/** Map a slider tick back to a real metadata value. */
-export const fromTick = (tick: number, bound: MetadataBound, isInteger: boolean): number => {
+/** Map a slider tick back to a real metadata value; endpoints return the exact bounds. */
+export const fromTick = (
+    tick: number,
+    bound: MetadataBound,
+    ticks: number,
+    isInteger: boolean
+): number => {
     if (tick <= 0) {
         return bound.min;
     }
-    if (tick >= SLIDER_TICKS) {
+    if (tick >= ticks) {
         return bound.max;
     }
-    const realValue = bound.min + (tick / SLIDER_TICKS) * (bound.max - bound.min);
+    const realValue = bound.min + (tick / ticks) * (bound.max - bound.min);
     return isInteger ? Math.round(realValue) : realValue;
 };

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.helpers.ts
@@ -1,34 +1,33 @@
-const METADATA_SLIDER_TICKS = 1000;
-const GRID_EPSILON = 1e-9;
+import type { MetadataBounds } from '$lib/services/types';
 
-export const getMetadataSliderStep = (min: number, max: number, isInteger: boolean): number => {
-    const step = (max - min) / METADATA_SLIDER_TICKS;
-    if (step <= 0) {
-        return isInteger ? 1 : 1 / METADATA_SLIDER_TICKS;
+type MetadataBound = MetadataBounds[string];
+
+// bits-ui snaps a slider value onto the `step` grid and writes the result back into the state it
+// watches. For a high-precision float step it rounds the value to the precision of step.toString(),
+// which makes the snap non-idempotent: the value drifts ~1 ULP each pass and never settles, so the
+// effect loops forever (effect_update_depth_exceeded). An integer tick domain (step 1) is always
+// on-grid, so the snap is a no-op and the loop can't start. Real values are used only for display
+// and commit.
+export const SLIDER_TICKS = 1000; // tick granularity: 0.1% of the range
+
+
+/** Map a real metadata value onto the slider's integer tick domain, clamped to [0, SLIDER_TICKS]. */
+export const toTick = (realValue: number, bound: MetadataBound): number => {
+    if (bound.max === bound.min) {
+        return 0;
     }
-    if (isInteger) {
-        return Math.max(1, Math.round(step));
+    const tick = Math.round(((realValue - bound.min) / (bound.max - bound.min)) * SLIDER_TICKS);
+    return Math.min(SLIDER_TICKS, Math.max(0, tick));
+};
+
+/** Map a slider tick back to a real metadata value. */
+export const fromTick = (tick: number, bound: MetadataBound, isInteger: boolean): number => {
+    if (tick <= 0) {
+        return bound.min;
     }
-    return step;
-};
-
-export const getMetadataSliderMax = (min: number, max: number, step: number): number => {
-    const steps = (max - min) / step;
-    const isMaxOnStepGrid = Math.abs(steps - Math.round(steps)) < GRID_EPSILON;
-    return isMaxOnStepGrid ? max : max + step;
-};
-
-export const getSliderDisplayMaxValue = (
-    valueMax: number,
-    boundMax: number,
-    sliderMax: number
-): number => {
-    return valueMax >= boundMax ? sliderMax : valueMax;
-};
-
-export const clampMetadataValuesToMax = (
-    newValues: number[],
-    boundMax: number
-): [number, number] => {
-    return [Math.min(newValues[0], boundMax), Math.min(newValues[1], boundMax)];
+    if (tick >= SLIDER_TICKS) {
+        return bound.max;
+    }
+    const realValue = bound.min + (tick / SLIDER_TICKS) * (bound.max - bound.min);
+    return isInteger ? Math.round(realValue) : realValue;
 };

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.svelte
@@ -2,12 +2,7 @@
     import { Slider } from '$lib/components/ui/slider/index.js';
     import type { MetadataBounds, MetadataValues } from '$lib/services/types';
     import { formatFloat, formatInteger } from '$lib/utils';
-    import {
-        clampMetadataValuesToMax,
-        getMetadataSliderMax,
-        getMetadataSliderStep,
-        getSliderDisplayMaxValue
-    } from './MetadataFilterItem.helpers';
+    import { SLIDER_TICKS, fromTick, toTick } from './MetadataFilterItem.helpers';
 
     type MetadataBound = MetadataBounds[string];
     type MetadataValue = MetadataValues[string];
@@ -22,12 +17,14 @@
     const { metadataKey, bound, value, onValueCommit }: MetadataFilterItemProps = $props();
 
     const isInteger = $derived(Number.isInteger(bound.min) && Number.isInteger(bound.max));
-    const sliderStep = $derived(getMetadataSliderStep(bound.min, bound.max, isInteger));
-    const sliderMax = $derived(getMetadataSliderMax(bound.min, bound.max, sliderStep));
-    const sliderValueMax = $derived(getSliderDisplayMaxValue(value.max, bound.max, sliderMax));
 
-    const handleValueCommit = (newValues: number[]) => {
-        onValueCommit(metadataKey, clampMetadataValuesToMax(newValues, bound.max));
+    const sliderValue = $derived([toTick(value.min, bound), toTick(value.max, bound)]);
+
+    const handleValueCommit = (newTicks: number[]) => {
+        onValueCommit(metadataKey, [
+            newTicks[0] !== sliderValue[0] ? fromTick(newTicks[0], bound, isInteger) : value.min,
+            newTicks[1] !== sliderValue[1] ? fromTick(newTicks[1], bound, isInteger) : value.max
+        ]);
     };
 
     const formatValue = (sliderValue: number): string => {
@@ -45,10 +42,10 @@
         <Slider
             type="multiple"
             class="filter-{metadataKey}"
-            min={bound.min}
-            max={sliderMax}
-            step={sliderStep}
-            value={[value.min, sliderValueMax]}
+            min={0}
+            max={SLIDER_TICKS}
+            step={1}
+            value={sliderValue}
             onValueCommit={handleValueCommit}
         />
     </div>

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.svelte
@@ -2,7 +2,7 @@
     import { Slider } from '$lib/components/ui/slider/index.js';
     import type { MetadataBounds, MetadataValues } from '$lib/services/types';
     import { formatFloat, formatInteger } from '$lib/utils';
-    import { SLIDER_TICKS, fromTick, toTick } from './MetadataFilterItem.helpers';
+    import { fromTick, getSliderTickCount, toTick } from './MetadataFilterItem.helpers';
 
     type MetadataBound = MetadataBounds[string];
     type MetadataValue = MetadataValues[string];
@@ -17,13 +17,21 @@
     const { metadataKey, bound, value, onValueCommit }: MetadataFilterItemProps = $props();
 
     const isInteger = $derived(Number.isInteger(bound.min) && Number.isInteger(bound.max));
+    const ticks = $derived(getSliderTickCount(bound, isInteger));
 
-    const sliderValue = $derived([toTick(value.min, bound), toTick(value.max, bound)]);
+    const sliderValue = $derived([
+        toTick(value.min, bound, ticks),
+        toTick(value.max, bound, ticks)
+    ]);
 
     const handleValueCommit = (newTicks: number[]) => {
         onValueCommit(metadataKey, [
-            newTicks[0] !== sliderValue[0] ? fromTick(newTicks[0], bound, isInteger) : value.min,
-            newTicks[1] !== sliderValue[1] ? fromTick(newTicks[1], bound, isInteger) : value.max
+            newTicks[0] !== sliderValue[0]
+                ? fromTick(newTicks[0], bound, ticks, isInteger)
+                : value.min,
+            newTicks[1] !== sliderValue[1]
+                ? fromTick(newTicks[1], bound, ticks, isInteger)
+                : value.max
         ]);
     };
 
@@ -43,7 +51,7 @@
             type="multiple"
             class="filter-{metadataKey}"
             min={0}
-            max={SLIDER_TICKS}
+            max={ticks}
             step={1}
             value={sliderValue}
             onValueCommit={handleValueCommit}

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.test.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.test.ts
@@ -10,32 +10,22 @@ describe('MetadataFilterItem', () => {
     const solarAngle = { min: -75.89126551973673, max: 87.50941362154188 };
 
     it('mounts a full-precision float range without an effect-update loop', () => {
+        const onValueCommit = vi.fn();
+
         expect(() =>
             render(MetadataFilterItem, {
                 props: {
                     metadataKey: 'solar_angle',
                     bound: solarAngle,
                     value: { ...solarAngle },
-                    onValueCommit: vi.fn()
+                    onValueCommit
                 }
             })
         ).not.toThrow();
 
         expect(screen.getByText('solar angle')).toBeInTheDocument();
-    });
 
-    it('does not commit a filter just from mounting', () => {
-        const onValueCommit = vi.fn();
-
-        render(MetadataFilterItem, {
-            props: {
-                metadataKey: 'solar_angle',
-                bound: solarAngle,
-                value: { ...solarAngle },
-                onValueCommit
-            }
-        });
-
+        // Should not commit a filter just from mounting.
         expect(onValueCommit).not.toHaveBeenCalled();
     });
 });

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.test.ts
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/MetadataFilterItem/MetadataFilterItem.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import '@testing-library/jest-dom';
+import MetadataFilterItem from './MetadataFilterItem.svelte';
+
+describe('MetadataFilterItem', () => {
+    // Regression guard: this exact float range made bits-ui's slider re-snap its value forever,
+    // throwing effect_update_depth_exceeded on mount and freezing the image grid. Rendering the
+    // component with a full-precision float range must not blow the effect-update depth limit.
+    const solarAngle = { min: -75.89126551973673, max: 87.50941362154188 };
+
+    it('mounts a full-precision float range without an effect-update loop', () => {
+        expect(() =>
+            render(MetadataFilterItem, {
+                props: {
+                    metadataKey: 'solar_angle',
+                    bound: solarAngle,
+                    value: { ...solarAngle },
+                    onValueCommit: vi.fn()
+                }
+            })
+        ).not.toThrow();
+
+        expect(screen.getByText('solar angle')).toBeInTheDocument();
+    });
+
+    it('does not commit a filter just from mounting', () => {
+        const onValueCommit = vi.fn();
+
+        render(MetadataFilterItem, {
+            props: {
+                metadataKey: 'solar_angle',
+                bound: solarAngle,
+                value: { ...solarAngle },
+                onValueCommit
+            }
+        });
+
+        expect(onValueCommit).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What has changed and why?

High precision float metadata ranges (e.g., [-75.89126551973673, 87.50941362154188]) caused infinite reactive loops that were crashing the UI. Ticks could initially be float - `bits-ui` does a to string conversion under the hood which would make the last unit keep drifting, so it could never be rounded to the nearest step, causing the infinite reactive loop.
Integer tick domains are now used for sliders.

## How has it been tested?
New/updated tests + manually 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata filter sliders for precise decimal ranges.
  * Ensured integer ranges keep every selectable integer value, including across wide ranges.
  * Prevented slider snapping issues that could affect image grid updates.
  * Preserved existing filter bounds when slider values remain unchanged.
  * Prevented filters from being committed during initial component mounting.
  * Improved handling of full-precision float ranges to prevent rendering errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->