### PR TITLE
LIG-10438: Bulk classification editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the Metadata Balancing strategy to the sampling dialog, to balance a selection over the
   values of a categorical metadata field such as weather or city.
 - Python SDK: Select images by the diversity of their annotation crop embeddings with `Sampling.subpart_diversity()`.
+- Add bulk classification editing for selected images in the GUI.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -12,7 +12,7 @@ from sqlmodel import col
 
 from lightly_studio.api.routes.api import annotations as annotations_module
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
-from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
+from lightly_studio.api.routes.api.status import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NOT_FOUND
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.annotation.annotation_base import (
@@ -243,6 +243,12 @@ class AnnotationUpdateInput(BaseModel):
     end_time_s: float | None = None
 
 
+class BulkDeleteAnnotationsInput(BaseModel):
+    """API input for bulk annotation deletion."""
+
+    annotation_ids: list[UUID]
+
+
 @annotations_router.put(
     "/annotations",
 )
@@ -310,6 +316,30 @@ def delete_annotation(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail="Annotation not found",
         ) from e
+
+
+@annotations_router.delete("/annotations")
+def bulk_delete_annotations(
+    session: SessionDep,
+    collection_id: Annotated[
+        UUID,
+        Path(title="collection Id", description="The ID of the annotation collection"),
+    ],
+    body: Annotated[BulkDeleteAnnotationsInput, Body()],
+) -> dict[str, int]:
+    """Delete annotations in the annotation collection."""
+    try:
+        deleted_count = annotation_resolver.bulk_delete_annotations(
+            session=session,
+            collection_id=collection_id,
+            annotation_ids=body.annotation_ids,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=HTTP_STATUS_BAD_REQUEST,
+            detail="Some annotations are not in the requested collection.",
+        ) from e
+    return {"deleted_count": deleted_count}
 
 
 @annotations_router.get("/annotations/payload/{sample_id}")

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotations/create_annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotations/create_annotation.py
@@ -9,12 +9,18 @@ from fastapi import APIRouter, Path
 from fastapi.params import Body
 from pydantic import BaseModel
 
+from lightly_studio.api.routes.api.status import HTTP_STATUS_CREATED
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
     AnnotationType,
     AnnotationView,
 )
+from lightly_studio.resolvers import annotation_resolver, resolve_grid_filter_embedding_region
+from lightly_studio.resolvers.annotation_resolver.bulk_create_classifications import (
+    BulkCreateClassificationsResult,
+)
+from lightly_studio.resolvers.grid_filter import GridFilter
 from lightly_studio.services import annotations_service
 from lightly_studio.services.annotations_service.create_annotation import AnnotationCreateParams
 
@@ -40,6 +46,22 @@ class AnnotationCreateInput(BaseModel):
     end_time_s: float | None = None
 
 
