### PR TITLE
Rename CROP_PATH capability to IMAGE_CROP_PATH

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -28,7 +28,7 @@ class Capability(str, Enum):
     IMAGE_PATH = "image_path"
     """Ingest: image by fsspec path or URL."""
 
-    CROP_PATH = "crop_path"
+    IMAGE_CROP_PATH = "image_crop_path"
     """Ingest: crop specified by an image fsspec or URL and a pixel box."""
 
     VIDEO_PATH = "video_path"
@@ -87,7 +87,7 @@ class ImagePathEmbedder(Embedder):
         """
 
 
-class CropPathEmbedder(Embedder):
+class ImageCropPathEmbedder(Embedder):
     """Embeds crops of stored images, each an image path plus a pixel box.
 
     <span class="doc-badge doc-badge--beta">Beta</span>

--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -11,9 +11,9 @@ import logging
 
 from lightly_studio.embed.embedder import (
     Capability,
-    CropPathEmbedder,
     Embedder,
     ImageBytesEmbedder,
+    ImageCropPathEmbedder,
     ImagePathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 _CAPABILITY_TO_TYPE = {
     Capability.IMAGE_PATH: ImagePathEmbedder,
-    Capability.CROP_PATH: CropPathEmbedder,
+    Capability.IMAGE_CROP_PATH: ImageCropPathEmbedder,
     Capability.VIDEO_PATH: VideoPathEmbedder,
     Capability.IMAGE_PIL: ImagePILEmbedder,
     Capability.TEXT: TextEmbedder,
@@ -79,10 +79,10 @@ class EmbedderRegistry:
         embedder = self._space_key_to_embedder.get(space_key)
         return embedder if isinstance(embedder, ImagePathEmbedder) else None
 
-    def get_crop_path_embedder(self, space_key: str) -> CropPathEmbedder | None:
+    def get_image_crop_path_embedder(self, space_key: str) -> ImageCropPathEmbedder | None:
         """Get the space's embedder if it embeds crops by path, else None."""
         embedder = self._space_key_to_embedder.get(space_key)
-        return embedder if isinstance(embedder, CropPathEmbedder) else None
+        return embedder if isinstance(embedder, ImageCropPathEmbedder) else None
 
     def get_video_path_embedder(self, space_key: str) -> VideoPathEmbedder | None:
         """Get the space's embedder if it embeds videos by path, else None."""

--- a/lightly_studio/src/lightly_studio/embed/random_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/random_embedder.py
@@ -10,8 +10,8 @@ import numpy as np
 from PIL.Image import Image
 
 from lightly_studio.embed.embedder import (
-    CropPathEmbedder,
     ImageBytesEmbedder,
+    ImageCropPathEmbedder,
     ImagePathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
@@ -22,7 +22,7 @@ from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, Imag
 
 class RandomEmbedder(
     ImagePathEmbedder,
-    CropPathEmbedder,
+    ImageCropPathEmbedder,
     VideoPathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -49,7 +49,7 @@ class TestEmbedderRegistry:
         assert registry.get_text_embedder(space_key="space-a") is embedder
         assert registry.get_image_path_embedder(space_key="space-a") is embedder
         # Getters for capabilities the embedder lacks return None.
-        assert registry.get_crop_path_embedder(space_key="space-a") is None
+        assert registry.get_image_crop_path_embedder(space_key="space-a") is None
         assert registry.get_video_path_embedder(space_key="space-a") is None
         assert registry.get_image_pil_embedder(space_key="space-a") is None
         assert registry.get_image_bytes_embedder(space_key="space-a") is None


### PR DESCRIPTION
## What has changed and why?

Rename the `CROP_PATH` embedder capability to `IMAGE_CROP_PATH` for naming consistency with the other image capabilities.

- `Capability.CROP_PATH` → `IMAGE_CROP_PATH` (value `"crop_path"` → `"image_crop_path"`)
- `CropPathEmbedder` → `ImageCropPathEmbedder`
- `EmbedderRegistry.get_crop_path_embedder` → `get_image_crop_path_embedder`

Beta feature, no external users yet.

## How has it been tested?

- `make static-checks` (ruff, mypy, format)
- `pytest tests/embed`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Renamed the crop embedding capability and related public interfaces to use “image crop path” terminology.
  * Updated the embedder registry lookup to match the new naming.
  * Crop embedding behavior and method signatures remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->