### PR TITLE
perf: decode video frames in parallel in embed_videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Speed up video embedding by decoding video frames in parallel.
 
 ### Deprecated
 

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -22,7 +22,7 @@ from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.embed import image_crop_embedding, image_embedding
 from lightly_studio.embed.image_embedding import EmbeddingContext
 from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, ImageCrop
-from lightly_studio.utils import batching
+from lightly_studio.utils import batching, executor, parallelize
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
 from .embedding_generator import (
@@ -177,12 +177,28 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
         kept_indices: list[int] = []
         report = FileOutcomeReport(label_overrides={FileOutcome.ADDED: "embedded"})
+        preprocess = self._preprocess
+
+        def decode_one(filepath: str) -> tuple[torch.Tensor | None, FileOutcome]:
+            # Runs on a worker thread: decode only, no shared state.
+            try:
+                return _load_video_frames(filepath, preprocess), FileOutcome.ADDED
+            except MissingInputFileError:
+                return None, FileOutcome.MISSING
+            except BrokenInputFileError:
+                return None, FileOutcome.BROKEN
 
         def preprocessed_videos_iter() -> Iterator[torch.Tensor]:
-            for index, filepath in enumerate(filepaths):
-                frames: torch.Tensor | None = None
-                with report.track(path=filepath):
-                    frames = _load_video_frames(filepath, self._preprocess)
+            # Decode in parallel, in input order. The report is not thread-safe, so record it here.
+            decoded = parallelize.thread_imap_lazy(
+                function=decode_one,
+                iterable=filepaths,
+                max_workers=executor.get_media_worker_count(),
+                # Read at most two batches ahead so the next batch is ready during inference.
+                buffer_size=2 * MAX_BATCH_SIZE,
+            )
+            for index, (frames, outcome) in enumerate(decoded):
+                report.record(path=filepaths[index], outcome=outcome)
                 if frames is not None:
                     kept_indices.append(index)
                     yield frames

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from lightly_studio.core.file_outcome_report import AllInputFilesFailedError
 from lightly_studio.dataset.perception_encoder_embedding_generator import (
+    MAX_BATCH_SIZE,
     MODEL_NAME,
     PerceptionEncoderEmbeddingGenerator,
 )
@@ -138,6 +139,39 @@ class TestPerceptionEncoderEmbeddingGenerator:
         assert result.embeddings.shape == (2, 512)
         # The two kept rows embed the same video, so they must match.
         assert np.allclose(result.embeddings[0], result.embeddings[1])
+
+    def test_embed_videos__preserves_order_across_batches_with_skips(self, tmp_path: Path) -> None:
+        """Keep embeddings aligned to input positions across batch boundaries.
+
+        The decode runs on a read-ahead pool. This input spans more than one batch, with
+        broken and missing files interleaved, so a reorder or a misaligned skip in the
+        concurrent pipeline shows as a wrong ``kept_indices`` or a mismatched row.
+        """
+        perception_encoder = PerceptionEncoderEmbeddingGenerator()
+        dog_video_path = str(FIXTURES_DIR / "dog.mp4")
+        broken_path = tmp_path / "broken.mp4"
+        broken_path.write_bytes(b"not a valid video")
+        missing_path = str(tmp_path / "missing.mp4")
+
+        total = MAX_BATCH_SIZE * 2 + 3
+        filepaths: list[str] = []
+        expected_kept: list[int] = []
+        for index in range(total):
+            if index % 5 == 0:
+                filepaths.append(missing_path)
+            elif index % 7 == 0:
+                filepaths.append(str(broken_path))
+            else:
+                filepaths.append(dog_video_path)
+                expected_kept.append(index)
+
+        result = perception_encoder.embed_videos(filepaths)
+
+        assert result.kept_indices == expected_kept
+        assert result.embeddings.shape == (len(expected_kept), 512)
+        # Every kept row embeds the same video, so any reorder or misalignment shows here.
+        for row in result.embeddings:
+            assert np.allclose(row, result.embeddings[0], atol=1e-4)
 
     def test_embed_videos__raises_when_all_files_broken(self, tmp_path: Path) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()


### PR DESCRIPTION
## What has changed and why?

`PerceptionEncoderEmbeddingGenerator.embed_videos` decoded video frames one file at a time before running inference. The image path was already made parallel in #2086, but the video path was not, so video embedding was decode-bound.

This change decodes the frames on a bounded thread pool with `parallelize.thread_imap_lazy` and `executor.get_media_worker_count()`, the same utilities the image path uses. Video decoding is heavy work that releases the GIL, so it runs across cores, and the read-ahead also overlaps decoding with model inference. The results stay in input order, and missing or broken files are still skipped and reported. The embeddings are unchanged.

The embedder was copied to `embed/perception_encoder_embedder.py` in #2195 with the same sequential decode. I left that copy untouched to avoid colliding with the in-progress `embed/` refactor (#2015).

## How has it been tested?

- Added a test that embeds more than one batch of videos with broken and missing files interleaved, so the parallel path is checked for correct order and skips across batch boundaries.
- `make static-checks` passes (ruff, mypy, format).
- The video embedding tests pass.
- Local benchmark on an RTX 4070 laptop GPU with real 1080p and 720p clips: embedding a 24-video mix went from about 1006 to about 191 ms per video (about 5.3x). Video decode is the dominant cost on real videos, so the parallel decode gives most of the speedup.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Video embedding is now faster by decoding video frames in parallel.

- **Reliability**
  - Missing or broken video files continue to be skipped and reported correctly.
  - Embedding results preserve the original input order, including across batches with skipped files.

- **Documentation**
  - Added an Unreleased changelog entry describing the video embedding performance improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->