### PR TITLE
Add annotation grid bulk deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the Metadata Balancing strategy to the sampling dialog, to balance a selection over the
   values of a categorical metadata field such as weather or city.
 - Python SDK: Select images by the diversity of their annotation crop embeddings with `Sampling.subpart_diversity()`.
+- Add bulk deletion for selected annotations in the GUI.
 
 ### Changed
 

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -15,6 +15,7 @@
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
     import { addAnnotationLabelChangeToUndoStack } from '$lib/services/addAnnotationLabelChangeToUndoStack';
     import { useUpdateAnnotationsMutation } from '$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
+    import { useBulkDeleteAnnotations } from '$lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations';
     import type { AnnotationWithPayloadView } from '$lib/api/lightly_studio_local';
     import useAuth from '$lib/hooks/useAuth/useAuth';
     import { hasMinimumRole } from '$lib/hooks/useAuth/hasMinimumRole';
@@ -147,6 +148,9 @@
         toggleSampleAnnotationCropSelection,
         clearSelectedSampleAnnotationCrops
     } = useGlobalStorage();
+    const selectedAnnotationIds = $derived(
+        $pickedAnnotationIds[collection_id] ?? new Set<string>()
+    );
 
     const annotations: AnnotationWithPayloadView[] = $derived(
         infiniteAnnotations.data?.pages.flatMap((page) => page.data) ?? []
@@ -186,7 +190,7 @@
     const selectedAnnotations = $derived(
         annotations
             .map((annotation) => annotation.annotation)
-            .filter((annotation) => $pickedAnnotationIds[collection_id]?.has(annotation.sample_id))
+            .filter((annotation) => selectedAnnotationIds.has(annotation.sample_id))
     );
 
     const handleSelectLabel = async (item: { value: string; label: string }) => {
@@ -199,13 +203,33 @@
         });
 
         await updateAnnotations(
-            selectedAnnotations.map((annotation) => ({
-                annotation_id: annotation.sample_id,
+            [...selectedAnnotationIds].map((annotationId) => ({
+                annotation_id: annotationId,
                 label_name: item.value,
                 collection_id: collection_id
             }))
         );
         clearSelectedSampleAnnotationCrops(collection_id);
+    };
+
+    const { deleteAnnotations } = useBulkDeleteAnnotations();
+    let isDeletingSelectedAnnotations = $state(false);
+
+    const handleDeleteSelectedAnnotations = async () => {
+        if (selectedAnnotationIds.size === 0 || isDeletingSelectedAnnotations) return;
+        isDeletingSelectedAnnotations = true;
+        try {
+            const result = await deleteAnnotations({
+                collectionId: collection_id,
+                annotationIds: [...selectedAnnotationIds]
+            });
+            if (!result.staleSelection) {
+                clearSelectedSampleAnnotationCrops(collection_id);
+                refresh();
+            }
+        } finally {
+            isDeletingSelectedAnnotations = false;
+        }
     };
 
     const scrollResetKey = $derived(infiniteLoaderIdentifier);
@@ -285,10 +309,11 @@
     {#if $isEditingMode && !hideSelectedAnnotationsPanel}
         <div class="min-w-[250px] max-w-[30%] flex-1">
             <SelectedAnnotations
-                {selectedAnnotations}
-                disabled={selectedAnnotations.length === 0}
-                isLoading={$isPending}
+                selectedCount={selectedAnnotationIds.size}
+                disabled={selectedAnnotationIds.size === 0}
+                isLoading={$isPending || isDeletingSelectedAnnotations}
                 onSelect={handleSelectLabel}
+                onDelete={handleDeleteSelectedAnnotations}
                 collectionId={collection_id}
             />
         </div>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
     sortedAnnotationsData: [] as AnnotationWithPayloadView[],
     updateAnnotations: vi.fn(),
     updateAnnotationsRaw: vi.fn(),
+    deleteAnnotations: vi.fn(),
     refresh: vi.fn(),
     isPendingStore: null as unknown as Writable<boolean>,
     pickedAnnotationIds: null as unknown as Writable<Record<string, Set<string>>>,
@@ -156,6 +157,12 @@ vi.mock('$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation', 
     }))
 }));
 
