### PR TITLE
Finish the Capability enum rename before it becomes public API

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -48,7 +48,6 @@ class Capability(str, Enum):
     """Video as raw file bytes. No local implementation yet."""
 
 
-
 class Embedder(ABC):
     """Base class for every embedder.
 

--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -24,6 +24,12 @@ class Capability(str, Enum):
     Members are named ``SUBJECT[_TRANSPORT]``, with the transport omitted when a
     subject has a single form. ``PATH`` and ``PIL`` are local-only; ``URL`` and
     ``BYTES`` are the transports an embedding backend can accept.
+
+    Capabilities are used both at ingest, when data is loaded into the database,
+    and interactively while the GUI runs. Which of the two a capability serves is
+    a property of the call site rather than of the capability itself:
+    ``IMAGE_BYTES`` backs interactive search today and bulk ingest over the wire
+    later.
     """
 
     IMAGE_PATH = "image_path"

--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -21,15 +21,9 @@ class Capability(str, Enum):
 
     <span class="doc-badge doc-badge--beta">Beta</span>
 
-    Members are named ``SUBJECT[_TRANSPORT]``, with the transport omitted when a
-    subject has a single form. ``PATH`` and ``PIL`` are local-only; ``URL`` and
-    ``BYTES`` are the transports an embedding backend can accept.
-
-    Capabilities are used both at ingest, when data is loaded into the database,
-    and interactively while the GUI runs. Which of the two a capability serves is
-    a property of the call site rather than of the capability itself:
-    ``IMAGE_BYTES`` backs interactive search today and bulk ingest over the wire
-    later.
+    Some capabilities are used at ingest time (IMAGE_PATH, IMAGE_CROP_PATH,
+    VIDEO_PATH, IMAGE_PIL, VIDEO_BYTES) and some interactively while the GUI
+    runs (TEXT, IMAGE_BYTES).
     """
 
     IMAGE_PATH = "image_path"
@@ -50,14 +44,9 @@ class Capability(str, Enum):
     IMAGE_BYTES = "image_bytes"
     """Image as raw file bytes."""
 
-    IMAGE_URL = "image_url"
-    """Image by URL. No local implementation yet."""
-
     VIDEO_BYTES = "video_bytes"
     """Video as raw file bytes. No local implementation yet."""
 
-    VIDEO_URL = "video_url"
-    """Video by URL. No local implementation yet."""
 
 
 class Embedder(ABC):

--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -1,9 +1,9 @@
 """Capability-split embedder interfaces.
 
 Defines the ``Embedder`` base class and one abstract subclass per input a model
-can embed: images and crops by path, videos, video frames, text, and images by
-bytes. A concrete model implements only the capabilities it supports, and
-callers pick an embedder by the capability they need.
+can embed: images and image crops by path, videos, video frames, text, and
+images by bytes. A concrete model implements only the capabilities it supports,
+and callers pick an embedder by the capability they need.
 """
 
 from __future__ import annotations
@@ -21,27 +21,37 @@ class Capability(str, Enum):
 
     <span class="doc-badge doc-badge--beta">Beta</span>
 
-    Some capabilities are used at ingest, when data is loaded into the database.
-    Others are needed interactively while the GUI runs.
+    Members are named ``SUBJECT[_TRANSPORT]``, with the transport omitted when a
+    subject has a single form. ``PATH`` and ``PIL`` are local-only; ``URL`` and
+    ``BYTES`` are the transports an embedding backend can accept.
     """
 
     IMAGE_PATH = "image_path"
-    """Ingest: image by fsspec path or URL."""
+    """Image by fsspec path."""
 
-    CROP_PATH = "crop_path"
-    """Ingest: crop specified by an image fsspec or URL and a pixel box."""
+    IMAGE_CROP_PATH = "image_crop_path"
+    """Crop given by an image fsspec path and a pixel box."""
 
     VIDEO_PATH = "video_path"
-    """Ingest: video by fsspec path or URL."""
+    """Video by fsspec path."""
 
     IMAGE_PIL = "image_pil"
