### PR TITLE
Fix: Refactor grid filter sample id queries

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -26,10 +26,9 @@ from lightly_studio.models.tag import (
     TagTable,
     TagView,
 )
-from lightly_studio.resolvers import embedding_region_resolver, tag_resolver
-from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers import tag_resolver
 from lightly_studio.resolvers.grid_filter import GridFilter
-from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.grid_filter_sample_ids import build_sample_ids_query
 
 tag_router = APIRouter()
 
@@ -236,28 +235,9 @@ def add_samples_to_tag_by_filter(
             detail=f"Tag {tag_id} not found in collection {collection_id}.",
         )
 
-    # Resolve any embedding-plot region selection to concrete sample ids before building
-    # the query (the point-in-polygon test needs the session, which `apply` lacks).
-    grid_filter = body.filter
-    if (
-        isinstance(grid_filter, ImageFilter)
-        and grid_filter.sample_filter is not None
-        and grid_filter.sample_filter.embedding_region is not None
-    ):
-        grid_filter.sample_filter.region_sample_ids = (
-            embedding_region_resolver.get_sample_ids_in_region(
-                session=session,
-                collection_id=collection_id,
-                region=grid_filter.sample_filter.embedding_region,
-            )
-        )
-    elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
-        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
-            session=session,
-            collection_id=collection_id,
-            region=grid_filter.embedding_region,
-        )
-    sample_ids_query = grid_filter.build_sample_ids_query(collection_id=collection_id)
+    sample_ids_query = build_sample_ids_query(
+        session=session, collection_id=collection_id, grid_filter=body.filter
+    )
     tag_resolver.add_samples_to_tag_from_query(
         session=session, tag_id=tag_id, sample_ids_query=sample_ids_query
     )

--- a/lightly_studio/src/lightly_studio/resolvers/grid_filter_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/grid_filter_sample_ids.py
@@ -1,0 +1,40 @@
+"""Resolve grid filters to the sample IDs they match."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+from sqlmodel.sql.expression import SelectOfScalar
+
+from lightly_studio.resolvers import embedding_region_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.grid_filter import GridFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
+
+
+def build_sample_ids_query(
+    session: Session, collection_id: UUID, grid_filter: GridFilter
+) -> SelectOfScalar[UUID]:
+    """Build a distinct sample-ID query for a grid filter and collection."""
+    # Resolve any embedding-plot region selection to concrete sample ids before building
+    # the query (the point-in-polygon test needs the session, which `apply` lacks).
+    if (
+        isinstance(grid_filter, ImageFilter)
+        and grid_filter.sample_filter is not None
+        and grid_filter.sample_filter.embedding_region is not None
+    ):
+        grid_filter.sample_filter.region_sample_ids = (
+            embedding_region_resolver.get_sample_ids_in_region(
+                session=session,
+                collection_id=collection_id,
+                region=grid_filter.sample_filter.embedding_region,
+            )
+        )
+    elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
+        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+            session=session,
+            collection_id=collection_id,
+            region=grid_filter.embedding_region,
+        )
+    return grid_filter.build_sample_ids_query(collection_id=collection_id)


### PR DESCRIPTION
## What has changed and why?

- Move the existing filter logic into one reusable helper.
- Keep the current tag-by-filter endpoint working exactly as before.

## How has it been tested?

- added new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adding samples to tags using image and annotation filters.
  * Ensured embedding-region filters consistently select the matching samples when applying filters to collections.
  * Standardized filter-based sample selection across supported filter types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->