### PR TITLE
Add bulk classification annotation resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -1,5 +1,9 @@
 """Resolvers for database operations."""
 
+from lightly_studio.resolvers.annotation_resolver.bulk_create_classifications import (
+    BulkCreateClassificationsResult,
+    bulk_create_classifications,
+)
 from lightly_studio.resolvers.annotation_resolver.create_many import create_many
 from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
     delete_annotation,
@@ -64,7 +68,9 @@ from lightly_studio.resolvers.annotation_resolver.update_temporal_span import (
 __all__ = [
     "AnnotationCrop",
     "AnnotationOrdering",
+    "BulkCreateClassificationsResult",
     "build_sample_ids_query",
+    "bulk_create_classifications",
     "create_many",
     "delete_annotation",
     "delete_annotations",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -69,11 +70,11 @@ def bulk_create_classifications(
     )
     created_annotation_ids: list[UUID] = []
     skipped_count = 0
-    streamed_parent_sample_ids_query = parent_sample_ids_query.execution_options(
-        yield_per=batching.DEFAULT_BATCH_SIZE
-    )
 
-    for parent_sample_ids in batching.batched(session.exec(streamed_parent_sample_ids_query)):
+    for parent_sample_ids in _iter_parent_sample_id_pages(
+        session=session,
+        parent_sample_ids_query=parent_sample_ids_query,
+    ):
         result = _bulk_create_classifications_for_source(
             session=session,
             parent_sample_ids=parent_sample_ids,
@@ -93,6 +94,42 @@ def bulk_create_classifications(
         result=result,
     )
     return result
+
+
+def _iter_parent_sample_id_pages(
+    session: Session,
+    parent_sample_ids_query: SelectOfScalar[UUID],
+) -> Iterator[list[UUID]]:
+    """Yield the sample ids matched by the query in pages of bounded size.
+
+    Every page is read with its own statement, so that writes between two pages cannot
+    interfere with an open cursor. Pages are keyset-based: the next page starts after the
+    last id of the previous one, which stays correct even when the writes change which
+    samples the query matches.
+
+    Args:
+        session: SQLAlchemy session for database operations.
+        parent_sample_ids_query: Query selecting the parent sample ids to page through.
+
+    Yields:
+        Pages of sample ids, ordered by sample id.
+    """
+    last_parent_sample_id: UUID | None = None
+    while True:
+        page_query = select(SampleTable.sample_id).where(
+            col(SampleTable.sample_id).in_(parent_sample_ids_query)
+        )
+        if last_parent_sample_id is not None:
+            page_query = page_query.where(col(SampleTable.sample_id) > last_parent_sample_id)
+        parent_sample_ids = list(
+            session.exec(
+                page_query.order_by(col(SampleTable.sample_id)).limit(batching.DEFAULT_BATCH_SIZE)
+            ).all()
+        )
+        if not parent_sample_ids:
+            return
+        yield parent_sample_ids
+        last_parent_sample_id = parent_sample_ids[-1]
 
 
 def _bulk_create_classifications_for_source(

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
@@ -73,6 +73,7 @@ def bulk_create_classifications(
 
     for parent_sample_ids in _iter_parent_sample_id_pages(
         session=session,
+        parent_collection_id=parent_collection_id,
         parent_sample_ids_query=parent_sample_ids_query,
     ):
         result = _bulk_create_classifications_for_source(
@@ -98,9 +99,13 @@ def bulk_create_classifications(
 
 def _iter_parent_sample_id_pages(
     session: Session,
+    parent_collection_id: UUID,
     parent_sample_ids_query: SelectOfScalar[UUID],
 ) -> Iterator[list[UUID]]:
     """Yield the sample ids matched by the query in pages of bounded size.
+
+    Only samples that belong to the parent collection are yielded, so that a query
+    reaching beyond it cannot create annotations under a foreign parent sample.
 
     Every page is read with its own statement, so that writes between two pages cannot
     interfere with an open cursor. Pages are keyset-based: the next page starts after the
@@ -109,6 +114,7 @@ def _iter_parent_sample_id_pages(
 
     Args:
         session: SQLAlchemy session for database operations.
+        parent_collection_id: Collection the parent samples must belong to.
         parent_sample_ids_query: Query selecting the parent sample ids to page through.
 
     Yields:
@@ -116,8 +122,10 @@ def _iter_parent_sample_id_pages(
     """
     last_parent_sample_id: UUID | None = None
     while True:
-        page_query = select(SampleTable.sample_id).where(
-            col(SampleTable.sample_id).in_(parent_sample_ids_query)
+        page_query = (
+            select(SampleTable.sample_id)
+            .where(col(SampleTable.sample_id).in_(parent_sample_ids_query))
+            .where(SampleTable.collection_id == parent_collection_id)
         )
         if last_parent_sample_id is not None:
             page_query = page_query.where(col(SampleTable.sample_id) > last_parent_sample_id)

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/bulk_create_classifications.py
@@ -1,0 +1,196 @@
+"""Bulk-create classification annotations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
+
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationCreate,
+    AnnotationType,
+)
+from lightly_studio.models.annotation_label import AnnotationLabelCreate
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers import (
+    annotation_label_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+)
+from lightly_studio.resolvers.annotation_resolver import create_many
+from lightly_studio.utils import batching
+
+
+class BulkCreateClassificationsResult(BaseModel):
+    """Result of a bulk classification create operation."""
+
+    created_annotation_ids: list[UUID]
+    created_count: int
+    skipped_count: int
+
+
+@dataclass(frozen=True)
+class _ClassificationCreateContext:
+    parent_collection_id: UUID
+    annotation_label_id: UUID
+    annotation_collection_id: UUID
+    annotation_collection_name: str | None
+
+
+def bulk_create_classifications(
+    session: Session,
+    parent_collection_id: UUID,
+    parent_sample_ids_query: SelectOfScalar[UUID],
+    class_name: str,
+    annotation_collection_name: str | None = None,
+) -> BulkCreateClassificationsResult:
+    """Create classification annotations for all parent samples returned by a query."""
+    annotation_label_id = _get_or_create_annotation_label_id(
+        session=session,
+        parent_collection_id=parent_collection_id,
+        class_name=class_name,
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=session,
+        collection_id=parent_collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name=annotation_collection_name,
+    )
+    context = _ClassificationCreateContext(
+        parent_collection_id=parent_collection_id,
+        annotation_label_id=annotation_label_id,
+        annotation_collection_id=annotation_collection_id,
+        annotation_collection_name=annotation_collection_name,
+    )
+    created_annotation_ids: list[UUID] = []
+    skipped_count = 0
+    streamed_parent_sample_ids_query = parent_sample_ids_query.execution_options(
+        yield_per=batching.DEFAULT_BATCH_SIZE
+    )
+
+    for parent_sample_ids in batching.batched(session.exec(streamed_parent_sample_ids_query)):
+        result = _bulk_create_classifications_for_source(
+            session=session,
+            parent_sample_ids=parent_sample_ids,
+            context=context,
+        )
+        created_annotation_ids.extend(result.created_annotation_ids)
+        skipped_count += result.skipped_count
+
+    result = BulkCreateClassificationsResult(
+        created_annotation_ids=created_annotation_ids,
+        created_count=len(created_annotation_ids),
+        skipped_count=skipped_count,
+    )
+    _mark_stale_if_changed(
+        session=session,
+        annotation_collection_id=annotation_collection_id,
+        result=result,
+    )
+    return result
+
+
+def _bulk_create_classifications_for_source(
+    session: Session,
+    parent_sample_ids: list[UUID],
+    context: _ClassificationCreateContext,
+) -> BulkCreateClassificationsResult:
+    existing_parent_sample_ids = _get_existing_classification_parent_sample_ids(
+        session=session,
+        parent_sample_ids=parent_sample_ids,
+        annotation_label_id=context.annotation_label_id,
+        annotation_collection_id=context.annotation_collection_id,
+    )
+    annotations = [
+        AnnotationCreate(
+            annotation_label_id=context.annotation_label_id,
+            annotation_type=AnnotationType.CLASSIFICATION,
+            parent_sample_id=parent_sample_id,
+        )
+        for parent_sample_id in parent_sample_ids
+        if parent_sample_id not in existing_parent_sample_ids
+    ]
+    if not annotations:
+        return BulkCreateClassificationsResult(
+            created_annotation_ids=[],
+            created_count=0,
+            skipped_count=len(parent_sample_ids),
+        )
+
+    created_annotation_ids = create_many.create_many(
+        session=session,
+        parent_collection_id=context.parent_collection_id,
+        annotations=annotations,
+        collection_name=context.annotation_collection_name,
+    )
+    return BulkCreateClassificationsResult(
+        created_annotation_ids=created_annotation_ids,
+        created_count=len(created_annotation_ids),
+        skipped_count=len(parent_sample_ids) - len(created_annotation_ids),
+    )
+
+
+def _get_existing_classification_parent_sample_ids(
+    session: Session,
+    parent_sample_ids: list[UUID],
+    annotation_label_id: UUID,
+    annotation_collection_id: UUID,
+) -> set[UUID]:
+    existing_parent_sample_ids: set[UUID] = set()
+    for parent_sample_id_batch in batching.batched(parent_sample_ids):
+        existing_parent_sample_ids.update(
+            session.exec(
+                select(AnnotationBaseTable.parent_sample_id)
+                .join(SampleTable, col(AnnotationBaseTable.sample_id) == col(SampleTable.sample_id))
+                .where(col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_id_batch))
+                .where(AnnotationBaseTable.annotation_label_id == annotation_label_id)
+                .where(AnnotationBaseTable.annotation_type == AnnotationType.CLASSIFICATION)
+                .where(SampleTable.collection_id == annotation_collection_id)
+            ).all()
+        )
+    return existing_parent_sample_ids
+
+
+def _get_or_create_annotation_label_id(
+    session: Session,
+    parent_collection_id: UUID,
+    class_name: str,
+) -> UUID:
+    collection = collection_resolver.get_by_id(session=session, collection_id=parent_collection_id)
+    if collection is None:
+        raise ValueError(f"Collection with id {parent_collection_id} not found.")
+
+    label = annotation_label_resolver.get_by_label_name(
+        session=session,
+        dataset_id=collection.dataset_id,
+        label_name=class_name,
+    )
+    if label is not None:
+        return label.annotation_label_id
+
+    return annotation_label_resolver.create(
+        session=session,
+        label=AnnotationLabelCreate(
+            dataset_id=collection.dataset_id,
+            annotation_label_name=class_name,
+        ),
+    ).annotation_label_id
+
+
+def _mark_stale_if_changed(
+    session: Session,
+    annotation_collection_id: UUID,
+    result: BulkCreateClassificationsResult,
+) -> None:
+    if not result.created_annotation_ids:
+        return
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=session,
+        collection_id=annotation_collection_id,
+    )

--- a/lightly_studio/tests/resolvers/annotations/test_bulk_create_classifications.py
+++ b/lightly_studio/tests/resolvers/annotations/test_bulk_create_classifications.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation_label import AnnotationLabelTable
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
+from tests.helpers_resolvers import (
+    ImageStub,
+    create_annotation,
+    create_annotation_label,
+    create_images,
+)
+
+
+def test_bulk_create_classifications__creates_classifications(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png")],
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id for image in images],
+        ),
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    annotations = _get_annotations(db_session)
+    assert result.created_count == 2
+    assert result.skipped_count == 0
+    assert {annotation.sample_id for annotation in annotations} == set(
+        result.created_annotation_ids
+    )
+    assert {annotation.parent_sample_id for annotation in annotations} == {
+        image.sample_id for image in images
+    }
+    assert {annotation.annotation_type for annotation in annotations} == {
+        AnnotationType.CLASSIFICATION
+    }
+    assert all(annotation.object_detection_details is None for annotation in annotations)
+    assert all(annotation.segmentation_details is None for annotation in annotations)
+
+
+def test_bulk_create_classifications__skips_duplicate_classifications(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png"), ImageStub(path="b.png")],
+    )
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[images[0].sample_id],
+        ),
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[images[0].sample_id, images[1].sample_id],
+        ),
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    assert result.created_count == 1
+    assert result.skipped_count == 1
+    assert len(_get_annotations(db_session)) == 2
+
+
+def test_bulk_create_classifications__object_detection_same_class_does_not_block_classification(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="car",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_collection_name="ground_truth",
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id],
+        ),
+        class_name="car",
+        annotation_collection_name="ground_truth",
+    )
+
+    annotations = _get_annotations(db_session)
+    assert result.created_count == 1
+    assert result.skipped_count == 0
+    assert {annotation.annotation_type for annotation in annotations} == {
+        AnnotationType.OBJECT_DETECTION,
+        AnnotationType.CLASSIFICATION,
+    }
+
+
+def test_bulk_create_classifications__different_class_and_source_scope_dedupe(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id],
+        ),
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    other_class = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id],
+        ),
+        class_name="cat",
+        annotation_collection_name="ground_truth",
+    )
+    other_source = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id],
+        ),
+        class_name="dog",
+        annotation_collection_name="prediction",
+    )
+
+    assert other_class.created_count == 1
+    assert other_source.created_count == 1
+    assert len(_get_annotations(db_session)) == 3
+
+
+def test_bulk_create_classifications__matches_filter_query(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[
+            ImageStub(path="wide.png", width=1920),
+            ImageStub(path="narrow.png", width=10),
+        ],
+    )
+    query = ImageFilter(width=FilterDimensions(min=100)).build_sample_ids_query(
+        collection_id=collection.collection_id
+    )
+
+    result = annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=query,
+        class_name="dog",
+        annotation_collection_name="ground_truth",
+    )
+
+    assert result.created_count == 1
+    assert _get_annotations(db_session)[0].parent_sample_id == images[0].sample_id
+
+
+def test_bulk_create_classifications__default_source(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id],
+        ),
+        class_name="dog",
+    )
+
+    annotation_collection = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    assert _get_annotations(db_session)[0].sample.collection_id == annotation_collection
+
+
+def test_bulk_create_classifications__reuses_existing_class(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    image = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="a.png")],
+    )[0]
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+
+    annotation_resolver.bulk_create_classifications(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        parent_sample_ids_query=_sample_ids_query(
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id],
+        ),
+        class_name="dog",
+    )
+
+    labels = list(db_session.exec(select(AnnotationLabelTable)).all())
+    assert labels == [label]
+    assert _get_annotations(db_session)[0].annotation_label_id == label.annotation_label_id
+
+
+def _get_annotations(session: Session) -> list[AnnotationBaseTable]:
+    return list(session.exec(select(AnnotationBaseTable)).all())
+
+
+def _sample_ids_query(
+    collection_id: UUID,
+    sample_ids: list[UUID],
+) -> SelectOfScalar[UUID]:
+    return (
+        select(SampleTable.sample_id)
+        .where(SampleTable.collection_id == collection_id)
+        .where(col(SampleTable.sample_id).in_(sample_ids))
+    )


### PR DESCRIPTION
## What has changed and why?

- Adds resolver support for bulk creating image classification annotations.
- Creates/reuses annotation classes and annotation sources, skips duplicate classifications, and marks affected evaluation runs stale.
- Adds resolver tests for creation, duplicate handling, source/class scoping, and filtered query input.

Stack: #2204 -> #2201 -> #2202

## How has it been tested?

```bash
cd lightly_studio
./.venv/bin/pytest tests/resolvers/annotations/test_bulk_create_classifications.py -q
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk creation of classification annotations across multiple samples.
  * Existing classifications are skipped to prevent duplicates.
  * Supports sample filtering, annotation collection selection, and default sources.
  * Reuses existing annotation labels when available.
  * Reports created and skipped totals, including IDs for newly created annotations.
* **Bug Fixes**
  * Prevents object-detection annotations with the same class from blocking classification creation.
  * Validates that the selected parent collection exists before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->