### PR TITLE
Add: Dataset query split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDK: `ImageDataset.add_images_from_path` now accepts `tag_depth > 1` to tag images by several leading directory levels (previously only `tag_depth=1` was supported).
 - Python SDK (beta): Simplified embedding generator interface. Implement `embedding_space_spec`, returning the new `EmbeddingSpaceSpec` (`space_key`, `dimension`) instead of the former `get_embedding_model_input`.
 - Bump lightly-mundig to 0.1.15; its sampling algorithms are up to 7x faster.
+- Python SDK: Split a dataset into new sample tags with `DatasetQuery.split()`
 
 ### Deprecated
 

--- a/lightly_studio/docs/docs/concepts_and_tools/tags.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/tags.md
@@ -55,6 +55,28 @@ dataset.match(VideoSampleField.width > 1920).add_tag("high-res")
 
 See [Search and Filter](search_and_filter.md#query-in-python) for the full query API.
 
+### Splitting a dataset
+
+`DatasetQuery.split` creates new tags and assigns every matching image or video sample to exactly
+one of them. Tag sizes are relative weights, so this creates a 70/20/10 train, validation, and
+test split. The optional seed makes the assignment reproducible while the queried samples remain
+unchanged.
+
+```python
+counts = dataset.query().split({"train": 7, "validation": 2, "test": 1}, seed=42)
+# {"train": 700, "validation": 200, "test": 100} for a 1,000-sample dataset
+```
+
+Split a workload instead by choosing one tag for each reviewer:
+
+```python
+from lightly_studio.core.dataset_query import ImageSampleField
+
+dataset.match(ImageSampleField.width > 1920).split({"reviewer-a": 1, "reviewer-b": 1})
+```
+
+Output tag names must be new. Video-frame datasets are not yet supported.
+
 ### Tagging when loading data
 
 When working with images, the `ImageDataset` class provides convenience features to automatically

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from typing import Generic, cast
 from uuid import UUID
 
@@ -386,6 +386,33 @@ class DatasetQuery(Generic[T]):
         # Use resolver to bulk assign tag (handles validation and edge cases)
         tag_resolver.add_sample_ids_to_tag_id(
             session=self.session, tag_id=tag.tag_id, sample_ids=sample_ids
+        )
+
+    def split(self, tag_sizes: Mapping[str, int], seed: int | None = None) -> dict[str, int]:
+        """Partition the current query result into newly-created sample tags.
+
+        Args:
+            tag_sizes: Ordered tag names and their positive relative sizes.
+            seed: Optional seed for reproducible assignments.
+
+        Returns:
+            The number of samples assigned to each created tag.
+
+        Raises:
+            ValueError: If this query is not for images or videos, split definitions
+                are invalid, a tag already exists, or the query is empty.
+        """
+        if self.dataset.sample_type not in {SampleType.IMAGE, SampleType.VIDEO}:
+            raise ValueError("Splitting is only supported for image and video datasets.")
+        return tag_resolver.split_samples(
+            session=self.session,
+            collection_id=self.dataset.collection_id,
+            sample_ids=[sample.sample_id for sample in self],
+            splits=[
+                tag_resolver.SplitDefinition(tag_name=name, relative_size=size)
+                for name, size in tag_sizes.items()
+            ],
+            seed=seed,
         )
 
     def sampling(self) -> Sampling:

--- a/lightly_studio/tests/core/dataset_query/test_dataset_query_split.py
+++ b/lightly_studio/tests/core/dataset_query/test_dataset_query_split.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import tag_resolver
+from tests.helpers_resolvers import create_collection, create_image, create_tag
+
+
+def test_split__partitions_the_current_filtered_query(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    narrow = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="narrow.png",
+        width=10,
+    )
+    wide_images = [
+        create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs=f"wide-{index}.png",
+            width=100,
+        )
+        for index in range(3)
+    ]
+
+    counts = (
+        DatasetQuery(dataset=dataset, session=db_session)
+        .match(ImageSampleField.width > 50)
+        .split({"train": 2, "test": 1}, seed=7)
+    )
+
+    assert counts == {"train": 2, "test": 1}
+    tagged_sample_ids = set()
+    for tag_name in counts:
+        tag = tag_resolver.get_by_name(
+            session=db_session, tag_name=tag_name, collection_id=dataset.collection_id
+        )
+        assert tag is not None
+        tagged_sample_ids.update(
+            tag_resolver.get_sample_ids_by_tag_id(session=db_session, tag_id=tag.tag_id)
+        )
+    assert tagged_sample_ids == {image.sample_id for image in wide_images}
+    assert narrow.sample_id not in tagged_sample_ids
+
+
+@pytest.mark.parametrize(
+    "tag_sizes",
+    [
+        {"train": 1},
+        {" ": 1, "test": 1},
+        {" train ": 1, "train": 1},
+        {"train": 0, "test": 1},
+        {"train": -1, "test": 1},
+    ],
+)
+def test_split__rejects_invalid_tag_sizes(db_session: Session, tag_sizes: dict[str, int]) -> None:
+    dataset = create_collection(session=db_session)
+    create_image(session=db_session, collection_id=dataset.collection_id)
+    create_image(session=db_session, collection_id=dataset.collection_id)
+
+    with pytest.raises(ValueError, match=r"At least|must"):
+        DatasetQuery(dataset=dataset, session=db_session).split(tag_sizes=tag_sizes)
+
+
+def test_split__rejects_empty_or_too_small_query_result(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+
+    with pytest.raises(ValueError, match="empty"):
+        DatasetQuery(dataset=dataset, session=db_session).split(tag_sizes={"train": 1, "test": 1})
+
+    create_image(session=db_session, collection_id=dataset.collection_id)
+    with pytest.raises(ValueError, match="cannot exceed"):
+        DatasetQuery(dataset=dataset, session=db_session).split(
+            tag_sizes={"train": 1, "validation": 1, "test": 1}
+        )
+
+
+def test_split__rejects_existing_tag_without_creating_other_tags(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    create_image(session=db_session, collection_id=dataset.collection_id)
+    create_image(session=db_session, collection_id=dataset.collection_id)
+    create_tag(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        tag_name="train",
+    )
+
+    with pytest.raises(ValueError, match="already exist"):
+        DatasetQuery(dataset=dataset, session=db_session).split(tag_sizes={"train": 1, "test": 1})
+
+    assert (
+        tag_resolver.get_by_name(
+            session=db_session, tag_name="test", collection_id=dataset.collection_id
+        )
+        is None
+    )
+
+
+def test_split__same_seed_assigns_the_same_samples(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    for index in range(8):
+        create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs=f"s{index}.png",
+        )
+
+    # Splitting twice with the same seed must tag the same samples, so the two "train" tags
+    # hold identical sets even though the resolver shuffles the scope.
+    tagged_sample_ids = []
+    for prefix in ("first", "second"):
+        DatasetQuery(dataset=dataset, session=db_session).split(
+            {f"{prefix}-train": 1, f"{prefix}-test": 1}, seed=7
+        )
+        tag = tag_resolver.get_by_name(
+            session=db_session,
+            tag_name=f"{prefix}-train",
+            collection_id=dataset.collection_id,
+        )
+        assert tag is not None
+        tagged_sample_ids.append(
+            set(tag_resolver.get_sample_ids_by_tag_id(session=db_session, tag_id=tag.tag_id))
+        )
+
+    assert tagged_sample_ids[0] == tagged_sample_ids[1]
+
+
+def test_split__rejects_unsupported_sample_type(db_session: Session) -> None:
+    dataset = create_collection(session=db_session, sample_type=SampleType.VIDEO_FRAME)
+
+    with pytest.raises(ValueError, match="only supported for image and video"):
+        DatasetQuery(dataset=dataset, session=db_session).split(tag_sizes={"train": 1, "test": 1})


### PR DESCRIPTION
## What has changed and why?

- Add the Python API to split datasets based on queries (uses new resolved introduced in previous PR #2191)
- Adds documentation on how to use the Python API

```python
counts = dataset.query().split({"train": 7, "validation": 2, "test": 1}, seed=42)
# {"train": 700, "validation": 200, "test": 100} for a 1,000-sample dataset
```

## How has it been tested?

- New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dataset splitting through `DatasetQuery.split()`, allowing matching image or video samples to be assigned across newly created tags using relative sizes.
  - Added optional seed-based reproducibility for consistent assignments.
  - Added validation for tag names, split sizes, existing tags, unsupported datasets, and insufficient results.

- **Documentation**
  - Added usage guidance and examples for splitting full datasets or filtered query results.

- **Changelog**
  - Documented the new dataset-splitting capability under Unreleased changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->