+vi.mock('$lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations', () => ({
+    useBulkDeleteAnnotations: vi.fn(() => ({
+        deleteAnnotations: mocks.deleteAnnotations
+    }))
+}));
+
 vi.mock('$lib/hooks/useScrollRestoration/useScrollRestoration', () => ({
     useScrollRestoration: vi.fn(() => ({
         initialize: vi.fn(),
@@ -245,6 +252,7 @@ describe('AnnotationsGrid', () => {
         vi.clearAllMocks();
         mocks.annotationsData = [];
         mocks.sortedAnnotationsData = [];
+        mocks.deleteAnnotations.mockResolvedValue({ deletedCount: 0, staleSelection: false });
         mocks.getCollectionVersion.mockResolvedValue('v1');
         mocks.pickedAnnotationIds.set({});
         mocks.isEditingModeStore.set(false);
@@ -340,5 +348,22 @@ describe('AnnotationsGrid', () => {
                 groupId: 'annotation-label-change'
             })
         );
+    });
+
+    it('deletes selected annotations and refreshes the grid', async () => {
+        mocks.annotationsData = [buildClassificationAnnotation('cls-1')];
+        mocks.pickedAnnotationIds.set({ 'col-1': new Set(['cls-1']) });
+        mocks.isEditingModeStore.set(true);
+
+        renderGrid();
+
+        await fireEvent.click(screen.getByTestId('mock-delete-annotations'));
+
+        expect(mocks.deleteAnnotations).toHaveBeenCalledWith({
+            collectionId: 'col-1',
+            annotationIds: ['cls-1']
+        });
+        expect(mocks.clearSelectedSampleAnnotationCrops).toHaveBeenCalledWith('col-1');
+        expect(mocks.refresh).toHaveBeenCalledOnce();
     });
 });

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import { Trash2 } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import * as Popover from '$lib/components/ui/popover';
+
+    type Props = {
+        selectedCount: number;
+        disabled?: boolean;
+        isLoading?: boolean;
+        onDelete: () => Promise<void> | void;
+    };
+
+    let { selectedCount, disabled = false, isLoading = false, onDelete }: Props = $props();
+    let open = $state(false);
+
+    const handleDelete = async (event: MouseEvent) => {
+        event.stopPropagation();
+        await onDelete();
+        open = false;
+    };
+</script>
+
+<Popover.Root bind:open>
+    <Popover.Trigger>
+        {#snippet child({ props })}
+            <Button
+                variant="destructive"
+                buttonProps={{
+                    ...props,
+                    disabled: disabled || isLoading || selectedCount === 0,
+                    class: 'w-full',
+                    'data-testid': 'bulk-delete-annotations-trigger'
+                }}
+                icon={Trash2}
+            >
+                Delete
+            </Button>
+        {/snippet}
+    </Popover.Trigger>
+    <Popover.Content class="w-72 text-sm">
+        Delete {selectedCount}
+        {selectedCount === 1 ? 'annotation' : 'annotations'}. This cannot be undone.
+        <div class="mt-3 flex justify-end gap-2">
+            <Button
+                variant="outline"
+                buttonProps={{
+                    size: 'sm',
+                    disabled: isLoading,
+                    onclick: (event: MouseEvent) => {
+                        event.stopPropagation();
+                        open = false;
+                    }
+                }}
+            >
+                Cancel
+            </Button>
+            <Button
+                variant="destructive"
+                buttonProps={{
+                    size: 'sm',
+                    disabled: isLoading,
+                    'data-testid': 'bulk-delete-annotations-confirm',
+                    onclick: handleDelete
+                }}
+            >
+                Delete
+            </Button>
+        </div>
+    </Popover.Content>
+</Popover.Root>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.test.ts
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import BulkDeleteAnnotationsButton from './BulkDeleteAnnotationsButton.svelte';
+
+const defaultProps = {
+    selectedCount: 3,
+    disabled: false,
+    isLoading: false,
+    onDelete: vi.fn()
+};
+
+describe('BulkDeleteAnnotationsButton', () => {
+    it('confirms before deleting selected annotations', async () => {
+        const onDelete = vi.fn();
+        render(BulkDeleteAnnotationsButton, { props: { ...defaultProps, onDelete } });
+
+        await fireEvent.click(screen.getByTestId('bulk-delete-annotations-trigger'));
+
+        expect(onDelete).not.toHaveBeenCalled();
+        expect(screen.getByText(/Delete 3 annotations/)).toBeInTheDocument();
+
+        await fireEvent.click(screen.getByTestId('bulk-delete-annotations-confirm'));
+
+        expect(onDelete).toHaveBeenCalledOnce();
+    });
+
+    it('disables deletion when there is no selected annotation', () => {
+        render(BulkDeleteAnnotationsButton, {
+            props: { ...defaultProps, selectedCount: 0 }
+        });
+
+        expect(screen.getByTestId('bulk-delete-annotations-trigger')).toBeDisabled();
+    });
+});

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.mock.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.mock.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-    import type { AnnotationView } from '$lib/api/lightly_studio_local';
-
     interface Props {
-        selectedAnnotations: AnnotationView[];
+        selectedCount: number;
         disabled: boolean;
         isLoading: boolean;
         collectionId: string;
         onSelect: (item: { value: string; label: string }) => void;
+        onDelete: () => Promise<void> | void;
     }
 
-    let { onSelect }: Props = $props();
+    let { selectedCount, onSelect, onDelete }: Props = $props();
 </script>
 
 <button
@@ -17,4 +16,7 @@
     onclick={() => onSelect({ value: 'new-label', label: 'New Label' })}
 >
     Select Label
+</button>
+<button data-testid="mock-delete-annotations" onclick={onDelete}>
+    Delete {selectedCount}
 </button>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
@@ -2,20 +2,22 @@
     import { Card, CardContent } from '$lib/components';
     import { Segment } from '$lib/components';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
-    import type { AnnotationView } from '$lib/api/lightly_studio_local';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
+    import BulkDeleteAnnotationsButton from './BulkDeleteAnnotationsButton.svelte';
 
     type Props = {
-        selectedAnnotations: Array<AnnotationView>;
+        selectedCount: number;
         onSelect: (item: { value: string; label: string }) => void;
         disabled?: boolean;
         isLoading?: boolean;
         collectionId: string;
+        onDelete: () => Promise<void> | void;
     };
 
-    const { selectedAnnotations, onSelect, disabled, isLoading, collectionId }: Props = $props();
+    const { selectedCount, onSelect, disabled, isLoading, collectionId, onDelete }: Props =
+        $props();
 
     const result = useAnnotationLabels(() => ({ collectionId }));
 
@@ -27,7 +29,7 @@
         <div
             class="flex h-full min-h-0 flex-col space-y-4 overflow-hidden dark:[color-scheme:dark]"
         >
-            <Segment title={`Selected annotations: ${selectedAnnotations.length}`}>
+            <Segment title={`Selected annotations: ${selectedCount}`}>
                 <div class="flex flex-col space-y-4">
                     <div class="text-md mb-2">
                         You can edit annotation classes for multiple annotations at once.
@@ -45,6 +47,12 @@
                             <LabelNotFound label={inputValue} />
                         {/snippet}
                     </SelectList>
+                    <BulkDeleteAnnotationsButton
+                        {selectedCount}
+                        {disabled}
+                        {isLoading}
+                        {onDelete}
+                    />
                 </div>
             </Segment>
         </div>

--- a/lightly_studio_view/src/lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useBulkDeleteAnnotations/useBulkDeleteAnnotations.ts
@@ -1,0 +1,48 @@
+import { bulkDeleteAnnotations } from '$lib/api/lightly_studio_local';
+import { useInvalidateAnnotationGridQueries } from '$lib/hooks/useInvalidateAnnotationGridQueries';
+import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
+import { useInvalidateEvaluationRunsQueries } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
+import { usePostHog } from '$lib/hooks';
+import { useQueryClient } from '@tanstack/svelte-query';
+import { toast } from 'svelte-sonner';
+
+export const useBulkDeleteAnnotations = () => {
+    const client = useQueryClient();
+    const invalidateAnnotationGridQueries = useInvalidateAnnotationGridQueries();
+    const invalidateEvaluationRunsQueries = useInvalidateEvaluationRunsQueries();
+    const { trackEvent } = usePostHog();
+
+    const deleteAnnotations = async ({
+        collectionId,
+        annotationIds
+    }: {
+        collectionId: string;
+        annotationIds: string[];
+    }) => {
+        if (annotationIds.length === 0) return { deletedCount: 0, staleSelection: false };
+
+        const response = await bulkDeleteAnnotations({
+            path: { collection_id: collectionId },
+            body: { annotation_ids: annotationIds }
+        });
+        if (response.error) {
+            if (response.response.status === 400) {
+                toast.error('Some selected annotations no longer belong to this source.');
+                return { deletedCount: 0, staleSelection: true };
+            }
+            toast.error('Failed to delete annotations. Please try again.');
+            throw response.error;
+        }
+
+        invalidateAnnotationGridQueries(collectionId);
+        client.invalidateQueries({ queryKey: useImageAnnotationCountsQueryKey });
+        invalidateEvaluationRunsQueries();
+        trackEvent('annotations_bulk_deleted', {
+            collection_id: collectionId,
+            annotation_count: annotationIds.length
+        });
+        return { deletedCount: response.data.deleted_count, staleSelection: false };
+    };
+
+    return { deleteAnnotations };
+};


### PR DESCRIPTION
## What has changed and why?

- Adds annotation-grid UI for deleting selected annotations in bulk.
- Wires the UI through a bulk-delete hook and refreshes/clears selection after a successful delete.
- Adds focused frontend coverage for the delete confirmation button and grid handoff.

Depends on #2198.

## How has it been tested?

```bash
cd lightly_studio_view
npx vitest run src/lib/components/AnnotationsGrid/SelectedAnnotations/BulkDeleteAnnotationsButton.test.ts src/lib/components/AnnotationsGrid/AnnotationsGrid.test.ts
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
