### PR TITLE
Add bulk annotation deletion API

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -12,7 +12,7 @@ from sqlmodel import col
 
 from lightly_studio.api.routes.api import annotations as annotations_module
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
-from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
+from lightly_studio.api.routes.api.status import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NOT_FOUND
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.annotation.annotation_base import (
@@ -243,6 +243,12 @@ class AnnotationUpdateInput(BaseModel):
     end_time_s: float | None = None
 
 
+class BulkDeleteAnnotationsInput(BaseModel):
+    """API input for bulk annotation deletion."""
+
+    annotation_ids: list[UUID]
+
+
 @annotations_router.put(
     "/annotations",
 )
@@ -310,6 +316,30 @@ def delete_annotation(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail="Annotation not found",
         ) from e
+
+
+@annotations_router.delete("/annotations")
+def bulk_delete_annotations(
+    session: SessionDep,
+    collection_id: Annotated[
+        UUID,
+        Path(title="collection Id", description="The ID of the annotation collection"),
+    ],
+    body: Annotated[BulkDeleteAnnotationsInput, Body()],
+) -> dict[str, int]:
+    """Delete annotations in the annotation collection."""
+    try:
+        deleted_count = annotation_resolver.bulk_delete_annotations(
+            session=session,
+            collection_id=collection_id,
+            annotation_ids=body.annotation_ids,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=HTTP_STATUS_BAD_REQUEST,
+            detail="Some annotations are not in the requested collection.",
+        ) from e
+    return {"deleted_count": deleted_count}
 
 
 @annotations_router.get("/annotations/payload/{sample_id}")

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -1,5 +1,8 @@
 """Resolvers for database operations."""
 
+from lightly_studio.resolvers.annotation_resolver.bulk_delete_annotations import (
+    bulk_delete_annotations,
+)
 from lightly_studio.resolvers.annotation_resolver.create_many import create_many
 from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
     delete_annotation,
@@ -65,6 +68,7 @@ __all__ = [
     "AnnotationCrop",
     "AnnotationOrdering",
     "build_sample_ids_query",
+    "bulk_delete_annotations",
     "create_many",
     "delete_annotation",
     "delete_annotations",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_delete_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_delete_annotations.py
@@ -1,0 +1,132 @@
+"""Bulk-delete annotations scoped to one annotation collection."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, delete, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
+from lightly_studio.models.annotation.segmentation import SegmentationAnnotationTable
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.temporal_span import TemporalSpanTable
+from lightly_studio.resolvers.annotation_resolver.delete_annotation import delete_evaluation_metrics
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.evaluation_run_resolver import mark_stale_by_collection_id
+from lightly_studio.utils import batching
+
+
+def bulk_delete_annotations(
+    session: Session,
+    collection_id: UUID,
+    annotation_ids: list[UUID],
+) -> int:
+    """Delete annotations after validating all ids belong to the collection."""
+    unique_annotation_ids = list(dict.fromkeys(annotation_ids))
+    if not unique_annotation_ids:
+        return 0
+
+    scoped_annotation_ids = _get_scoped_annotation_ids(
+        session=session,
+        collection_id=collection_id,
+        annotation_ids=unique_annotation_ids,
+    )
+    if scoped_annotation_ids != set(unique_annotation_ids):
+        raise ValueError("Some annotations are not in the requested collection.")
+
+    parent_sample_ids = _get_parent_sample_ids(
+        session=session,
+        annotation_ids=unique_annotation_ids,
+    )
+    delete_evaluation_metrics(
+        session=session,
+        annotation_ids=unique_annotation_ids,
+        parent_sample_ids=parent_sample_ids,
+    )
+    _delete_detail_rows(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    _delete_annotation_base_rows(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    _delete_annotation_sample_children(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    _delete_annotation_samples(session=session, annotation_ids=unique_annotation_ids)
+    session.commit()
+
+    deleted_count = len(unique_annotation_ids)
+    mark_stale_by_collection_id(session=session, collection_id=collection_id)
+    return deleted_count
+
+
+def _get_scoped_annotation_ids(
+    session: Session,
+    collection_id: UUID,
+    annotation_ids: list[UUID],
+) -> set[UUID]:
+    filters = AnnotationsFilter(sample_ids=annotation_ids, collection_ids=[collection_id])
+    query = filters.build_sample_ids_query(collection_id=collection_id)
+    return set(session.exec(query).all())
+
+
+def _get_parent_sample_ids(session: Session, annotation_ids: list[UUID]) -> list[UUID]:
+    parent_sample_ids: list[UUID] = []
+    for annotation_id_batch in batching.batched(annotation_ids):
+        parent_sample_ids.extend(
+            session.exec(
+                select(AnnotationBaseTable.parent_sample_id).where(
+                    col(AnnotationBaseTable.sample_id).in_(annotation_id_batch)
+                )
+            ).all()
+        )
+    return parent_sample_ids
+
+
+def _delete_detail_rows(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(ObjectDetectionAnnotationTable).where(
+                col(ObjectDetectionAnnotationTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+        session.exec(
+            delete(SegmentationAnnotationTable).where(
+                col(SegmentationAnnotationTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+        session.exec(
+            delete(TemporalSpanTable).where(col(TemporalSpanTable.sample_id).in_(annotation_id_batch))
+        )
+
+
+def _delete_annotation_base_rows(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(AnnotationBaseTable).where(
+                col(AnnotationBaseTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+
+
+def _delete_annotation_sample_children(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(SampleTagLinkTable).where(
+                col(SampleTagLinkTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+        session.exec(
+            delete(SampleEmbeddingTable).where(
+                col(SampleEmbeddingTable.sample_id).in_(annotation_id_batch)
+            )
+        )
+
+
+def _delete_annotation_samples(session: Session, annotation_ids: list[UUID]) -> None:
+    for annotation_id_batch in batching.batched(annotation_ids):
+        session.exec(
+            delete(SampleTable).where(col(SampleTable.sample_id).in_(annotation_id_batch))
+        )

--- a/lightly_studio/tests/api/routes/api/test_bulk_delete_annotations.py
+++ b/lightly_studio/tests/api/routes/api/test_bulk_delete_annotations.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from lightly_studio.api.routes.api.status import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_OK
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    ImageStub,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+    create_images,
+)
+
+
+def test_bulk_delete_annotations_route__deletes_annotations(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )
+    annotation = annotations[0]
+    annotation_id = annotation.sample_id
+    annotation_collection_id = annotation.sample.collection_id
+
+    response = test_client.request(
+        "DELETE",
+        f"/api/collections/{annotation_collection_id}/annotations",
+        json={"annotation_ids": [str(annotation_id)]},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"deleted_count": 1}
+    assert db_session.get(AnnotationBaseTable, annotation_id) is None
+    assert db_session.get(SampleTable, annotation_id) is None
+
+
+def test_bulk_delete_annotations_route__rejects_wrong_collection(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    other_source = create_collection(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        collection_name="other",
+    )
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotation = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )[0]
+
+    response = test_client.request(
+        "DELETE",
+        f"/api/collections/{other_source.collection_id}/annotations",
+        json={"annotation_ids": [str(annotation.sample_id)]},
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+    assert db_session.get(AnnotationBaseTable, annotation.sample_id) is not None

--- a/lightly_studio/tests/resolvers/annotations/test_bulk_delete_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_bulk_delete_annotations.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
+from lightly_studio.models.annotation.segmentation import SegmentationAnnotationTable
+from lightly_studio.models.annotation_collection_coverage import AnnotationCollectionCoverageTable
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.temporal_span import TemporalSpanTable
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    ImageStub,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+    create_embedding_model,
+    create_images,
+    create_sample_embedding,
+    create_tag,
+)
+
+
+def test_bulk_delete_annotations__deletes_all_annotation_types_and_children(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png"), ImageStub(path="c.png")],
+    )
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=images[0].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+                start_time_s=0,
+                end_time_s=1,
+            ),
+            AnnotationDetails(
+                sample_id=images[1].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+            AnnotationDetails(
+                sample_id=images[2].sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                segmentation_mask=[1, 0, 1, 0],
+            ),
+        ],
+    )
+    annotation_collection_id = annotations[0].sample.collection_id
+    tag = create_tag(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        tag_name="annotation-tag",
+        kind="annotation",
+    )
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_dimension=2,
+    )
+    for annotation in annotations:
+        annotation.sample.tags.append(tag)
+        create_sample_embedding(
+            session=db_session,
+            sample_id=annotation.sample_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            embedding=[0.1, 0.2],
+        )
+    db_session.commit()
+    annotation_ids = [annotation.sample_id for annotation in annotations]
+    coverage_before = _coverage_rows(db_session)
+
+    deleted_count = annotation_resolver.bulk_delete_annotations(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        annotation_ids=annotation_ids,
+    )
+
+    assert deleted_count == 3
+    assert db_session.exec(select(AnnotationBaseTable)).all() == []
+    assert db_session.exec(select(ObjectDetectionAnnotationTable)).all() == []
+    assert db_session.exec(select(SegmentationAnnotationTable)).all() == []
+    assert db_session.exec(select(TemporalSpanTable)).all() == []
+    assert db_session.exec(select(SampleTagLinkTable)).all() == []
+    assert db_session.exec(select(SampleEmbeddingTable)).all() == []
+    assert not db_session.exec(
+        select(SampleTable).where(col(SampleTable.sample_id).in_(annotation_ids))
+    ).all()
+    assert _coverage_rows(db_session) == coverage_before
+
+
+def test_bulk_delete_annotations__rejects_out_of_collection_id_and_deletes_nothing(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    other_collection = create_collection(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        collection_name="other",
+    )
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )
+    annotation_id = annotations[0].sample_id
+
+    with pytest.raises(ValueError, match="requested collection"):
+        annotation_resolver.bulk_delete_annotations(
+            session=db_session,
+            collection_id=other_collection.collection_id,
+            annotation_ids=[annotation_id],
+        )
+
+    assert db_session.get(AnnotationBaseTable, annotation_id) is not None
+    assert db_session.get(SampleTable, annotation_id) is not None
+
+
+def test_bulk_delete_annotations__dedupes_and_allows_empty_list(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        collection_name="ground_truth",
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+        ],
+    )
+    annotation_id = annotations[0].sample_id
+
+    assert annotation_resolver.bulk_delete_annotations(
+        session=db_session,
+        collection_id=annotations[0].sample.collection_id,
+        annotation_ids=[],
+    ) == 0
+    assert annotation_resolver.bulk_delete_annotations(
+        session=db_session,
+        collection_id=annotations[0].sample.collection_id,
+        annotation_ids=[annotation_id, annotation_id],
+    ) == 1
+
+
+def test_bulk_delete_annotations__rejects_unknown_id(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    with pytest.raises(ValueError, match="requested collection"):
+        annotation_resolver.bulk_delete_annotations(
+            session=db_session,
+            collection_id=annotation_collection_id,
+            annotation_ids=[uuid4()],
+        )
+
+
+def _coverage_rows(session: Session) -> set[tuple[UUID, UUID]]:
+    return {
+        (row.annotation_collection_id, row.parent_sample_id)
+        for row in session.exec(select(AnnotationCollectionCoverageTable)).all()
+    }


### PR DESCRIPTION
## What has changed and why?

- Adds a backend route for bulk deleting annotations from one annotation source.
- Adds a resolver that validates all requested annotation IDs belong to the requested source before deleting anything.
- Keeps the change backend-only; the annotation-grid UI is in the stacked frontend PR.

Stack: #2198 -> #2199

## How has it been tested?

```bash
cd lightly_studio
./.venv/bin/pytest tests/resolvers/annotations/test_bulk_delete_annotations.py tests/api/routes/api/test_bulk_delete_annotations.py -q
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