+class BulkCreateClassificationsInput(BaseModel):
+    """API input for bulk classification creation."""
+
+    sample_ids: list[UUID]
+    class_name: str
+    annotation_collection_name: str | None = None
+
+
+class BulkCreateClassificationsByFilterInput(BaseModel):
+    """API input for filtered bulk classification creation."""
+
+    filter: GridFilter
+    class_name: str
+    annotation_collection_name: str | None = None
+
+
 @create_annotation_router.post(
     "/annotations",
     response_model=AnnotationView,
@@ -57,4 +79,53 @@ def create_annotation(
         annotation=AnnotationCreateParams(
             collection_id=collection_id, **create_annotation_input.model_dump()
         ),
+    )
+
+
+@create_annotation_router.post(
+    "/annotations/classifications/bulk",
+    response_model=BulkCreateClassificationsResult,
+    status_code=HTTP_STATUS_CREATED,
+)
+def bulk_create_classifications(
+    collection_id: Annotated[
+        UUID, Path(title="collection Id", description="The ID of the collection")
+    ],
+    session: SessionDep,
+    body: Annotated[BulkCreateClassificationsInput, Body()],
+) -> BulkCreateClassificationsResult:
+    """Bulk-create classification annotations for selected samples."""
+    return annotation_resolver.bulk_create_classifications(
+        session=session,
+        parent_collection_id=collection_id,
+        parent_sample_ids=body.sample_ids,
+        class_name=body.class_name,
+        annotation_collection_name=body.annotation_collection_name,
+    )
+
+
+@create_annotation_router.post(
+    "/annotations/classifications/bulk_by_filter",
+    response_model=BulkCreateClassificationsResult,
+    status_code=HTTP_STATUS_CREATED,
+)
+def bulk_create_classifications_by_filter(
+    collection_id: Annotated[
+        UUID, Path(title="collection Id", description="The ID of the collection")
+    ],
+    session: SessionDep,
+    body: Annotated[BulkCreateClassificationsByFilterInput, Body()],
+) -> BulkCreateClassificationsResult:
+    """Bulk-create classification annotations for filtered samples."""
+    grid_filter = resolve_grid_filter_embedding_region.resolve_grid_filter_embedding_region(
+        session=session,
+        collection_id=collection_id,
+        grid_filter=body.filter,
+    )
+    return annotation_resolver.bulk_create_classifications_from_query(
+        session=session,
+        parent_collection_id=collection_id,
+        parent_sample_ids_query=grid_filter.build_sample_ids_query(collection_id=collection_id),
+        class_name=body.class_name,
+        annotation_collection_name=body.annotation_collection_name,
     )

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -26,10 +26,8 @@ from lightly_studio.models.tag import (
     TagTable,
     TagView,
 )
-from lightly_studio.resolvers import embedding_region_resolver, tag_resolver
-from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers import resolve_grid_filter_embedding_region, tag_resolver
 from lightly_studio.resolvers.grid_filter import GridFilter
-from lightly_studio.resolvers.image_filter import ImageFilter
 
 tag_router = APIRouter()
 
@@ -236,27 +234,11 @@ def add_samples_to_tag_by_filter(
             detail=f"Tag {tag_id} not found in collection {collection_id}.",
         )
 
-    # Resolve any embedding-plot region selection to concrete sample ids before building
-    # the query (the point-in-polygon test needs the session, which `apply` lacks).
-    grid_filter = body.filter
-    if (
-        isinstance(grid_filter, ImageFilter)
-        and grid_filter.sample_filter is not None
-        and grid_filter.sample_filter.embedding_region is not None
-    ):
-        grid_filter.sample_filter.region_sample_ids = (
-            embedding_region_resolver.get_sample_ids_in_region(
-                session=session,
-                collection_id=collection_id,
-                region=grid_filter.sample_filter.embedding_region,
-            )
-        )
-    elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
-        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
-            session=session,
-            collection_id=collection_id,
-            region=grid_filter.embedding_region,
-        )
+    grid_filter = resolve_grid_filter_embedding_region.resolve_grid_filter_embedding_region(
+        session=session,
+        collection_id=collection_id,
+        grid_filter=body.filter,
+    )
     sample_ids_query = grid_filter.build_sample_ids_query(collection_id=collection_id)
     tag_resolver.add_samples_to_tag_from_query(
         session=session, tag_id=tag_id, sample_ids_query=sample_ids_query

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -1,5 +1,13 @@
 """Resolvers for database operations."""
 
+from lightly_studio.resolvers.annotation_resolver.bulk_create_classifications import (
+    BulkCreateClassificationsResult,
+    bulk_create_classifications,
+    bulk_create_classifications_from_query,
+)
+from lightly_studio.resolvers.annotation_resolver.bulk_delete_annotations import (
+    bulk_delete_annotations,
+)
 from lightly_studio.resolvers.annotation_resolver.create_many import create_many
 from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
     delete_annotation,
@@ -64,7 +72,11 @@ from lightly_studio.resolvers.annotation_resolver.update_temporal_span import (
 __all__ = [
     "AnnotationCrop",
     "AnnotationOrdering",
+    "BulkCreateClassificationsResult",
     "build_sample_ids_query",
+    "bulk_create_classifications",
+    "bulk_create_classifications_from_query",
+    "bulk_delete_annotations",
     "create_many",
     "delete_annotation",
     "delete_annotations",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
@@ -1,0 +1,221 @@
+"""Bulk-create classification annotations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
+
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationCreate,
+    AnnotationType,
+)
+from lightly_studio.models.annotation_label import AnnotationLabelCreate
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.annotation_label_resolver import create as create_annotation_label
+from lightly_studio.resolvers.annotation_label_resolver import get_by_label_name
+from lightly_studio.resolvers.annotation_resolver import create_many
+from lightly_studio.resolvers.collection_resolver import get_by_id, get_or_create_child_collection
+from lightly_studio.resolvers.evaluation_run_resolver import mark_stale_by_collection_id
+from lightly_studio.utils import batching
+
+
+class BulkCreateClassificationsResult(BaseModel):
+    """Result of a bulk classification create operation."""
+
+    created_annotation_ids: list[UUID]
+    created_count: int
+    skipped_count: int
+
+
+def bulk_create_classifications(
+    session: Session,
+    parent_collection_id: UUID,
+    parent_sample_ids: list[UUID],
+    class_name: str,
+    annotation_collection_name: str | None = None,
+) -> BulkCreateClassificationsResult:
+    """Create classification annotations for parent samples, skipping duplicates."""
+    annotation_label_id = _get_or_create_annotation_label_id(
+        session=session,
+        parent_collection_id=parent_collection_id,
+        class_name=class_name,
+    )
+    unique_parent_sample_ids = list(dict.fromkeys(parent_sample_ids))
+    annotation_collection_id = get_or_create_child_collection(
+        session=session,
+        collection_id=parent_collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name=annotation_collection_name,
+    )
+    result = _bulk_create_classifications_for_source(
+        session=session,
+        parent_collection_id=parent_collection_id,
+        parent_sample_ids=unique_parent_sample_ids,
+        annotation_label_id=annotation_label_id,
+        annotation_collection_id=annotation_collection_id,
+        annotation_collection_name=annotation_collection_name,
+    )
+    _mark_stale_if_changed(
+        session=session,
+        annotation_collection_id=annotation_collection_id,
+        result=result,
+    )
+    return result
+
+
+def bulk_create_classifications_from_query(
+    session: Session,
+    parent_collection_id: UUID,
+    parent_sample_ids_query: SelectOfScalar[UUID],
+    class_name: str,
+    annotation_collection_name: str | None = None,
+) -> BulkCreateClassificationsResult:
+    """Create classification annotations for all parent samples returned by a query."""
+    annotation_label_id = _get_or_create_annotation_label_id(
+        session=session,
+        parent_collection_id=parent_collection_id,
+        class_name=class_name,
+    )
+    annotation_collection_id = get_or_create_child_collection(
+        session=session,
+        collection_id=parent_collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name=annotation_collection_name,
+    )
+    created_annotation_ids: list[UUID] = []
+    skipped_count = 0
+
+    for parent_sample_ids in batching.batched(session.exec(parent_sample_ids_query).all()):
+        # `create_many` commits internally, so each batch is its own transaction. This is
+        # acceptable because dedupe makes a failed run recoverable by retrying the request.
+        result = _bulk_create_classifications_for_source(
+            session=session,
+            parent_collection_id=parent_collection_id,
+            parent_sample_ids=parent_sample_ids,
+            annotation_label_id=annotation_label_id,
+            annotation_collection_id=annotation_collection_id,
+            annotation_collection_name=annotation_collection_name,
+        )
+        created_annotation_ids.extend(result.created_annotation_ids)
+        skipped_count += result.skipped_count
+
+    result = BulkCreateClassificationsResult(
+        created_annotation_ids=created_annotation_ids,
+        created_count=len(created_annotation_ids),
+        skipped_count=skipped_count,
+    )
+    _mark_stale_if_changed(
+        session=session,
+        annotation_collection_id=annotation_collection_id,
+        result=result,
+    )
+    return result
+
+
+def _bulk_create_classifications_for_source(  # noqa: PLR0913
+    session: Session,
+    parent_collection_id: UUID,
+    parent_sample_ids: list[UUID],
+    annotation_label_id: UUID,
+    annotation_collection_id: UUID,
+    annotation_collection_name: str | None,
+) -> BulkCreateClassificationsResult:
+    existing_parent_sample_ids = _get_existing_classification_parent_sample_ids(
+        session=session,
+        parent_sample_ids=parent_sample_ids,
+        annotation_label_id=annotation_label_id,
+        annotation_collection_id=annotation_collection_id,
+    )
+    annotations = [
+        AnnotationCreate(
+            annotation_label_id=annotation_label_id,
+            annotation_type=AnnotationType.CLASSIFICATION,
+            parent_sample_id=parent_sample_id,
+        )
+        for parent_sample_id in parent_sample_ids
+        if parent_sample_id not in existing_parent_sample_ids
+    ]
+    if not annotations:
+        return BulkCreateClassificationsResult(
+            created_annotation_ids=[],
+            created_count=0,
+            skipped_count=len(parent_sample_ids),
+        )
+
+    created_annotation_ids = create_many.create_many(
+        session=session,
+        parent_collection_id=parent_collection_id,
+        annotations=annotations,
+        collection_name=annotation_collection_name,
+    )
+    return BulkCreateClassificationsResult(
+        created_annotation_ids=created_annotation_ids,
+        created_count=len(created_annotation_ids),
+        skipped_count=len(parent_sample_ids) - len(created_annotation_ids),
+    )
+
+
+def _get_existing_classification_parent_sample_ids(
+    session: Session,
+    parent_sample_ids: list[UUID],
+    annotation_label_id: UUID,
+    annotation_collection_id: UUID,
+) -> set[UUID]:
+    existing_parent_sample_ids: set[UUID] = set()
+    for parent_sample_id_batch in batching.batched(parent_sample_ids):
+        existing_parent_sample_ids.update(
+            session.exec(
+                select(AnnotationBaseTable.parent_sample_id)
+                .join(SampleTable, col(AnnotationBaseTable.sample_id) == col(SampleTable.sample_id))
+                .where(col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_id_batch))
+                .where(AnnotationBaseTable.annotation_label_id == annotation_label_id)
+                .where(AnnotationBaseTable.annotation_type == AnnotationType.CLASSIFICATION)
+                .where(SampleTable.collection_id == annotation_collection_id)
+            ).all()
+        )
+    return existing_parent_sample_ids
+
+
+def _get_or_create_annotation_label_id(
+    session: Session,
+    parent_collection_id: UUID,
+    class_name: str,
+) -> UUID:
+    collection = get_by_id(session=session, collection_id=parent_collection_id)
+    if collection is None:
+        raise ValueError(f"Collection with id {parent_collection_id} not found.")
+
+    label = get_by_label_name(
+        session=session,
+        dataset_id=collection.dataset_id,
+        label_name=class_name,
+    )
+    if label is not None:
+        return label.annotation_label_id
+
+    return create_annotation_label(
+        session=session,
+        label=AnnotationLabelCreate(
+            dataset_id=collection.dataset_id,
+            annotation_label_name=class_name,
+        ),
+    ).annotation_label_id
+
+
+def _mark_stale_if_changed(
+    session: Session,
+    annotation_collection_id: UUID,
+    result: BulkCreateClassificationsResult,
+) -> None:
+    if not result.created_annotation_ids:
+        return
+
+    mark_stale_by_collection_id(
+        session=session,
+        collection_id=annotation_collection_id,
+    )

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_delete_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_delete_annotations.py
@@ -1,0 +1,132 @@
+"""Bulk-delete annotations scoped to one annotation collection."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, delete, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
+from lightly_studio.models.annotation.segmentation import SegmentationAnnotationTable
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.temporal_span import TemporalSpanTable
+from lightly_studio.resolvers.annotation_resolver.delete_annotation import delete_evaluation_metrics
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.evaluation_run_resolver import mark_stale_by_collection_id
+from lightly_studio.utils import batching
+
+
+def bulk_delete_annotations(
+    session: Session,
+    collection_id: UUID,
+    annotation_ids: list[UUID],
+) -> int:
+    """Delete annotations after validating all ids belong to the collection."""
+    unique_annotation_ids = list(dict.fromkeys(annotation_ids))
+    if not unique_annotation_ids:
+        return 0
+
+    scoped_annotation_ids = _get_scoped_annotation_ids(
+        session=session,
+        collection_id=collection_id,
+        annotation_ids=unique_annotation_ids,
+    )
+    if scoped_annotation_ids != set(unique_annotation_ids):
+        raise ValueError("Some annotations are not in the requested collection.")
+
+    parent_sample_ids = _get_parent_sample_ids(
+        session=session,
+        annotation_ids=unique_annotation_ids,
+    )
+    delete_evaluation_metrics(
+        session=session,
+        annotation_ids=unique_annotation_ids,
+        parent_sample_ids=parent_sample_ids,
+    )
+    _delete_detail_rows(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    _delete_annotation_base_rows(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    _delete_annotation_sample_children(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    _delete_annotation_samples(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    deleted_count = len(unique_annotation_ids)
+    mark_stale_by_collection_id(session=session, collection_id=collection_id)
+    return deleted_count
+
+
+def _get_scoped_annotation_ids(
+    session: Session,
+    collection_id: UUID,
+    annotation_ids: list[UUID],
+) -> set[UUID]:
+    filters = AnnotationsFilter(sample_ids=annotation_ids, collection_ids=[collection_id])
+    query = filters.build_sample_ids_query(collection_id=collection_id)
+    return set(session.exec(query).all())
+
+
+def _get_parent_sample_ids(session: Session, annotation_ids: list[UUID]) -> list[UUID]:
+    parent_sample_ids: list[UUID] = []
+    for annotation_id_batch in batching.batched(annotation_ids):
+        parent_sample_ids.extend(
+            session.exec(
+                select(AnnotationBaseTable.parent_sample_id).where(
+                    col(AnnotationBaseTable.sample_id).in_(annotation_id_batch)
+                )
+            ).all()
+        )
+    return parent_sample_ids
+
+
+def _delete_detail_rows(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(ObjectDetectionAnnotationTable).where(
+                col(ObjectDetectionAnnotationTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+        session.exec(
+            delete(SegmentationAnnotationTable).where(
+                col(SegmentationAnnotationTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+        session.exec(
+            delete(TemporalSpanTable).where(col(TemporalSpanTable.sample_id).in_(annotation_id_batch))
+        )
+
+
+def _delete_annotation_base_rows(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(AnnotationBaseTable).where(
+                col(AnnotationBaseTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+
+
+def _delete_annotation_sample_children(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(SampleTagLinkTable).where(
+                col(SampleTagLinkTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+        session.exec(
+            delete(SampleEmbeddingTable).where(
+                col(SampleEmbeddingTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+
+
+def _delete_annotation_samples(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(SampleTable).where(col(SampleTable.sample_id).in_(annotation_id_batch))
+        )

--- a/lightly_studio/src/lightly_studio/resolvers/resolve_grid_filter_embedding_region.py
+++ b/lightly_studio/src/lightly_studio/resolvers/resolve_grid_filter_embedding_region.py
@@ -1,0 +1,39 @@
+"""Resolve embedding-region predicates on grid filters."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import embedding_region_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.grid_filter import GridFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
+
+
+def resolve_grid_filter_embedding_region(
+    session: Session,
+    collection_id: UUID,
+    grid_filter: GridFilter,
+) -> GridFilter:
+    """Resolve any embedding-region selection to concrete sample ids."""
+    if (
+        isinstance(grid_filter, ImageFilter)
+        and grid_filter.sample_filter is not None
+        and grid_filter.sample_filter.embedding_region is not None
+    ):
+        grid_filter.sample_filter.region_sample_ids = (
+            embedding_region_resolver.get_sample_ids_in_region(
+                session=session,
+                collection_id=collection_id,
+                region=grid_filter.sample_filter.embedding_region,
+            )
+        )
+    elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
+        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+            session=session,
+            collection_id=collection_id,
+            region=grid_filter.embedding_region,
+        )
+    return grid_filter

--- a/lightly_studio/tests/api/routes/api/annotations/test_bulk_classifications.py
+++ b/lightly_studio/tests/api/routes/api/annotations/test_bulk_classifications.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from lightly_studio.api.routes.api.status import HTTP_STATUS_CREATED
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from tests.helpers_resolvers import ImageStub, create_collection, create_images
+
+
+def test_bulk_create_classifications_route__creates_classifications(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png")],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/annotations/classifications/bulk",
+        json={
+            "sample_ids": [str(image.sample_id) for image in images],
+            "class_name": "dog",
+            "annotation_collection_name": "ground_truth",
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert response.json()["created_count"] == 2
+    assert response.json()["skipped_count"] == 0
+    assert {
+        annotation.annotation_type
+        for annotation in db_session.exec(select(AnnotationBaseTable)).all()
+    } == {AnnotationType.CLASSIFICATION}
+
+
+def test_bulk_create_classifications_by_filter_route__skips_existing(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="wide.png", width=1920), ImageStub(path="narrow.png", width=10)],
+    )
+    url = f"/api/collections/{collection.collection_id}/annotations/classifications/bulk_by_filter"
+    body = {
+        "filter": {"filter_type": "image", "width": {"min": 100}},
+        "class_name": "dog",
+        "annotation_collection_name": "ground_truth",
+    }
+
+    first = test_client.post(url, json=body)
+    second = test_client.post(url, json=body)
+
+    assert first.status_code == HTTP_STATUS_CREATED
+    assert second.status_code == HTTP_STATUS_CREATED
+    assert first.json()["created_count"] == 1
+    assert second.json()["created_count"] == 0
+    assert second.json()["skipped_count"] == 1

--- a/lightly_studio/tests/api/routes/api/test_bulk_delete_annotations.py
+++ b/lightly_studio/tests/api/routes/api/test_bulk_delete_annotations.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from lightly_studio.api.routes.api.status import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_OK
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    ImageStub,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+    create_images,
+)
+
+
+def test_bulk_delete_annotations_route__deletes_annotations(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )
+    annotation = annotations[0]
+    annotation_id = annotation.sample_id
+    annotation_collection_id = annotation.sample.collection_id
+
+    response = test_client.request(
+        "DELETE",
+        f"/api/collections/{annotation_collection_id}/annotations",
+        json={"annotation_ids": [str(annotation_id)]},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"deleted_count": 1}
+    assert db_session.get(AnnotationBaseTable, annotation_id) is None
+    assert db_session.get(SampleTable, annotation_id) is None
+
+
+def test_bulk_delete_annotations_route__rejects_wrong_collection(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    other_source = create_collection(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        collection_name="other",
+    )
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotation = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )[0]
+
+    response = test_client.request(
+        "DELETE",
+        f"/api/collections/{other_source.collection_id}/annotations",
+        json={"annotation_ids": [str(annotation.sample_id)]},
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+    assert db_session.get(AnnotationBaseTable, annotation.sample_id) is not None

--- a/lightly_studio/tests/resolvers/annotations/test_bulk_create_classifications.py
+++ b/lightly_studio/tests/resolvers/annotations/test_bulk_create_classifications.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from sqlmodel import Session, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation_label import AnnotationLabelTable
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from lightly_studio.resolvers.image_filter import ImageFilter
+from tests.helpers_resolvers import (
+    ImageStub,
+    create_annotation,
+    create_annotation_label,
+    create_images,
+)
+
+
+def test_bulk_create_classifications__creates_classifications(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png")],
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id for image in images],
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    annotations = _get_annotations(db_session)
+    assert result.created_count == 2
+    assert result.skipped_count == 0
+    assert {annotation.sample_id for annotation in annotations} == set(
+        result.created_annotation_ids
+    )
+    assert {annotation.parent_sample_id for annotation in annotations} == {
+        image.sample_id for image in images
+    }
+    assert {annotation.annotation_type for annotation in annotations} == {
+        AnnotationType.CLASSIFICATION
+    }
+    assert all(annotation.object_detection_details is None for annotation in annotations)
+    assert all(annotation.segmentation_details is None for annotation in annotations)
+
+
+def test_bulk_create_classifications__skips_duplicate_classifications(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png")],
+    )
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[images[0].sample_id],
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[images[0].sample_id, images[1].sample_id, images[1].sample_id],
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    assert result.created_count == 1
+    assert result.skipped_count == 1
+    assert len(_get_annotations(db_session)) == 2
+
+
+def test_bulk_create_classifications__object_detection_same_class_does_not_block_classification(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="car",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_collection_name="ground_truth",
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id],
+        class_name="car",
+        annotation_collection_name="ground_truth",
+    )
+
+    annotations = _get_annotations(db_session)
+    assert result.created_count == 1
+    assert result.skipped_count == 0
+    assert {annotation.annotation_type for annotation in annotations} == {
+        AnnotationType.OBJECT_DETECTION,
+        AnnotationType.CLASSIFICATION,
+    }
+
+
+def test_bulk_create_classifications__different_class_and_source_scope_dedupe(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id],
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    other_class = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id],
+        class_name="cat",
+        annotation_collection_name="ground_truth",
+    )
+    other_source = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id],
+        class_name="dog",
+        annotation_collection_name="prediction",
+    )
+
+    assert other_class.created_count == 1
+    assert other_source.created_count == 1
+    assert len(_get_annotations(db_session)) == 3
+
+
+def test_bulk_create_classifications_from_query__matches_id_list(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[
+            ImageStub(path="wide.png", width=1920),
+            ImageStub(path="narrow.png", width=10),
+        ],
+    )
+    query = ImageFilter(width={"min": 100}).build_sample_ids_query(
+        collection_id=collection.collection_id
+    )
+
+    result = annotation_resolver.bulk_create_classifications_from_query(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=query,
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    assert result.created_count == 1
+    assert _get_annotations(db_session)[0].parent_sample_id == images[0].sample_id
+
+
+def test_bulk_create_classifications__default_source(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id],
+        class_name="dog",
+    )
+
+    annotation_collection = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    assert _get_annotations(db_session)[0].sample.collection_id == annotation_collection
+
+
+def test_bulk_create_classifications__reuses_existing_class(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids=[image.sample_id],
+        class_name="dog",
+    )
+
+    labels = list(db_session.exec(select(AnnotationLabelTable)).all())
+    assert labels == [label]
+    assert _get_annotations(db_session)[0].annotation_label_id == label.annotation_label_id
+
+
+def _get_annotations(session: Session) -> list[AnnotationBaseTable]:
+    return list(session.exec(select(AnnotationBaseTable)).all())

--- a/lightly_studio/tests/resolvers/annotations/test_bulk_delete_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_bulk_delete_annotations.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
+from lightly_studio.models.annotation.segmentation import SegmentationAnnotationTable
+from lightly_studio.models.annotation_collection_coverage import AnnotationCollectionCoverageTable
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.temporal_span import TemporalSpanTable
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    ImageStub,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+    create_embedding_model,
+    create_images,
+    create_sample_embedding,
+    create_tag,
+)
+
+
+def test_bulk_delete_annotations__deletes_all_annotation_types_and_children(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png"), ImageStub(path="c.png")],
+    )
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=images[0].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+                start_time_s=0,
+                end_time_s=1,
+            ),
+            AnnotationDetails(
+                sample_id=images[1].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+            AnnotationDetails(
+                sample_id=images[2].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                segmentation_mask=[1, 0, 1, 0],
+            ),
+        ],
+    )
+    annotation_collection_id = annotations[0].sample.collection_id
+    tag = create_tag(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        tag_name="annotation-tag",
+        kind="annotation",
+    )
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_dimension=2,
+    )
+    for annotation in annotations:
+        annotation.sample.tags.append(tag)
+        create_sample_embedding(
+            session=db_session,
+            sample_id=annotation.sample_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            embedding=[0.1, 0.2],
+        )
+    db_session.commit()
+    annotation_ids = [annotation.sample_id for annotation in annotations]
+    coverage_before = _coverage_rows(db_session)
+
+    deleted_count = annotation_resolver.bulk_delete_annotations(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        annotation_ids=annotation_ids,
+    )
+
+    assert deleted_count == 3
+    assert db_session.exec(select(AnnotationBaseTable)).all() == []
+    assert db_session.exec(select(ObjectDetectionAnnotationTable)).all() == []
+    assert db_session.exec(select(SegmentationAnnotationTable)).all() == []
+    assert db_session.exec(select(TemporalSpanTable)).all() == []
+    assert db_session.exec(select(SampleTagLinkTable)).all() == []
+    assert db_session.exec(select(SampleEmbeddingTable)).all() == []
+    assert not db_session.exec(
+        select(SampleTable).where(col(SampleTable.sample_id).in_(annotation_ids))
+    ).all()
+    assert _coverage_rows(db_session) == coverage_before
+
+
+def test_bulk_delete_annotations__rejects_out_of_collection_id_and_deletes_nothing(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    other_collection = create_collection(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        collection_name="other",
+    )
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )
+    annotation_id = annotations[0].sample_id
+
+    with pytest.raises(ValueError, match="requested collection"):
+        annotation_resolver.bulk_delete_annotations(
+            session=db_session,
+            collection_id=other_collection.collection_id,
+            annotation_ids=[annotation_id],
+        )
+
+    assert db_session.get(AnnotationBaseTable, annotation_id) is not None
+    assert db_session.get(SampleTable, annotation_id) is not None
+
+
+def test_bulk_delete_annotations__dedupes_and_allows_empty_list(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )
+    annotation_id = annotations[0].sample_id
+
+    assert annotation_resolver.bulk_delete_annotations(
+        session=db_session,
+        collection_id=annotations[0].sample.collection_id,
+        annotation_ids=[],
+    ) == 0
+    assert annotation_resolver.bulk_delete_annotations(
+        session=db_session,
+        collection_id=annotations[0].sample.collection_id,
+        annotation_ids=[annotation_id, annotation_id],
+    ) == 1
+
+
+def test_bulk_delete_annotations__rejects_unknown_id(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    with pytest.raises(ValueError, match="requested collection"):
+        annotation_resolver.bulk_delete_annotations(
+            session=db_session,
+            collection_id=annotation_collection_id,
+            annotation_ids=[uuid4()],
+        )
+
+
+def _coverage_rows(session: Session) -> set[tuple[UUID, UUID]]:
+    return {
+        (row.annotation_collection_id, row.parent_sample_id)
+        for row in session.exec(select(AnnotationCollectionCoverageTable)).all()
+    }

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -15,6 +15,7 @@
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
     import { addAnnotationLabelChangeToUndoStack } from '$lib/services/addAnnotationLabelChangeToUndoStack';
     import { useUpdateAnnotationsMutation } from '$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
+    import { useBulkDeleteAnnotations } from '$lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations';
     import type { AnnotationWithPayloadView } from '$lib/api/lightly_studio_local';
     import useAuth from '$lib/hooks/useAuth/useAuth';
     import { hasMinimumRole } from '$lib/hooks/useAuth/hasMinimumRole';
@@ -147,6 +148,9 @@
         toggleSampleAnnotationCropSelection,
         clearSelectedSampleAnnotationCrops
     } = useGlobalStorage();
+    const selectedAnnotationIds = $derived(
+        $pickedAnnotationIds[collection_id] ?? new Set<string>()
+    );
 
     const annotations: AnnotationWithPayloadView[] = $derived(
         infiniteAnnotations.data?.pages.flatMap((page) => page.data) ?? []
@@ -186,7 +190,7 @@
     const selectedAnnotations = $derived(
         annotations
             .map((annotation) => annotation.annotation)
-            .filter((annotation) => $pickedAnnotationIds[collection_id]?.has(annotation.sample_id))
+            .filter((annotation) => selectedAnnotationIds.has(annotation.sample_id))
     );
 
     const handleSelectLabel = async (item: { value: string; label: string }) => {
@@ -199,13 +203,33 @@
         });
 
         await updateAnnotations(
-            selectedAnnotations.map((annotation) => ({
-                annotation_id: annotation.sample_id,
+            [...selectedAnnotationIds].map((annotationId) => ({
+                annotation_id: annotationId,
                 label_name: item.value,
                 collection_id: collection_id
             }))
         );
         clearSelectedSampleAnnotationCrops(collection_id);
+    };
+
+    const { deleteAnnotations } = useBulkDeleteAnnotations();
+    let isDeletingSelectedAnnotations = $state(false);
+
+    const handleDeleteSelectedAnnotations = async () => {
+        if (selectedAnnotationIds.size === 0 || isDeletingSelectedAnnotations) return;
+        isDeletingSelectedAnnotations = true;
+        try {
+            const result = await deleteAnnotations({
+                collectionId: collection_id,
+                annotationIds: [...selectedAnnotationIds]
+            });
+            if (!result.staleSelection) {
+                clearSelectedSampleAnnotationCrops(collection_id);
+                refresh();
+            }
+        } finally {
+            isDeletingSelectedAnnotations = false;
+        }
     };
 
     const scrollResetKey = $derived(infiniteLoaderIdentifier);
@@ -285,10 +309,11 @@
     {#if $isEditingMode && !hideSelectedAnnotationsPanel}
         <div class="min-w-[250px] max-w-[30%] flex-1">
             <SelectedAnnotations
-                {selectedAnnotations}
-                disabled={selectedAnnotations.length === 0}
-                isLoading={$isPending}
+                selectedCount={selectedAnnotationIds.size}
+                disabled={selectedAnnotationIds.size === 0}
+                isLoading={$isPending || isDeletingSelectedAnnotations}
                 onSelect={handleSelectLabel}
+                onDelete={handleDeleteSelectedAnnotations}
                 collectionId={collection_id}
             />
         </div>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import { Trash2 } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import * as Popover from '$lib/components/ui/popover';
+
+    type Props = {
+        selectedCount: number;
+        disabled?: boolean;
+        isLoading?: boolean;
+        onDelete: () => Promise<void> | void;
+    };
+
+    let { selectedCount, disabled = false, isLoading = false, onDelete }: Props = $props();
+    let open = $state(false);
+
+    const handleDelete = async (event: MouseEvent) => {
+        event.stopPropagation();
+        await onDelete();
+        open = false;
+    };
+</script>
+
+<Popover.Root bind:open>
+    <Popover.Trigger>
+        {#snippet child({ props })}
+            <Button
+                variant="destructive"
+                buttonProps={{
+                    ...props,
+                    disabled: disabled || isLoading || selectedCount === 0,
+                    class: 'w-full',
+                    'data-testid': 'bulk-delete-annotations-trigger'
+                }}
+                icon={Trash2}
+            >
+                Delete
+            </Button>
+        {/snippet}
+    </Popover.Trigger>
+    <Popover.Content class="w-72 text-sm">
+        Delete {selectedCount}
+        {selectedCount === 1 ? 'annotation' : 'annotations'}. This cannot be undone.
+        <div class="mt-3 flex justify-end gap-2">
+            <Button
+                variant="outline"
+                buttonProps={{
+                    size: 'sm',
+                    disabled: isLoading,
+                    onclick: (event: MouseEvent) => {
+                        event.stopPropagation();
+                        open = false;
+                    }
+                }}
+            >
+                Cancel
+            </Button>
+            <Button
+                variant="destructive"
+                buttonProps={{
+                    size: 'sm',
+                    disabled: isLoading,
+                    'data-testid': 'bulk-delete-annotations-confirm',
+                    onclick: handleDelete
+                }}
+            >
+                Delete
+            </Button>
+        </div>
+    </Popover.Content>
+</Popover.Root>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
@@ -2,20 +2,22 @@
     import { Card, CardContent } from '$lib/components';
     import { Segment } from '$lib/components';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
-    import type { AnnotationView } from '$lib/api/lightly_studio_local';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
+    import BulkDeleteAnnotationsButton from './BulkDeleteAnnotationsButton.svelte';
 
     type Props = {
-        selectedAnnotations: Array<AnnotationView>;
+        selectedCount: number;
         onSelect: (item: { value: string; label: string }) => void;
         disabled?: boolean;
         isLoading?: boolean;
         collectionId: string;
+        onDelete: () => Promise<void> | void;
     };
 
-    const { selectedAnnotations, onSelect, disabled, isLoading, collectionId }: Props = $props();
+    const { selectedCount, onSelect, disabled, isLoading, collectionId, onDelete }: Props =
+        $props();
 
     const result = useAnnotationLabels(() => ({ collectionId }));
 
@@ -27,7 +29,7 @@
         <div
             class="flex h-full min-h-0 flex-col space-y-4 overflow-hidden dark:[color-scheme:dark]"
         >
-            <Segment title={`Selected annotations: ${selectedAnnotations.length}`}>
+            <Segment title={`Selected annotations: ${selectedCount}`}>
                 <div class="flex flex-col space-y-4">
                     <div class="text-md mb-2">
                         You can edit annotation classes for multiple annotations at once.
@@ -45,6 +47,12 @@
                             <LabelNotFound label={inputValue} />
                         {/snippet}
                     </SelectList>
+                    <BulkDeleteAnnotationsButton
+                        {selectedCount}
+                        {disabled}
+                        {isLoading}
+                        {onDelete}
+                    />
                 </div>
             </Segment>
         </div>

--- a/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanel.stories.svelte
+++ b/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanel.stories.svelte
@@ -1,0 +1,23 @@
+<script module lang="ts">
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import BulkClassificationPanel from './BulkClassificationPanel.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/BulkClassificationPanel',
+        component: BulkClassificationPanel
+    });
+</script>
+
+<Story
+    name="Default"
+    args={{
+        selectedCount: 10,
+        sourceName: 'ground_truth',
+        className: 'dog',
+        sourceNames: ['ground_truth', 'prediction'],
+        classNames: ['cat', 'dog'],
+        onSourceSelect: () => undefined,
+        onClassSelect: () => undefined,
+        onApply: () => undefined
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanel.svelte
+++ b/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanel.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    import { Info } from '@lucide/svelte';
+    import { Button } from '$lib/components/ui/button';
+    import * as Alert from '$lib/components/ui/alert';
+    import * as Dialog from '$lib/components/ui/dialog';
+    import CreateableNamePicker from './CreateableNamePicker.svelte';
+
+    type Props = {
+        selectedCount: number;
+        sourceName?: string;
+        className?: string;
+        sourceNames: string[];
+        classNames: string[];
+        isApplying?: boolean;
+        onSourceSelect: (name: string) => void;
+        onClassSelect: (name: string) => void;
+        onApply: () => Promise<void> | void;
+    };
+
+    let {
+        selectedCount,
+        sourceName,
+        className,
+        sourceNames,
+        classNames,
+        isApplying = false,
+        onSourceSelect,
+        onClassSelect,
+        onApply
+    }: Props = $props();
+
+    let confirmOpen = $state(false);
+    const canApply = $derived(Boolean(sourceName && className) && !isApplying);
+    const heading = $derived(
+        `${selectedCount} ${selectedCount === 1 ? 'image' : 'images'} selected`
+    );
+
+    async function handleConfirm() {
+        await onApply();
+        confirmOpen = false;
+    }
+</script>
+
+<div class="h-full overflow-hidden border-l bg-background p-3 dark:[color-scheme:dark]">
+    <div class="flex h-full min-h-0 w-[260px] flex-col gap-4 overflow-hidden">
+        <h2 class="text-sm font-semibold">{heading}</h2>
+        <CreateableNamePicker
+            label="Source"
+            placeholder="Select a source"
+            selectedName={sourceName}
+            names={sourceNames}
+            disabled={isApplying}
+            onSelect={onSourceSelect}
+        />
+        <CreateableNamePicker
+            label="Class"
+            placeholder="Select a class"
+            selectedName={className}
+            names={classNames}
+            disabled={isApplying}
+            onSelect={onClassSelect}
+        />
+        <Dialog.Root bind:open={confirmOpen}>
+            <Dialog.Trigger>
+                {#snippet child({ props })}
+                    <Button {...props} class="w-full" disabled={!canApply}>Add class</Button>
+                {/snippet}
+            </Dialog.Trigger>
+            <Dialog.Content class="max-w-sm">
+                <Dialog.Header>
+                    <Dialog.Title>Add class</Dialog.Title>
+                    <Dialog.Description>
+                        Add <strong>{className}</strong> to {selectedCount}
+                        {selectedCount === 1 ? ' image ' : ' images '} in
+                        <strong>{sourceName}</strong>. This cannot be undone.
+                    </Dialog.Description>
+                </Dialog.Header>
+                <Dialog.Footer>
+                    <Dialog.Close>
+                        {#snippet child({ props })}
+                            <Button {...props} variant="outline" disabled={isApplying}>
+                                Cancel
+                            </Button>
+                        {/snippet}
+                    </Dialog.Close>
+                    <Button disabled={isApplying} onclick={handleConfirm}>Add class</Button>
+                </Dialog.Footer>
+            </Dialog.Content>
+        </Dialog.Root>
+        <Alert.Root class="bg-muted/50 py-3 text-xs">
+            <Info class="size-3.5" />
+            <Alert.Description>
+                Change or remove annotations in the annotation view.
+            </Alert.Description>
+        </Alert.Root>
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanel.test.ts
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import BulkClassificationPanel from './BulkClassificationPanel.svelte';
+
+const defaultProps = {
+    selectedCount: 10,
+    sourceName: 'ground_truth',
+    className: 'dog',
+    sourceNames: ['ground_truth'],
+    classNames: ['dog'],
+    onSourceSelect: vi.fn(),
+    onClassSelect: vi.fn(),
+    onApply: vi.fn()
+};
+
+describe('BulkClassificationPanel', () => {
+    it('renders the approved panel copy', () => {
+        render(BulkClassificationPanel, { props: defaultProps });
+
+        expect(screen.getByText('10 images selected')).toBeInTheDocument();
+        expect(screen.getByText('Source')).toBeInTheDocument();
+        expect(screen.getByText('Class')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Add class' })).toBeInTheDocument();
+        expect(
+            screen.getByText('Change or remove annotations in the annotation view.')
+        ).toBeInTheDocument();
+    });
+
+    it('confirms before applying', async () => {
+        const onApply = vi.fn();
+        render(BulkClassificationPanel, { props: { ...defaultProps, onApply } });
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Add class' }));
+
+        expect(onApply).not.toHaveBeenCalled();
+        expect(screen.getByRole('heading', { name: 'Add class' })).toBeInTheDocument();
+        expect(screen.getAllByText('dog')).toHaveLength(2);
+        expect(screen.getAllByText('ground_truth')).toHaveLength(2);
+
+        await fireEvent.click(screen.getAllByRole('button', { name: 'Add class' }).at(-1)!);
+
+        expect(onApply).toHaveBeenCalledOnce();
+    });
+
+    it('disables applying while in flight', () => {
+        render(BulkClassificationPanel, { props: { ...defaultProps, isApplying: true } });
+
+        expect(screen.getByRole('button', { name: 'Add class' })).toBeDisabled();
+    });
+});

--- a/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanelContainer.svelte
+++ b/lightly_studio_view/src/lib/components/BulkClassificationPanel/BulkClassificationPanelContainer.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    import { get } from 'svelte/store';
+    import { page } from '$app/state';
+    import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
+    import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
+    import { useBulkCreateClassifications } from '$lib/hooks/useBulkCreateClassifications/useBulkCreateClassifications';
+    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import BulkClassificationPanel from './BulkClassificationPanel.svelte';
+
+    type Props = {
+        collectionId: string;
+    };
+
+    let { collectionId }: Props = $props();
+
+    const DEFAULT_SOURCE_NAME = 'annotation';
+    const rootCollectionId = $derived(page.params.dataset_id!);
+    const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
+    const annotationLabelsQuery = useAnnotationLabels(() => ({ collectionId }));
+    const { addClass } = useBulkCreateClassifications();
+    const {
+        getSelectedSampleIds,
+        getSelectAllSnapshot,
+        isEditingMode,
+        lastAnnotationSource,
+        updateLastAnnotationSource,
+        clearSelectedSamples
+    } = useGlobalStorage();
+    const selectedSampleIds = $derived(getSelectedSampleIds(collectionId));
+    const selectAllSnapshot = $derived(get(getSelectAllSnapshot(collectionId)));
+    const sourceNames = $derived(
+        annotationCollectionsQuery.data?.map((source) => source.name) ?? []
+    );
+    const classNames = $derived(
+        annotationLabelsQuery.data?.map((label) => label.annotation_label_name) ?? []
+    );
+
+    let sourceName = $state<string>();
+    let className = $state<string>();
+    let isApplying = $state(false);
+
+    const effectiveSourceName = $derived(
+        sourceName ??
+            $lastAnnotationSource[collectionId] ??
+            sourceNames.find((name) => name === DEFAULT_SOURCE_NAME) ??
+            sourceNames[0] ??
+            DEFAULT_SOURCE_NAME
+    );
+
+    const sourceOptions = $derived([...new Set([...sourceNames, effectiveSourceName])]);
+    const classOptions = $derived([...new Set([...classNames, ...(className ? [className] : [])])]);
+
+    $effect(() => {
+        if (sourceName === undefined) {
+            sourceName = effectiveSourceName;
+        }
+    });
+
+    const handleSourceSelect = (name: string) => {
+        sourceName = name;
+        updateLastAnnotationSource(collectionId, name);
+    };
+
+    const handleApply = async () => {
+        if (!className || !sourceName || isApplying || $selectedSampleIds.size === 0) return;
+        isApplying = true;
+        try {
+            await addClass({
+                collectionId,
+                selectedIds: $selectedSampleIds,
+                className,
+                sourceName,
+                selectAllSnapshot,
+                rootCollectionId
+            });
+            clearSelectedSamples(collectionId);
+        } finally {
+            isApplying = false;
+        }
+    };
+</script>
+
+{#if $isEditingMode && $selectedSampleIds.size > 0}
+    <BulkClassificationPanel
+        selectedCount={$selectedSampleIds.size}
+        {sourceName}
+        {className}
+        sourceNames={sourceOptions}
+        classNames={classOptions}
+        {isApplying}
+        onSourceSelect={handleSourceSelect}
+        onClassSelect={(name) => {
+            className = name;
+        }}
+        onApply={handleApply}
+    />
+{/if}

--- a/lightly_studio_view/src/lib/components/BulkClassificationPanel/CreateableNamePicker.svelte
+++ b/lightly_studio_view/src/lib/components/BulkClassificationPanel/CreateableNamePicker.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import SelectList from '$lib/components/SelectList/SelectList.svelte';
+    import type { ListItem } from '$lib/components/SelectList/types';
+
+    type Props = {
+        label: string;
+        placeholder: string;
+        selectedName?: string;
+        names: string[];
+        disabled?: boolean;
+        onSelect: (name: string) => void;
+    };
+
+    let { label, placeholder, selectedName, names, disabled = false, onSelect }: Props = $props();
+
+    const items = $derived(names.map((name) => ({ value: name, label: name })));
+    const selectedItem = $derived(
+        selectedName ? { value: selectedName, label: selectedName } : undefined
+    );
+
+    const handleSelect = (item: ListItem) => {
+        onSelect(item.value);
+    };
+</script>
+
+<div class="space-y-1.5">
+    <div class="text-xs font-medium text-muted-foreground">{label}</div>
+    <SelectList
+        {items}
+        {selectedItem}
+        name={label}
+        label={placeholder}
+        placeholder="Search or create…"
+        className="w-full"
+        contentClassName="w-[var(--bits-popover-anchor-width)]"
+        onSelect={handleSelect}
+        onKeyboardConfirm={handleSelect}
+        {disabled}
+    />
+</div>

--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -25,6 +25,7 @@
     import { selectRangeByAnchor } from '$lib/utils/selectRangeByAnchor';
     import { page } from '$app/state';
     import SampleImageGridItem from '../SampleImageGridItem/SampleImageGridItem.svelte';
+    import BulkClassificationPanelContainer from '../BulkClassificationPanel/BulkClassificationPanelContainer.svelte';
 
     // Import the settings hook
     const { gridViewSampleRenderingStore, showSampleFilenamesStore } = useSettings();
@@ -229,78 +230,87 @@
     const scrollResetKey = $derived(filterHash + ($textEmbedding?.queryText ?? ''));
 </script>
 
-<GridContainer
-    message={{
-        loading: 'Loading images...',
-        error: 'Error loading images',
-        empty: {
-            title: 'No images found',
-            description: "This collection doesn't contain any images."
-        }
-    }}
-    status={{
-        loading: infiniteSamples.isPending,
-        error: infiniteSamples.isError,
-        empty: infiniteSamples.isSuccess && samples.length === 0,
-        success: isReady
-    }}
-    loader={{
-        loadMore: handleLoadMore,
-        disabled: !infiniteSamples.hasNextPage || infiniteSamples.isFetchingNextPage,
-        loading: infiniteSamples.isFetchingNextPage
-    }}
-    itemCount={samples.length}
->
-    {#snippet children({ footer })}
-        <Grid
+<div class="flex h-full min-w-0 flex-1">
+    <div class="min-w-0 flex-1">
+        <GridContainer
+            message={{
+                loading: 'Loading images...',
+                error: 'Error loading images',
+                empty: {
+                    title: 'No images found',
+                    description: "This collection doesn't contain any images."
+                }
+            }}
+            status={{
+                loading: infiniteSamples.isPending,
+                error: infiniteSamples.isError,
+                empty: infiniteSamples.isSuccess && samples.length === 0,
+                success: isReady
+            }}
+            loader={{
+                loadMore: handleLoadMore,
+                disabled: !infiniteSamples.hasNextPage || infiniteSamples.isFetchingNextPage,
+                loading: infiniteSamples.isFetchingNextPage
+            }}
             itemCount={samples.length}
-            {columnCount}
-            overScan={sampleGridOverscan}
-            onScroll={handleScroll}
-            {initialScrollPosition}
-            {scrollResetKey}
-            gridProps={{ 'data-testid': 'images-grid', class: 'dark:[color-scheme:dark]' }}
         >
-            {#snippet gridItem({ index, style, width, height })}
-                {#if samples[index]}
-                    {#key samples[index].sample_id}
-                        {@const displayTextOnImage = $showSampleFilenamesStore
-                            ? samples[index].file_name
-                            : samples[index].captions?.[0]?.text}
-                        <GridItem
-                            {width}
-                            {height}
-                            {style}
-                            dataSampleName={samples[index].file_name}
-                            dataIndex={index}
-                            dataTestId="sample-grid-item"
-                            isSelected={$selectedSampleIds.has(samples[index].sample_id)}
-                            ariaLabel={`View image: ${samples[index].file_name}`}
-                            dragData={{
-                                url: getGridImageURL({
-                                    sampleId: samples[index].sample_id,
-                                    quality: 'raw'
-                                }),
-                                fileName: samples[index].file_name
-                            }}
-                            ondblclick={() => handleOnDoubleClick(samples[index].sample_id)}
-                            onSelect={(event) =>
-                                handleGridItemSelect(event, samples[index].sample_id, index)}
-                        >
-                            <SampleImageGridItem
-                                sample={samples[index]}
-                                {objectFit}
-                                tileWidth={width}
-                                tileHeight={height}
-                                {displayTextOnImage}
-                            />
-                        </GridItem>
-                    {/key}
-                {/if}
+            {#snippet children({ footer })}
+                <Grid
+                    itemCount={samples.length}
+                    {columnCount}
+                    overScan={sampleGridOverscan}
+                    onScroll={handleScroll}
+                    {initialScrollPosition}
+                    {scrollResetKey}
+                    gridProps={{ 'data-testid': 'images-grid', class: 'dark:[color-scheme:dark]' }}
+                >
+                    {#snippet gridItem({ index, style, width, height })}
+                        {#if samples[index]}
+                            {#key samples[index].sample_id}
+                                {@const displayTextOnImage = $showSampleFilenamesStore
+                                    ? samples[index].file_name
+                                    : samples[index].captions?.[0]?.text}
+                                <GridItem
+                                    {width}
+                                    {height}
+                                    {style}
+                                    dataSampleName={samples[index].file_name}
+                                    dataIndex={index}
+                                    dataTestId="sample-grid-item"
+                                    isSelected={$selectedSampleIds.has(samples[index].sample_id)}
+                                    ariaLabel={`View image: ${samples[index].file_name}`}
+                                    dragData={{
+                                        url: getGridImageURL({
+                                            sampleId: samples[index].sample_id,
+                                            quality: 'raw'
+                                        }),
+                                        fileName: samples[index].file_name
+                                    }}
+                                    ondblclick={() => handleOnDoubleClick(samples[index].sample_id)}
+                                    onSelect={(event) =>
+                                        handleGridItemSelect(
+                                            event,
+                                            samples[index].sample_id,
+                                            index
+                                        )}
+                                >
+                                    <SampleImageGridItem
+                                        sample={samples[index]}
+                                        {objectFit}
+                                        tileWidth={width}
+                                        tileHeight={height}
+                                        {displayTextOnImage}
+                                    />
+                                </GridItem>
+                            {/key}
+                        {/if}
+                    {/snippet}
+                    {#snippet footerItem()}
+                        {@render footer()}
+                    {/snippet}
+                </Grid>
             {/snippet}
-            {#snippet footerItem()}
-                {@render footer()}
-            {/snippet}
-        </Grid>
-    {/snippet}
-</GridContainer>
+        </GridContainer>
+    </div>
+    <BulkClassificationPanelContainer collectionId={collection_id} />
+</div>

--- a/lightly_studio_view/src/lib/hooks/useBulkCreateClassifications/useBulkCreateClassifications.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useBulkCreateClassifications/useBulkCreateClassifications.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { formatBulkCreateToast, shouldBulkCreateByFilter } from './useBulkCreateClassifications';
+
+const filter = { filter_type: 'image' as const };
+
+describe('shouldBulkCreateByFilter', () => {
+    it('uses the filter route only for an intact select-all snapshot', () => {
+        expect(
+            shouldBulkCreateByFilter({
+                selectAllSnapshot: { filter, size: 2 },
+                selectedIds: new Set(['a', 'b'])
+            })
+        ).toBe(true);
+
+        expect(
+            shouldBulkCreateByFilter({
+                selectAllSnapshot: { filter, size: 3 },
+                selectedIds: new Set(['a', 'b'])
+            })
+        ).toBe(false);
+
+        expect(
+            shouldBulkCreateByFilter({
+                selectAllSnapshot: null,
+                selectedIds: new Set(['a', 'b'])
+            })
+        ).toBe(false);
+    });
+});
+
+describe('formatBulkCreateToast', () => {
+    it('formats created and skipped outcomes', () => {
+        expect(
+            formatBulkCreateToast(
+                { created_annotation_ids: ['a'], created_count: 40, skipped_count: 0 },
+                40
+            )
+        ).toBe('Added the class to 40 images.');
+        expect(
+            formatBulkCreateToast(
+                { created_annotation_ids: ['a'], created_count: 28, skipped_count: 12 },
+                40
+            )
+        ).toBe('Added to 28 of 40 images; 12 already had this class.');
+        expect(
+            formatBulkCreateToast(
+                { created_annotation_ids: [], created_count: 0, skipped_count: 5 },
+                5
+            )
+        ).toBe('No images changed; all 5 already had this class.');
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useBulkCreateClassifications/useBulkCreateClassifications.ts
+++ b/lightly_studio_view/src/lib/hooks/useBulkCreateClassifications/useBulkCreateClassifications.ts
@@ -1,0 +1,123 @@
+import type {
+    BulkCreateClassificationsResult,
+    TagByFilterBody
+} from '$lib/api/lightly_studio_local';
+import {
+    bulkCreateClassifications,
+    bulkCreateClassificationsByFilter
+} from '$lib/api/lightly_studio_local';
+import {
+    readAnnotationCollectionsQueryKey,
+    readAnnotationLabelsQueryKey,
+    readCollectionHierarchyQueryKey
+} from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { useInvalidateAnnotationGridQueries } from '$lib/hooks/useInvalidateAnnotationGridQueries';
+import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
+import { useInvalidateEvaluationRunsQueries } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
+import { usePostHog } from '$lib/hooks';
+import { useQueryClient } from '@tanstack/svelte-query';
+import { toast } from 'svelte-sonner';
+
+type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
+
+type BulkCreateClassificationsInput = {
+    collectionId: string;
+    selectedIds: Set<string>;
+    className: string;
+    sourceName: string;
+    selectAllSnapshot: SelectAllSnapshot | null;
+    rootCollectionId: string;
+};
+
+export const useBulkCreateClassifications = () => {
+    const client = useQueryClient();
+    const invalidateAnnotationGridQueries = useInvalidateAnnotationGridQueries();
+    const invalidateEvaluationRunsQueries = useInvalidateEvaluationRunsQueries();
+    const { trackEvent } = usePostHog();
+
+    const invalidate = (collectionId: string, rootCollectionId: string) => {
+        invalidateAnnotationGridQueries(collectionId);
+        client.invalidateQueries({ queryKey: useImageAnnotationCountsQueryKey });
+        client.invalidateQueries({
+            queryKey: readAnnotationCollectionsQueryKey({ path: { collection_id: collectionId } })
+        });
+        client.invalidateQueries({
+            queryKey: readAnnotationLabelsQueryKey({ path: { collection_id: collectionId } })
+        });
+        client.invalidateQueries({
+            queryKey: readCollectionHierarchyQueryKey({ path: { collection_id: rootCollectionId } })
+        });
+        invalidateEvaluationRunsQueries();
+    };
+
+    const addClass = async ({
+        collectionId,
+        selectedIds,
+        className,
+        sourceName,
+        selectAllSnapshot,
+        rootCollectionId
+    }: BulkCreateClassificationsInput): Promise<BulkCreateClassificationsResult> => {
+        const selectedCount = selectedIds.size;
+        const isUnmodifiedSelectAll = shouldBulkCreateByFilter({
+            selectAllSnapshot,
+            selectedIds
+        });
+        const response =
+            isUnmodifiedSelectAll && selectAllSnapshot
+                ? await bulkCreateClassificationsByFilter({
+                      path: { collection_id: collectionId },
+                      body: {
+                          filter: selectAllSnapshot.filter,
+                          class_name: className,
+                          annotation_collection_name: sourceName
+                      }
+                  })
+                : await bulkCreateClassifications({
+                      path: { collection_id: collectionId },
+                      body: {
+                          sample_ids: [...selectedIds],
+                          class_name: className,
+                          annotation_collection_name: sourceName
+                      }
+                  });
+
+        if (response.error || !response.data) {
+            toast.error('Failed to add the class. Please try again.');
+            throw response.error ?? new Error('Failed to add the class.');
+        }
+
+        invalidate(collectionId, rootCollectionId);
+        trackEvent('annotations_bulk_labeled', {
+            collection_id: collectionId,
+            selected_count: selectedCount,
+            created_count: response.data.created_count,
+            skipped_count: response.data.skipped_count
+        });
+        toast.success(formatBulkCreateToast(response.data, selectedCount));
+        return response.data;
+    };
+
+    return { addClass };
+};
+
+export const formatBulkCreateToast = (
+    result: BulkCreateClassificationsResult,
+    selectedCount: number
+) => {
+    if (result.created_count === 0) {
+        return `No images changed; all ${selectedCount} already had this class.`;
+    }
+    if (result.skipped_count > 0) {
+        return `Added to ${result.created_count} of ${selectedCount} images; ${result.skipped_count} already had this class.`;
+    }
+    return `Added the class to ${result.created_count} images.`;
+};
+
+export const shouldBulkCreateByFilter = ({
+    selectAllSnapshot,
+    selectedIds
+}: {
+    selectAllSnapshot: SelectAllSnapshot | null;
+    selectedIds: Set<string>;
+}) => selectAllSnapshot != null && selectAllSnapshot.size === selectedIds.size;

--- a/lightly_studio_view/src/lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations.ts
@@ -1,0 +1,48 @@
+import { bulkDeleteAnnotations } from '$lib/api/lightly_studio_local';
+import { useInvalidateAnnotationGridQueries } from '$lib/hooks/useInvalidateAnnotationGridQueries';
+import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
+import { useInvalidateEvaluationRunsQueries } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
+import { usePostHog } from '$lib/hooks';
+import { useQueryClient } from '@tanstack/svelte-query';
+import { toast } from 'svelte-sonner';
+
+export const useBulkDeleteAnnotations = () => {
+    const client = useQueryClient();
+    const invalidateAnnotationGridQueries = useInvalidateAnnotationGridQueries();
+    const invalidateEvaluationRunsQueries = useInvalidateEvaluationRunsQueries();
+    const { trackEvent } = usePostHog();
+
+    const deleteAnnotations = async ({
+        collectionId,
+        annotationIds
+    }: {
+        collectionId: string;
+        annotationIds: string[];
+    }) => {
+        if (annotationIds.length === 0) return { deletedCount: 0, staleSelection: false };
+
+        const response = await bulkDeleteAnnotations({
+            path: { collection_id: collectionId },
+            body: { annotation_ids: annotationIds }
+        });
+        if (response.error) {
+            if (response.response.status === 400) {
+                toast.error('Some selected annotations no longer belong to this source.');
+                return { deletedCount: 0, staleSelection: true };
+            }
+            toast.error('Failed to delete annotations. Please try again.');
+            throw response.error;
+        }
+
+        invalidateAnnotationGridQueries(collectionId);
+        client.invalidateQueries({ queryKey: useImageAnnotationCountsQueryKey });
+        invalidateEvaluationRunsQueries();
+        trackEvent('annotations_bulk_deleted', {
+            collection_id: collectionId,
+            annotation_count: annotationIds.length
+        });
+        return { deletedCount: response.data.deleted_count, staleSelection: false };
+    };
+
+    return { deleteAnnotations };
+};


### PR DESCRIPTION
## What has changed and why?

Adds bulk classification editing for selected image-grid samples and bulk annotation deletion for annotation-grid selections.

- Adds resolver-backed API routes for bulk-adding classification annotations by selected IDs or by grid filter, including class/source creation, classification-only dedupe, skip counts, and embedding-region filter resolution.
- Adds scoped bulk annotation deletion for annotation source routes, including detail rows, metrics, tag links, embeddings, and annotation sample cleanup while preserving coverage rows.
- Adds the image-grid selection panel with source/class pickers, confirmation, toasts, analytics, and select-all filter dispatch; adds annotation-grid bulk delete confirmation.
- Keeps the GUI path at route + resolver level, without introducing a new service layer.
- This PR is larger than the preferred PR size because the user-visible flow spans API contract, resolver semantics, grid selection dispatch, and UI wiring. Generated frontend client files are intentionally not committed.

Suggested reviewer: Horatiu Almasan based on recent ownership of the touched grid/API files. Alternative: Leonardo Rosa.

Screenshot: TODO before marking ready for review.

## How has it been tested?

- `cd lightly_studio && ./.venv/bin/pytest tests/resolvers/annotations/test_bulk_create_classifications.py tests/resolvers/annotations/test_bulk_delete_annotations.py tests/api/routes/api/annotations/test_bulk_classifications.py tests/api/routes/api/test_bulk_delete_annotations.py -q`
- `cd lightly_studio && ./.venv/bin/ruff check src/lightly_studio tests/resolvers/annotations/test_bulk_create_classifications.py tests/resolvers/annotations/test_bulk_delete_annotations.py tests/api/routes/api/annotations/test_bulk_classifications.py tests/api/routes/api/test_bulk_delete_annotations.py`
- `cd lightly_studio && ./.venv/bin/mypy src/lightly_studio`
- `cd lightly_studio_view && npm run lint` (passes; existing warning in `coverage/block-navigation.js`)
- `cd lightly_studio_view && npm run check`
- `cd lightly_studio_view && npx vitest run src/lib/components/BulkClassificationPanel/BulkClassificationPanel.test.ts src/lib/hooks/useBulkCreateClassifications/useBulkCreateClassifications.test.ts`

Note: `uv run ...` / `make ...` are blocked locally because this checkout pins `uv ==0.12.6` and PATH has `0.12.7`; backend checks above were run through the existing virtualenv.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
