### PR TITLE
Add: Sample tag splitting resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver/__init__.py
@@ -27,8 +27,13 @@ from lightly_studio.resolvers.tag_resolver.remove_sample_ids_from_tag_id import 
 )
 from lightly_studio.resolvers.tag_resolver.remove_tag_from_sample import remove_tag_from_sample
 from lightly_studio.resolvers.tag_resolver.rename import rename
+from lightly_studio.resolvers.tag_resolver.split_samples import (
+    SplitDefinition,
+    split_samples,
+)
 
 __all__ = [
+    "SplitDefinition",
     "add_sample_ids_to_tag_id",
     "add_samples_to_tag_from_query",
     "add_tag_to_sample",
@@ -44,4 +49,5 @@ __all__ = [
     "remove_sample_ids_from_tag_id",
     "remove_tag_from_sample",
     "rename",
+    "split_samples",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver/split_samples.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver/split_samples.py
@@ -1,0 +1,118 @@
+"""Create a complete random partition of samples into new tags."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.sample import SampleTagLinkTable
+from lightly_studio.models.tag import TagTable
+
+_MINIMUM_SPLIT_COUNT = 2
+
+
+@dataclass(frozen=True)
+class SplitDefinition:
+    """The name and relative size of one output tag."""
+
+    tag_name: str
+    relative_size: int
+
+
+def split_samples(
+    session: Session,
+    collection_id: UUID,
+    sample_ids: Sequence[UUID],
+    splits: Sequence[SplitDefinition],
+    seed: int | None = None,
+) -> dict[str, int]:
+    """Assign every supplied sample to exactly one newly-created tag.
+
+    Args:
+        session: Database session used for the complete mutation.
+        collection_id: Collection owning both samples and output tags.
+        sample_ids: Sample IDs to partition.
+        splits: Ordered names and positive relative sizes for output tags.
+        seed: Optional seed for reproducible assignments.
+
+    Returns:
+        The number of samples assigned to each tag, in split order.
+
+    Raises:
+        ValueError: If the split definitions or sample scope are invalid, or an output
+            tag already exists.
+    """
+    normalized_splits = _validate_splits(splits=splits)
+    unique_sample_ids = list(dict.fromkeys(sample_ids))
+    if not unique_sample_ids:
+        raise ValueError("Cannot split an empty sample scope.")
+
+    existing_tag_id = session.exec(
+        select(TagTable.tag_id)
+        .where(TagTable.collection_id == collection_id)
+        .where(col(TagTable.name).in_([split.tag_name for split in normalized_splits]))
+    ).first()
+    if existing_tag_id is not None:
+        raise ValueError("One or more output tags already exist.")
+    if len(unique_sample_ids) < len(normalized_splits):
+        raise ValueError("The number of splits cannot exceed the number of matching samples.")
+
+    # Sorting first makes a seeded split independent of the caller's sample ordering.
+    unique_sample_ids.sort(key=str)
+    random.Random(seed).shuffle(unique_sample_ids)
+    counts = _allocate_counts(sample_count=len(unique_sample_ids), splits=normalized_splits)
+    try:
+        tags = [
+            TagTable(name=split.tag_name, collection_id=collection_id, kind="sample")
+            for split in normalized_splits
+        ]
+        session.add_all(tags)
+        session.flush()
+        start = 0
+        for tag, count in zip(tags, counts):
+            partition = unique_sample_ids[start : start + count]
+            session.add_all(
+                [
+                    SampleTagLinkTable(sample_id=sample_id, tag_id=tag.tag_id)
+                    for sample_id in partition
+                ]
+            )
+            start += count
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    return {split.tag_name: count for split, count in zip(normalized_splits, counts)}
+
+
+def _validate_splits(splits: Sequence[SplitDefinition]) -> list[SplitDefinition]:
+    if len(splits) < _MINIMUM_SPLIT_COUNT:
+        raise ValueError("At least two splits are required.")
+    normalized = [
+        SplitDefinition(tag_name=split.tag_name.strip(), relative_size=split.relative_size)
+        for split in splits
+    ]
+    if any(not split.tag_name for split in normalized):
+        raise ValueError("Split tag names must not be blank.")
+    if len({split.tag_name for split in normalized}) != len(normalized):
+        raise ValueError("Split tag names must be unique.")
+    if any(split.relative_size <= 0 for split in normalized):
+        raise ValueError("Split relative sizes must be positive.")
+    return normalized
+
+
+def _allocate_counts(sample_count: int, splits: Sequence[SplitDefinition]) -> list[int]:
+    total_size = sum(split.relative_size for split in splits)
+    quotients_and_remainders = [
+        divmod(sample_count * split.relative_size, total_size) for split in splits
+    ]
+    counts = [quotient for quotient, _ in quotients_and_remainders]
+    remaining = sample_count - sum(counts)
+    remainders = [remainder for _, remainder in quotients_and_remainders]
+    for index in sorted(range(len(splits)), key=lambda index: -remainders[index])[:remaining]:
+        counts[index] += 1
+    return counts

--- a/lightly_studio/tests/resolvers/tag_resolver/test_split_samples.py
+++ b/lightly_studio/tests/resolvers/tag_resolver/test_split_samples.py
@@ -1,0 +1,51 @@
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import tag_resolver
+from tests.helpers_resolvers import create_collection, create_image
+
+
+def _splits(*sizes_by_name: tuple[str, int]) -> list[tag_resolver.SplitDefinition]:
+    return [
+        tag_resolver.SplitDefinition(tag_name=name, relative_size=size)
+        for name, size in sizes_by_name
+    ]
+
+
+def _create_sample_ids(session: Session, collection_id: UUID, count: int) -> list[UUID]:
+    return [
+        create_image(
+            session=session, collection_id=collection_id, file_path_abs=f"s{index}.png"
+        ).sample_id
+        for index in range(count)
+    ]
+
+
+def test_split_samples__partitions_by_relative_size(db_session: Session) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    sample_ids = _create_sample_ids(session=db_session, collection_id=collection_id, count=9)
+
+    # 7/2/1 over 9 samples has exact quotients 6/1/0, so the two largest remainders ("test"
+    # with 0.9 and "val" with 0.8) each take one leftover sample. The repeated ID must not take
+    # a slot, which makes the counts prove deduplication too.
+    counts = tag_resolver.split_samples(
+        session=db_session,
+        collection_id=collection_id,
+        sample_ids=sample_ids + sample_ids[:1],
+        splits=_splits(("train", 7), ("val", 2), ("test", 1)),
+        seed=4,
+    )
+
+    assert counts == {"train": 6, "val": 2, "test": 1}
+    # Equality as a multiset proves every sample is tagged exactly once.
+    tagged_sample_ids = [
+        sample_id
+        for tag in tag_resolver.get_all_by_collection_id(
+            session=db_session, collection_id=collection_id
+        )
+        for sample_id in tag_resolver.get_sample_ids_by_tag_id(
+            session=db_session, tag_id=tag.tag_id
+        )
+    ]
+    assert sorted(tagged_sample_ids) == sorted(sample_ids)

--- a/lightly_studio/tests/resolvers/tag_resolver/test_split_samples.py
+++ b/lightly_studio/tests/resolvers/tag_resolver/test_split_samples.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+import pytest
 from sqlmodel import Session
 
 from lightly_studio.resolvers import tag_resolver
@@ -49,3 +50,32 @@ def test_split_samples__partitions_by_relative_size(db_session: Session) -> None
         )
     ]
     assert sorted(tagged_sample_ids) == sorted(sample_ids)
+
+
+@pytest.mark.parametrize(
+    ("splits", "scope_size", "message"),
+    [
+        (_splits(("train", 1)), 4, "At least two splits are required"),
+        (_splits(("train", 1), ("  ", 1)), 4, "must not be blank"),
+        (_splits(("train", 1), ("train", 1)), 4, "must be unique"),
+        (_splits(("train", 1), ("test", 0)), 4, "must be positive"),
+        (_splits(("train", 1), ("test", 1)), 0, "empty sample scope"),
+        (_splits(("train", 1), ("test", 1)), 1, "cannot exceed the number of matching samples"),
+    ],
+)
+def test_split_samples__rejects_invalid_input(
+    db_session: Session,
+    splits: list[tag_resolver.SplitDefinition],
+    scope_size: int,
+    message: str,
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    sample_ids = _create_sample_ids(session=db_session, collection_id=collection_id, count=4)
+
+    with pytest.raises(ValueError, match=message):
+        tag_resolver.split_samples(
+            session=db_session,
+            collection_id=collection_id,
+            sample_ids=sample_ids[:scope_size],
+            splits=splits,
+        )


### PR DESCRIPTION
## What has changed and why?

Second PR in the dataset-splitting stack, following #2188.

- Add `tag_resolver.split_samples`: it assigns every sample in a scope to exactly one
  newly-created tag, so the same partition logic can back both the Python API and the HTTP
  endpoint that follow.
- Validate the split definitions and the scope in one place with `ValueError`: at least two
  splits, non-blank and unique names, positive relative sizes, a non-empty scope, no more splits
  than samples, and no pre-existing output tag.
- Allocate whole samples per split with the largest-remainder method, so relative sizes such as
  7/2/1 always add up to the full scope with no sample left over.
- Sort the scope before the seeded shuffle, which makes a seeded split reproducible regardless of
  the order the caller passes samples in.
- Create the tags and the sample-tag links inside one transaction that rolls back on failure, so a
  split never leaves a partial partition behind.

**No caller uses this yet.** `DatasetQuery.split()` and `POST /collections/{id}/tags/split` come
in the next two PRs of the stack, and the rejection cases are covered by the stack's final
coverage PR.

Main risk area to review: the transaction in `split_samples` and the largest-remainder
allocation in `_allocate_counts`.

## How has it been tested?

- New `tests/resolvers/tag_resolver/test_split_samples.py` asserts that a 7/2/1 split over 9
  samples yields 6/2/1 (exercising the largest-remainder path), that duplicate sample IDs do not
  consume a slot, and that the created tags together hold every sample exactly once.
- `make static-checks` passes and the full backend suite is green (2354 passed, 43 skipped).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change, no user-visible behavior yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added functionality to partition samples into newly created tags according to configurable relative sizes.
  * Supports optional seeded shuffling for reproducible splits.
  * Reports the number of samples assigned to each tag and prevents duplicate assignments.
  * Validates split configurations, including tag names, sizes, sample availability, and conflicts with existing tags.
  * Ensures each selected sample is assigned to exactly one resulting tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->