-    """Ingest: video frame as a PIL image."""
+    """Video frame as a PIL image."""
 
     TEXT = "text"
-    """Interactive: text query."""
+    """Text query."""
 
     IMAGE_BYTES = "image_bytes"
-    """Interactive: image as raw file bytes."""
+    """Image as raw file bytes."""
+
+    IMAGE_URL = "image_url"
+    """Image by URL. No local implementation yet."""
+
+    VIDEO_BYTES = "video_bytes"
+    """Video as raw file bytes. No local implementation yet."""
+
+    VIDEO_URL = "video_url"
+    """Video by URL. No local implementation yet."""
 
 
 class Embedder(ABC):
@@ -66,11 +76,9 @@ class Embedder(ABC):
 
 
 class ImagePathEmbedder(Embedder):
-    """Embeds images read from an fsspec path or URL (local, ``s3://``, ...).
+    """Embeds images read from an fsspec path (local, ``s3://``, ...).
 
     <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Used at ingest.
     """
 
     __slots__ = ()
@@ -80,25 +88,23 @@ class ImagePathEmbedder(Embedder):
         """Embed a batch of images given by path.
 
         Args:
-            paths: fsspec paths or URLs of the images to embed.
+            paths: fsspec paths of the images to embed.
 
         Returns:
             The embeddings and the indices of the inputs they cover.
         """
 
 
-class CropPathEmbedder(Embedder):
+class ImageCropPathEmbedder(Embedder):
     """Embeds crops of stored images, each an image path plus a pixel box.
 
     <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Used at ingest.
     """
 
     __slots__ = ()
 
     @abstractmethod
-    def embed_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
+    def embed_image_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
         """Embed a batch of image crops given by path and pixel box.
 
         Args:
@@ -110,11 +116,9 @@ class CropPathEmbedder(Embedder):
 
 
 class VideoPathEmbedder(Embedder):
-    """Embeds videos read from an fsspec path or URL.
+    """Embeds videos read from an fsspec path.
 
     <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Used at ingest.
     """
 
     __slots__ = ()
@@ -124,7 +128,7 @@ class VideoPathEmbedder(Embedder):
         """Embed a batch of videos given by path.
 
         Args:
-            paths: fsspec paths or URLs of the videos to embed.
+            paths: fsspec paths of the videos to embed.
 
         Returns:
             The embeddings and the indices of the inputs they cover.
@@ -135,8 +139,6 @@ class ImagePILEmbedder(Embedder):
     """Embeds video frames given as PIL images.
 
     <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Used at ingest.
     """
 
     __slots__ = ()
@@ -157,8 +159,6 @@ class TextEmbedder(Embedder):
     """Embeds text queries.
 
     <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Used for interactive requests.
     """
 
     __slots__ = ()
@@ -180,8 +180,8 @@ class ImageBytesEmbedder(Embedder):
 
     <span class="doc-badge doc-badge--beta">Beta</span>
 
-    Used for interactive requests, where the upload has no path to read. JPEG,
-    PNG and WebP only.
+    For callers that have no path to read, such as an upload. JPEG, PNG and
+    WebP only.
     """
 
     __slots__ = ()

--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -1,9 +1,9 @@
 """Capability-split embedder interfaces.
 
 Defines the ``Embedder`` base class and one abstract subclass per input a model
-can embed: images and image crops by path, videos, video frames, text, and
-images by bytes. A concrete model implements only the capabilities it supports,
-and callers pick an embedder by the capability they need.
+can embed: images and crops by path, videos, video frames, text, and images by
+bytes. A concrete model implements only the capabilities it supports, and
+callers pick an embedder by the capability they need.
 """
 
 from __future__ import annotations
@@ -21,9 +21,8 @@ class Capability(str, Enum):
 
     <span class="doc-badge doc-badge--beta">Beta</span>
 
-    Some capabilities are used at ingest time (IMAGE_PATH, IMAGE_CROP_PATH,
-    VIDEO_PATH, IMAGE_PIL, VIDEO_BYTES) and some interactively while the GUI
-    runs (TEXT, IMAGE_BYTES).
+    Some capabilities are used at ingest, when data is loaded into the database.
+    Others are needed interactively while the GUI runs.
     """
 
     IMAGE_PATH = "image_path"

--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -26,25 +26,25 @@ class Capability(str, Enum):
     """
 
     IMAGE_PATH = "image_path"
-    """Image by fsspec path."""
+    """Ingest: image by fsspec path."""
 
     IMAGE_CROP_PATH = "image_crop_path"
-    """Crop given by an image fsspec path and a pixel box."""
+    """Ingest: crop specified by an image fsspec path and a pixel box."""
 
     VIDEO_PATH = "video_path"
-    """Video by fsspec path."""
+    """Ingest: video by fsspec path."""
 
     IMAGE_PIL = "image_pil"
-    """Video frame as a PIL image."""
+    """Ingest: video frame as a PIL image."""
 
     TEXT = "text"
-    """Text query."""
+    """Interactive: text query."""
 
     IMAGE_BYTES = "image_bytes"
-    """Image as raw file bytes."""
+    """Interactive and ingest: image as raw file bytes."""
 
     VIDEO_BYTES = "video_bytes"
-    """Video as raw file bytes. No local implementation yet."""
+    """Ingest: video as raw file bytes. No local implementation yet."""
 
 
 class Embedder(ABC):

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -11,9 +11,9 @@ import logging
 
 from lightly_studio.embed.embedder import (
     Capability,
-    CropPathEmbedder,
     Embedder,
     ImageBytesEmbedder,
+    ImageCropPathEmbedder,
     ImagePathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
@@ -22,9 +22,10 @@ from lightly_studio.embed.embedder import (
 
 logger = logging.getLogger(__name__)
 
+# Capabilities that have no local implementation yet are absent.
 _CAPABILITY_TO_TYPE = {
     Capability.IMAGE_PATH: ImagePathEmbedder,
-    Capability.CROP_PATH: CropPathEmbedder,
+    Capability.IMAGE_CROP_PATH: ImageCropPathEmbedder,
     Capability.VIDEO_PATH: VideoPathEmbedder,
     Capability.IMAGE_PIL: ImagePILEmbedder,
     Capability.TEXT: TextEmbedder,
@@ -79,10 +80,10 @@ class EmbedderRegistry:
         embedder = self._space_key_to_embedder.get(space_key)
         return embedder if isinstance(embedder, ImagePathEmbedder) else None
 
-    def get_crop_path_embedder(self, space_key: str) -> CropPathEmbedder | None:
-        """Get the space's embedder if it embeds crops by path, else None."""
+    def get_image_crop_path_embedder(self, space_key: str) -> ImageCropPathEmbedder | None:
+        """Get the space's embedder if it embeds image crops by path, else None."""
         embedder = self._space_key_to_embedder.get(space_key)
-        return embedder if isinstance(embedder, CropPathEmbedder) else None
+        return embedder if isinstance(embedder, ImageCropPathEmbedder) else None
 
     def get_video_path_embedder(self, space_key: str) -> VideoPathEmbedder | None:
         """Get the space's embedder if it embeds videos by path, else None."""

--- a/lightly_studio/src/lightly_studio/embed/random_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/random_embedder.py
@@ -1,7 +1,8 @@
 """Embedder that produces random vectors.
 
-Implements every capability so it can stand in for a real model in tests, demos
-and local development. The vectors carry no meaning, so search results are random.
+Implements every locally implemented capability so it can stand in for a real model
+in tests, demos and local development. The vectors carry no meaning, so search
+results are random.
 """
 
 from __future__ import annotations
@@ -10,8 +11,8 @@ import numpy as np
 from PIL.Image import Image
 
 from lightly_studio.embed.embedder import (
-    CropPathEmbedder,
     ImageBytesEmbedder,
+    ImageCropPathEmbedder,
     ImagePathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
@@ -22,7 +23,7 @@ from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, Imag
 
 class RandomEmbedder(
     ImagePathEmbedder,
-    CropPathEmbedder,
+    ImageCropPathEmbedder,
     VideoPathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
@@ -30,8 +31,8 @@ class RandomEmbedder(
 ):
     """Embedder that returns a random vector for every input.
 
-    Supports every capability. The vectors are meaningless, so it is meant for
-    tests, demos and local development, not for real search.
+    Supports every locally implemented capability. The vectors are meaningless, so it
+    is meant for tests, demos and local development, not for real search.
     """
 
     __slots__ = ("_dimension",)
@@ -52,7 +53,7 @@ class RandomEmbedder(
         """Return a random vector for each image path."""
         return self._random_result(count=len(paths))
 
-    def embed_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
+    def embed_image_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
         """Return a random vector for each crop."""
         return self._random_result(count=len(crops))
 

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -49,7 +49,7 @@ class TestEmbedderRegistry:
         assert registry.get_text_embedder(space_key="space-a") is embedder
         assert registry.get_image_path_embedder(space_key="space-a") is embedder
         # Getters for capabilities the embedder lacks return None.
-        assert registry.get_crop_path_embedder(space_key="space-a") is None
+        assert registry.get_image_crop_path_embedder(space_key="space-a") is None
         assert registry.get_video_path_embedder(space_key="space-a") is None
         assert registry.get_image_pil_embedder(space_key="space-a") is None
         assert registry.get_image_bytes_embedder(space_key="space-a") is None

--- a/lightly_studio/tests/embed/test_random_embedder.py
+++ b/lightly_studio/tests/embed/test_random_embedder.py
@@ -23,11 +23,11 @@ class TestRandomEmbedder:
         assert result.embeddings.dtype == np.float32
         assert result.kept_indices == [0, 1]
 
-    def test_embed_crops(self) -> None:
+    def test_embed_image_crops(self) -> None:
         embedder = RandomEmbedder(dimension=4)
         crop = ImageCrop(filepath="a.jpg", x=0, y=0, width=1, height=1)
 
-        result = embedder.embed_crops(crops=[crop])
+        result = embedder.embed_image_crops(crops=[crop])
 
         assert result.embeddings.shape == (1, 4)
         assert result.kept_indices == [0]


### PR DESCRIPTION
## Description

`Capability` and the `Embedder` ABCs are merged but not exported from `lightly_studio/__init__.py` and not referenced in the docs, so this rename is free today and a deprecation once they are public.

- `CROP_PATH` → `IMAGE_CROP_PATH`, `CropPathEmbedder` → `ImageCropPathEmbedder`, `embed_crops` → `embed_image_crops`, `get_crop_path_embedder` → `get_image_crop_path_embedder`. Subject-first matches the existing public `ImageCrop` type. Deliberately not `IMAGE_REGION_*`: a mask is also a region, so naming the rectangle "region" would leave a future non-rectangular capability with no name. `ImageCrop` keeps its name.
- Dropped "or URL" from the `IMAGE_PATH` and `VIDEO_PATH` docstrings. An fsspec path is resolved with our credentials; a presigned URL is fetched by whoever holds it. Conflating the two is what makes people assume `IMAGE_PATH` is legal over the wire — per LIG-10640 it is not, and `PATH` and `PIL` stay local-only.
- Added `VIDEO_BYTES`, declared ahead of a local implementation.
- `IMAGE_URL` and `VIDEO_URL` are **deferred, not merged into the path members**. The transport distinction above still holds; what is unsettled is how an implementer is meant to tell the two apart in practice, given fsspec also accepts `http(s)` paths. They land once signed URLs have a concrete call site to document them against. No `IMAGE_CROP_URL` in any case: crops have no endpoint of their own, we crop with padding on our side and post the result as image bytes.
- Dropped the `Ingest:` / `Interactive:` prefixes, and named the members per phase on the enum instead.

Existing member and class order is untouched.

## Linear

LIG-10735

## Test plan

`make static-checks` and `uv run pytest tests/embed` pass (41 tests). CI green on e919ec2.