### PR TITLE
Migrate PerceptionEncoderEmbedder to the Embedder protocols

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
@@ -90,6 +90,10 @@ class PerceptionEncoderEmbedder(
         Returns:
             The embeddings and the indices of the inputs they cover.
         """
+        if not texts:
+            empty = np.empty((0, self._model.output_dim), dtype=np.float32)
+            return EmbeddingResult(embeddings=empty, kept_indices=[])
+
         tokenized = self._tokenizer(texts).to(self._device)
         with torch.no_grad():
             embeddings = self._model.encode_text(tokenized, normalize=True).cpu().numpy()

--- a/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
@@ -8,7 +8,6 @@ import fsspec
 import numpy as np
 import torch
 from av import FFmpegError, container
-from numpy.typing import NDArray
 from PIL import Image
 from tqdm import tqdm
 
@@ -18,11 +17,14 @@ from lightly_studio.core.file_outcome_report import (
     FileOutcomeReport,
     MissingInputFileError,
 )
-from lightly_studio.dataset.embedding_generator import (
-    ImageEmbeddingGenerator,
-    VideoEmbeddingGenerator,
-)
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
+from lightly_studio.embed.embedder import (
+    CropPathEmbedder,
+    ImagePathEmbedder,
+    ImagePILEmbedder,
+    TextEmbedder,
+    VideoPathEmbedder,
+)
 from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, ImageCrop
 from lightly_studio.utils import batching
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
@@ -36,7 +38,13 @@ MAX_BATCH_SIZE: int = 16
 VIDEO_FRAMES_PER_SAMPLE: int = 8
 
 
-class PerceptionEncoderEmbedder(ImageEmbeddingGenerator, VideoEmbeddingGenerator):
+class PerceptionEncoderEmbedder(
+    ImagePathEmbedder,
+    CropPathEmbedder,
+    ImagePILEmbedder,
+    TextEmbedder,
+    VideoPathEmbedder,
+):
     """Perception Encoder Core embedding model."""
 
     def __init__(self) -> None:
@@ -73,76 +81,67 @@ class PerceptionEncoderEmbedder(ImageEmbeddingGenerator, VideoEmbeddingGenerator
             dimension=self._model.output_dim,
         )
 
-    def embed_text(self, text: str) -> list[float]:
-        """Embed a text with Perception Encoder.
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        """Embed a batch of texts with Perception Encoder.
 
         Args:
-            text: The text to embed.
+            texts: The strings to embed.
 
         Returns:
-            A list of floats representing the generated embedding.
+            The embeddings and the indices of the inputs they cover.
         """
-        tokenized = self._tokenizer([text]).to(self._device)
+        tokenized = self._tokenizer(texts).to(self._device)
         with torch.no_grad():
-            embedding = self._model.encode_text(tokenized, normalize=True)[0]
-            # Convert embedding to list of floats.
-            embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
-        return embedding_list
+            embeddings = self._model.encode_text(tokenized, normalize=True).cpu().numpy()
+        return EmbeddingResult(
+            embeddings=embeddings.astype(np.float32), kept_indices=list(range(len(texts)))
+        )
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
+    def embed_images(self, paths: list[str]) -> EmbeddingResult:
         """Embed images with Perception Encoder.
 
         Args:
-            filepaths: A list of file paths to the images to embed.
-            show_progress: Whether to show a progress bar during embedding.
+            paths: fsspec paths or URLs of the images to embed.
 
         Returns:
-            An ``EmbeddingResult`` with embeddings for the readable files, in the same
-            order as the corresponding input file paths.
+            The embeddings and the indices of the inputs they cover.
         """
         return image_embedding.embed_image_files_batched(
-            filepaths=filepaths,
+            filepaths=paths,
             context=self._embedding_context(),
-            show_progress=show_progress,
+            show_progress=True,
         )
 
-    def embed_image_crops(
-        self, image_crops: list[ImageCrop], show_progress: bool = True
-    ) -> EmbeddingResult:
+    def embed_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
         """Embed image crops with Perception Encoder.
 
         Args:
-            image_crops: A list of image crop definitions to embed.
-            show_progress: Whether to show a progress bar during embedding.
+            crops: The crops to embed.
 
         Returns:
-            An ``EmbeddingResult`` with embeddings for the crops of readable files,
-            in the same order as the corresponding input crops.
+            The embeddings and the indices of the inputs they cover.
         """
         return image_crop_embedding.embed_image_crops_batched(
-            image_crops=image_crops,
+            image_crops=crops,
             context=self._embedding_context(),
-            show_progress=show_progress,
+            show_progress=True,
         )
 
-    def embed_pil_images(
-        self, images: list[Image.Image], show_progress: bool = True
-    ) -> NDArray[np.float32]:
-        """Embed in-memory PIL images with Perception Encoder.
+    def embed_frames(self, frames: list[Image.Image]) -> EmbeddingResult:
+        """Embed video frames with Perception Encoder.
 
         Args:
-            images: PIL images to embed.
-            show_progress: Whether to show a progress bar during embedding.
+            frames: The frames to embed, as PIL images.
 
         Returns:
-            A numpy array representing the generated embeddings in the same order
-            as the input images.
+            The embeddings and the indices of the inputs they cover.
         """
-        return image_embedding.embed_pil_images_batched(
-            images=images,
+        embeddings = image_embedding.embed_pil_images_batched(
+            images=frames,
             context=self._embedding_context(),
-            show_progress=show_progress,
+            show_progress=True,
         )
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(frames))))
 
     def _embedding_context(self) -> EmbeddingContext:
         """Build the model-specific configuration for batched image embedding."""
@@ -156,11 +155,11 @@ class PerceptionEncoderEmbedder(ImageEmbeddingGenerator, VideoEmbeddingGenerator
             ),
         )
 
-    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
+    def embed_videos(self, paths: list[str]) -> EmbeddingResult:
         """Embed videos with Perception Encoder, skipping missing or broken files.
 
         Args:
-            filepaths: A list of file paths to the videos to embed.
+            paths: fsspec paths or URLs of the videos to embed.
 
         Returns:
             An ``EmbeddingResult`` whose embeddings cover only the readable videos, with
@@ -169,7 +168,7 @@ class PerceptionEncoderEmbedder(ImageEmbeddingGenerator, VideoEmbeddingGenerator
         Raises:
             AllInputFilesFailedError: If every attempted file was missing or broken.
         """
-        total_videos = len(filepaths)
+        total_videos = len(paths)
         if not total_videos:
             empty = np.empty((0, self._model.output_dim), dtype=np.float32)
             return EmbeddingResult(embeddings=empty, kept_indices=[])
@@ -179,7 +178,7 @@ class PerceptionEncoderEmbedder(ImageEmbeddingGenerator, VideoEmbeddingGenerator
         report = FileOutcomeReport(label_overrides={FileOutcome.ADDED: "embedded"})
 
         def preprocessed_videos_iter() -> Iterator[torch.Tensor]:
-            for index, filepath in enumerate(filepaths):
+            for index, filepath in enumerate(paths):
                 frames: torch.Tensor | None = None
                 with report.track(path=filepath):
                     frames = _load_video_frames(filepath, self._preprocess)

--- a/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
@@ -19,7 +19,7 @@ from lightly_studio.core.file_outcome_report import (
 )
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.embed.embedder import (
-    CropPathEmbedder,
+    ImageCropPathEmbedder,
     ImagePathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
@@ -40,7 +40,7 @@ VIDEO_FRAMES_PER_SAMPLE: int = 8
 
 class PerceptionEncoderEmbedder(
     ImagePathEmbedder,
-    CropPathEmbedder,
+    ImageCropPathEmbedder,
     ImagePILEmbedder,
     TextEmbedder,
     VideoPathEmbedder,
@@ -116,7 +116,7 @@ class PerceptionEncoderEmbedder(
             show_progress=True,
         )
 
-    def embed_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
+    def embed_image_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
         """Embed image crops with Perception Encoder.
 
         Args:

--- a/lightly_studio/tests/embed/test_perception_encoder_embedder.py
+++ b/lightly_studio/tests/embed/test_perception_encoder_embedder.py
@@ -26,18 +26,28 @@ class TestPerceptionEncoderEmbedder:
         assert space_spec.space_key == MODEL_NAME
 
     def test_embed_text(self) -> None:
-        text = "a cat"
         perception_encoder = PerceptionEncoderEmbedder()
-        embedding = perception_encoder.embed_text(text)
-        assert len(embedding) == 512
+        result = perception_encoder.embed_text(texts=["a cat"])
+
+        assert result.kept_indices == [0]
+        assert result.embeddings.shape == (1, 512)
 
         # Normalize and test a few values.
-        embedding_normed = np.array(embedding)
+        embedding_normed = result.embeddings[0]
         embedding_normed /= np.linalg.norm(embedding_normed)
         assert np.isclose(embedding_normed[0], -0.0108, atol=1e-4)
         assert np.isclose(embedding_normed[1], -0.0152, atol=1e-4)
         assert np.isclose(embedding_normed[2], -0.0406, atol=1e-4)
         assert np.isclose(embedding_normed[3], -0.0312, atol=1e-4)
+
+    def test_embed_text__empty_input(self) -> None:
+        perception_encoder = PerceptionEncoderEmbedder()
+
+        result = perception_encoder.embed_text(texts=[])
+
+        assert result.embeddings.shape == (0, 512)
+        assert result.embeddings.dtype == np.float32
+        assert result.kept_indices == []
 
     def test_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
@@ -56,46 +66,50 @@ class TestPerceptionEncoderEmbedder:
         assert np.isclose(cat_embedding_normed[2], 0.0307, atol=1e-4)
         assert np.isclose(cat_embedding_normed[3], -0.0493, atol=1e-4)
 
-    def test_embed_image_crops__empty_input(self) -> None:
+    def test_embed_crops__empty_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
-        embeddings = perception_encoder.embed_image_crops([]).embeddings
+        result = perception_encoder.embed_crops(crops=[])
 
-        assert embeddings.shape == (0, 512)
+        assert result.embeddings.shape == (0, 512)
+        assert result.kept_indices == []
 
-    def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
+    def test_embed_crops__full_image_crop_matches_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
         with Image.open(cat_image_path) as image:
             width, height = image.size
 
         full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
-        crop_embeddings = perception_encoder.embed_image_crops([full_crop]).embeddings
-        image_embeddings = perception_encoder.embed_images([str(cat_image_path)]).embeddings
+        crop_result = perception_encoder.embed_crops(crops=[full_crop])
+        image_result = perception_encoder.embed_images(paths=[str(cat_image_path)])
 
-        assert crop_embeddings.shape == (1, 512)
+        assert crop_result.embeddings.shape == (1, 512)
+        assert crop_result.kept_indices == [0]
         # A crop covering the entire image is preprocessed and encoded identically
         # to the full image, so the embeddings must match.
-        assert np.allclose(crop_embeddings[0], image_embeddings[0], atol=1e-4)
+        assert np.allclose(crop_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
 
-    def test_embed_pil_images__empty_input(self) -> None:
+    def test_embed_frames__empty_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
-        embeddings = perception_encoder.embed_pil_images([])
+        result = perception_encoder.embed_frames(frames=[])
 
-        assert embeddings.shape == (0, 512)
+        assert result.embeddings.shape == (0, 512)
+        assert result.kept_indices == []
 
-    def test_embed_pil_images__matches_embed_images(self) -> None:
+    def test_embed_frames__matches_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
         with Image.open(cat_image_path) as image:
             cat_pil_image = image.convert("RGB")
 
-        pil_embeddings = perception_encoder.embed_pil_images([cat_pil_image])
-        image_embeddings = perception_encoder.embed_images([str(cat_image_path)]).embeddings
+        frame_result = perception_encoder.embed_frames(frames=[cat_pil_image])
+        image_result = perception_encoder.embed_images(paths=[str(cat_image_path)])
 
-        assert pil_embeddings.shape == (1, 512)
+        assert frame_result.embeddings.shape == (1, 512)
+        assert frame_result.kept_indices == [0]
         # An in-memory PIL image is preprocessed and encoded identically to the same
         # image loaded from disk, so the embeddings must match.
-        assert np.allclose(pil_embeddings[0], image_embeddings[0], atol=1e-4)
+        assert np.allclose(frame_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
 
     def test_embed_videos(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
@@ -157,12 +171,8 @@ class TestPerceptionEncoderEmbedder:
         perception_encoder = PerceptionEncoderEmbedder()
 
         # Embed texts.
-        text_emb = torch.tensor(
-            [
-                perception_encoder.embed_text("a cat"),
-                perception_encoder.embed_text("a dog"),
-                perception_encoder.embed_text("a tiger"),
-            ]
+        text_emb = torch.from_numpy(
+            perception_encoder.embed_text(texts=["a cat", "a dog", "a tiger"]).embeddings
         )
         text_emb /= text_emb.norm(dim=-1, keepdim=True)
 
@@ -189,12 +199,14 @@ class TestPerceptionEncoderEmbedder:
         perception_encoder = PerceptionEncoderEmbedder()
 
         # Embed texts.
-        text_emb = torch.tensor(
-            [
-                perception_encoder.embed_text("giving a dog a treat"),
-                perception_encoder.embed_text("giving a horse a treat"),
-                perception_encoder.embed_text("giving a tiger a treat"),
-            ]
+        text_emb = torch.from_numpy(
+            perception_encoder.embed_text(
+                texts=[
+                    "giving a dog a treat",
+                    "giving a horse a treat",
+                    "giving a tiger a treat",
+                ]
+            ).embeddings
         )
         text_emb /= text_emb.norm(dim=-1, keepdim=True)
 

--- a/lightly_studio/tests/embed/test_perception_encoder_embedder.py
+++ b/lightly_studio/tests/embed/test_perception_encoder_embedder.py
@@ -66,21 +66,21 @@ class TestPerceptionEncoderEmbedder:
         assert np.isclose(cat_embedding_normed[2], 0.0307, atol=1e-4)
         assert np.isclose(cat_embedding_normed[3], -0.0493, atol=1e-4)
 
-    def test_embed_crops__empty_input(self) -> None:
+    def test_embed_image_crops__empty_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
-        result = perception_encoder.embed_crops(crops=[])
+        result = perception_encoder.embed_image_crops(crops=[])
 
         assert result.embeddings.shape == (0, 512)
         assert result.kept_indices == []
 
-    def test_embed_crops__full_image_crop_matches_embed_images(self) -> None:
+    def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
         with Image.open(cat_image_path) as image:
             width, height = image.size
 
         full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
-        crop_result = perception_encoder.embed_crops(crops=[full_crop])
+        crop_result = perception_encoder.embed_image_crops(crops=[full_crop])
         image_result = perception_encoder.embed_images(paths=[str(cat_image_path)])
 
         assert crop_result.embeddings.shape == (1, 512)


### PR DESCRIPTION
## What has changed and why?

Move `PerceptionEncoderEmbedder` off the old `EmbeddingGenerator` protocols and onto the capability-split `*Embedder` ABCs. Edits a previously copied `PerceptionEncoderEmbeddingGenerator` class.

- Bases: `ImageEmbeddingGenerator`/`VideoEmbeddingGenerator` → `ImagePathEmbedder`, `CropPathEmbedder`, `ImagePILEmbedder`, `TextEmbedder`, `VideoPathEmbedder`
- `embed_text` now batched: `list[str]` → `EmbeddingResult`
- `embed_image_crops` → `embed_crops`; `embed_pil_images` (returned `NDArray`) → `embed_frames` (returns `EmbeddingResult`)
- Drop `show_progress` from the protocol methods; rename `filepaths` → `paths`

## How has it been tested?

`make static-checks` (ruff + mypy) pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batched text embedding for more efficient processing.
  * Embedding operations now return consistent results containing embeddings and retained-item indices.
  * Added handling for empty text, crop, and frame inputs.

* **Breaking Changes**
  * Renamed crop and frame embedding methods and standardized image and video path arguments.
  * Removed progress-display options from image and crop embedding methods.
  * Updated frame embedding results to use the standard embedding result format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->