### PR TITLE
Fix grid reload/jump to top for slow /metadata/info requests

### DIFF
--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
     import { useDimensions } from '$lib/hooks/useDimensions/useDimensions';
     import { type TextEmbedding, useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
+    import {
+        useMetadataFilters,
+        createMetadataFilters
+    } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
     import { useSettings } from '$lib/hooks/useSettings';
     import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
     import { useTags } from '$lib/hooks/useTags/useTags';
@@ -145,8 +148,10 @@
             Array.from($tagsSelected).join(','),
             `${$dimensions?.min_width}-${$dimensions?.max_width}`,
             `${$dimensions?.min_height}-${$dimensions?.max_height}`,
-            JSON.stringify($metadataValues),
-            JSON.stringify($categoricalMetadataValues),
+            // Hash the effective metadata filters, not the raw slider values, so
+            // /metadata/info seeding full-range values does not change the scroll
+            // key and yank the grid to the top.
+            JSON.stringify(createMetadataFilters($metadataValues, $categoricalMetadataValues)),
             $textEmbedding?.queryText || '',
             confusionCell ? JSON.stringify(confusionCell) : '',
             JSON.stringify($imageSortBy)

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createImagesInfiniteOptions } from './createImagesInfiniteOptions';
+import { createMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import type { ImageSortFieldExpr } from '$lib/api/lightly_studio_local';
 
 type Options = ReturnType<typeof createImagesInfiniteOptions>;
@@ -72,6 +73,43 @@ describe('createImagesInfiniteOptions', () => {
                 sort_by: null
             });
             expect(options.queryKey).toContain(null);
+        });
+
+        // Regression: /metadata/info resolving seeds every numeric field's value
+        // to its full range. That leaves the request unchanged, so the grid must
+        // not refetch.
+        it('stays stable when metadata_values expands from empty to full range', () => {
+            vi.mocked(createMetadataFilters).mockReturnValue([]);
+
+            const empty = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                metadata_values: {}
+            });
+            const fullRange = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                metadata_values: { camera_height: { min: 0.36, max: 3.76 } }
+            });
+
+            expect(fullRange.queryKey).toEqual(empty.queryKey);
+        });
+
+        it('changes when metadata filters are actually applied', () => {
+            vi.mocked(createMetadataFilters)
+                .mockReturnValueOnce([])
+                .mockReturnValueOnce([{ key: 'camera_height', value: 1, op: '>=' }]);
+
+            const unfiltered = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal'
+            });
+            const filtered = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal'
+            });
+
+            expect(filtered.queryKey).not.toEqual(unfiltered.queryKey);
         });
 
         it('produces different keys for different sort_by values', () => {

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
@@ -2,6 +2,7 @@ import type { InfiniteData } from '@tanstack/svelte-query';
 import { infiniteQueryOptions } from '@tanstack/svelte-query';
 import type { ReadImagesError, ReadImagesResponse } from '$lib/api/lightly_studio_local';
 import { readImages } from '$lib/api/lightly_studio_local';
+import { createMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { buildRequestBody } from './buildRequestBody';
 import type { ImagesInfiniteParams, SamplesQueryKey } from './types';
 
@@ -10,14 +11,24 @@ export const getImagesInfiniteQueryKeyPrefix = (collectionId: string) =>
 
 // Create infinite query options for samples with mode-aware logic.
 export const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
+    // Key on the effective metadata filters, not the raw slider state.
+    // When /metadata/info resolves it seeds every numeric field's value to its full
+    // range (min/max), which leaves the request unchanged because a full-range
+    // value emits no filter.
+    // Keying on the raw values would flip the key from `{}` to the seeded ranges
+    // and spawn a new query that re-enters loading for an identical request.
+    const metadataFilters = createMetadataFilters(
+        params.metadata_values ?? {},
+        params.categorical_metadata_values ?? {}
+    );
+
     // Build query key with intelligent structure to minimize refetches.
     const queryKey: SamplesQueryKey = [
         ...getImagesInfiniteQueryKeyPrefix(params.collection_id),
         params.mode,
         params.mode === 'normal' ? params.filters : params.classifierSamples,
         {
-            metadata_values: params.metadata_values,
-            categorical_metadata_values: params.categorical_metadata_values,
+            metadata_filters: metadataFilters,
             text_embedding: params.text_embedding,
             query_expr: params.query_expr
         },

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -1,7 +1,6 @@
 import type {
     AnnotationsFilter,
     EvaluationMetricSortExpr,
-    MetadataFilter,
     QueryExpr,
     ReadImagesRequest,
     SampleFilter,
@@ -38,7 +37,7 @@ export type SamplesQueryKey = readonly [
     ImagesInfiniteParams['mode'],
     NormalModeFilters | ClassifierSamples | undefined,
     {
-        metadata_filters?: MetadataFilter[];
+        metadata_filters?: SampleFilter['metadata_filters'];
         text_embedding?: ReadImagesRequest['text_embedding'];
         query_expr?: QueryExpr;
     },

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -1,6 +1,7 @@
 import type {
     AnnotationsFilter,
     EvaluationMetricSortExpr,
+    MetadataFilter,
     QueryExpr,
     ReadImagesRequest,
     SampleFilter,
@@ -37,8 +38,7 @@ export type SamplesQueryKey = readonly [
     ImagesInfiniteParams['mode'],
     NormalModeFilters | ClassifierSamples | undefined,
     {
-        metadata_values?: MetadataValues;
-        categorical_metadata_values?: CategoricalMetadataValues;
+        metadata_filters?: MetadataFilter[];
         text_embedding?: ReadImagesRequest['text_embedding'];
         query_expr?: QueryExpr;
     },

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -130,6 +130,8 @@
     ) {
         handleSampleSelect({ sampleId, index, shiftKey: event.shiftKey });
     }
+    // TODO(Mihnea, 09/2026): hash the effective metadata filters, not raw $filterParams.
+    // Same fix as Images.svelte's filterHash.
     const filterHash = $derived(JSON.stringify($filterParams));
     const { initialize, savePosition, getRestoredPosition } = useScrollRestoration('frames_scroll');
     onMount(async () => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -161,6 +161,8 @@
         handleSampleSelect({ sampleId, index, shiftKey: event.shiftKey });
     }
 
+    // TODO(Mihnea, 09/2026): hash the effective metadata filters, not raw $filterParams.
+    // Same fix as Images.svelte's filterHash.
     const filterHash = $derived(JSON.stringify({ filters: $filterParams, sortBy: $videoSortBy }));
     const { initialize, savePosition, getRestoredPosition } = useScrollRestoration('frames_scroll');
     onMount(async () => {


### PR DESCRIPTION
## What has changed and why?

#2187 uncovered two more issues when the metadata info API takes too long:
- grid reloads after the call finishes (during the 12s it can take it finish, you can scroll quite a lot and then you'd get back to the top)
- after fixing the previous, grid would no longer reload, but it would auto-scroll to the top 

Both issues had the same underlying root - keying off the actual metadata values instead of the effective filters (`SamplesQueryKey` and `filterHash`). The effective filter states are now used.

Note: this only covers images to improve UX for a customer. The annotations and video/frames grids were not investigated yet - left todos.

## How has it been tested?

New tests + manually (you can make the `get_metadata_info` to sleep for some seconds to easily reproduce and test the fixes)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image filtering by consistently applying the effective combination of metadata and categorical filters.
  - Prevented unnecessary image data reloads when numeric metadata values are automatically populated.
  - Ensured image data refreshes correctly when active metadata filters genuinely change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->