### PR TITLE
Implement MobileCLIPEmbedder on the Embedder interfaces

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/mobileclip_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/mobileclip_embedder.py
@@ -1,0 +1,172 @@
+"""MobileCLIP embedder.
+
+Wraps the MobileCLIP model behind the ``Embedder`` capability interfaces. It embeds
+images by path, image crops, PIL images and text into a shared embedding space, so
+text queries can be compared against image embeddings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from lightly_studio.dataset import file_utils
+from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
+from lightly_studio.embed import image_crop_embedding, image_embedding
+from lightly_studio.embed.embedder import (
+    ImageCropPathEmbedder,
+    ImagePathEmbedder,
+    ImagePILEmbedder,
+    TextEmbedder,
+)
+from lightly_studio.embed.image_embedding import EmbeddingContext
+from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, ImageCrop
+from lightly_studio.vendor import mobileclip
+
+MODEL_NAME = "mobileclip_s0"
+MOBILECLIP_DOWNLOAD_URL = (
+    f"https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/{MODEL_NAME}.pt"
+)
+MAX_BATCH_SIZE: int = 128
+EMBEDDING_DIMENSION: int = 512
+
+
+class MobileCLIPEmbedder(
+    ImagePathEmbedder,
+    ImageCropPathEmbedder,
+    ImagePILEmbedder,
+    TextEmbedder,
+):
+    """MobileCLIP embedding model.
+
+    Embeds images by path, image crops, video frames and text into one shared
+    embedding space. MobileCLIP cannot embed a whole video, so there is no video
+    capability; a video is covered frame by frame through ``embed_frames``.
+    """
+
+    __slots__ = ("_device", "_model", "_preprocess", "_tokenizer")
+
+    def __init__(self) -> None:
+        """Initialize the MobileCLIP embedding model.
+
+        This method loads the MobileCLIP model and its tokenizer. The model
+        checkpoint is downloaded and cached locally for future use.
+        """
+        model_path = _get_cached_mobileclip_checkpoint()
+        self._model, _, self._preprocess = mobileclip.create_model_and_transforms(
+            model_name=MODEL_NAME, pretrained=str(model_path)
+        )
+
+        # Auto select device: CUDA > MPS (Apple Silicon) > CPU
+        self._device = torch.device(
+            "cuda"
+            if torch.cuda.is_available()
+            else "mps"
+            if torch.backends.mps.is_available()
+            else "cpu"
+        )
+        self._model = self._model.to(self._device)
+        self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        """Describe the embedding space produced by this embedder.
+
+        Returns:
+            A specification of the embedding space.
+        """
+        return EmbeddingSpaceSpec(
+            space_key=MODEL_NAME,
+            dimension=EMBEDDING_DIMENSION,
+        )
+
+    def embed_images(self, paths: list[str]) -> EmbeddingResult:
+        """Embed images with MobileCLIP.
+
+        Args:
+            paths: fsspec paths of the images to embed.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+        return image_embedding.embed_image_files_batched(
+            filepaths=paths,
+            context=self._embedding_context(),
+            show_progress=True,
+        )
+
+    def embed_image_crops(self, crops: list[ImageCrop]) -> EmbeddingResult:
+        """Embed image crops with MobileCLIP.
+
+        Args:
+            crops: The crops to embed.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+        return image_crop_embedding.embed_image_crops_batched(
+            image_crops=crops,
+            context=self._embedding_context(),
+            show_progress=True,
+        )
+
+    def embed_frames(self, frames: list[Image.Image]) -> EmbeddingResult:
+        """Embed video frames with MobileCLIP.
+
+        Args:
+            frames: The frames to embed, as PIL images.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+        embeddings = image_embedding.embed_pil_images_batched(
+            images=frames,
+            context=self._embedding_context(),
+            show_progress=True,
+        )
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(frames))))
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        """Embed texts with MobileCLIP.
+
+        Args:
+            texts: The strings to embed.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+        if not texts:
+            empty = np.empty((0, EMBEDDING_DIMENSION), dtype=np.float32)
+            return EmbeddingResult(embeddings=empty, kept_indices=[])
+
+        tokenized = self._tokenizer(texts).to(self._device)
+        with torch.no_grad():
+            embeddings = self._model.encode_text(tokenized).cpu().numpy()  # type: ignore[operator]
+        return EmbeddingResult(
+            embeddings=embeddings.astype(np.float32), kept_indices=list(range(len(texts)))
+        )
+
+    def _embedding_context(self) -> EmbeddingContext:
+        """Build the model-specific configuration for batched image embedding."""
+        return EmbeddingContext(
+            embedding_dimension=EMBEDDING_DIMENSION,
+            max_batch_size=MAX_BATCH_SIZE,
+            device=self._device,
+            preprocess=self._preprocess,
+            encode_batch=lambda images_tensor: (
+                self._model.encode_image(images_tensor)  # type: ignore[operator]
+                .cpu()
+                .numpy()
+            ),
+        )
+
+
+def _get_cached_mobileclip_checkpoint() -> Path:
+    file_path = LIGHTLY_STUDIO_MODEL_CACHE_DIR / f"{MODEL_NAME}.pt"
+    file_utils.download_file_if_does_not_exist(
+        url=MOBILECLIP_DOWNLOAD_URL,
+        local_filename=file_path,
+    )
+    return file_path

--- a/lightly_studio/src/lightly_studio/embed/mobileclip_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/mobileclip_embedder.py
@@ -42,9 +42,9 @@ class MobileCLIPEmbedder(
 ):
     """MobileCLIP embedding model.
 
-    Embeds images by path, image crops, video frames and text into one shared
-    embedding space. MobileCLIP cannot embed a whole video, so there is no video
-    capability; a video is covered frame by frame through ``embed_frames``.
+    Embeds images by path, image crops, PIL images and text into one shared embedding
+    space. MobileCLIP cannot embed a whole video, so there is no video capability; a
+    video is covered frame by frame through ``embed_images_pil``.
     """
 
     __slots__ = ("_device", "_model", "_preprocess", "_tokenizer")
@@ -112,21 +112,23 @@ class MobileCLIPEmbedder(
             show_progress=True,
         )
 
-    def embed_frames(self, frames: list[Image.Image]) -> EmbeddingResult:
-        """Embed video frames with MobileCLIP.
+    def embed_images_pil(self, images: list[Image.Image]) -> EmbeddingResult:
+        """Embed PIL images with MobileCLIP.
 
         Args:
-            frames: The frames to embed, as PIL images.
+            images: The PIL images to embed.
 
         Returns:
             The embeddings and the indices of the inputs they cover.
         """
+        # TODO(Iunir, 09/2026): Let embed_pil_images_batched return an EmbeddingResult so
+        # the kept indices come from it instead of being assumed complete here.
         embeddings = image_embedding.embed_pil_images_batched(
-            images=frames,
+            images=images,
             context=self._embedding_context(),
             show_progress=True,
         )
-        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(frames))))
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(images))))
 
     def embed_text(self, texts: list[str]) -> EmbeddingResult:
         """Embed texts with MobileCLIP.

--- a/lightly_studio/tests/embed/test_mobileclip_embedder.py
+++ b/lightly_studio/tests/embed/test_mobileclip_embedder.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from lightly_studio.embed.mobileclip_embedder import (
+    EMBEDDING_DIMENSION,
+    MODEL_NAME,
+    MobileCLIPEmbedder,
+)
+from lightly_studio.embed.types import ImageCrop
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+class TestMobileCLIPEmbedder:
+    def test_embedding_space_spec(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+        space_spec = mobileclip.embedding_space_spec()
+
+        assert space_spec.space_key == MODEL_NAME
+        assert space_spec.dimension == EMBEDDING_DIMENSION
+
+    def test_embed_images(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+        cat_image_path = FIXTURES_DIR / "cat.jpg"
+
+        result = mobileclip.embed_images(paths=[str(cat_image_path)])
+
+        assert result.kept_indices == [0]
+        assert result.embeddings.shape == (1, 512)
+
+        # Normalise and test a few values.
+        cat_embedding_normed = result.embeddings[0]
+        cat_embedding_normed /= np.linalg.norm(cat_embedding_normed)
+        assert np.isclose(cat_embedding_normed[0], 0.0418, atol=1e-4)
+        assert np.isclose(cat_embedding_normed[1], 0.0563, atol=1e-4)
+        assert np.isclose(cat_embedding_normed[2], -0.0272, atol=1e-4)
+        assert np.isclose(cat_embedding_normed[3], 0.0319, atol=1e-4)
+
+    def test_embed_image_crops__empty_input(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+
+        result = mobileclip.embed_image_crops(crops=[])
+
+        assert result.embeddings.shape == (0, 512)
+        assert result.kept_indices == []
+
+    def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+        cat_image_path = FIXTURES_DIR / "cat.jpg"
+        with Image.open(cat_image_path) as image:
+            width, height = image.size
+
+        full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
+        crop_result = mobileclip.embed_image_crops(crops=[full_crop])
+        image_result = mobileclip.embed_images(paths=[str(cat_image_path)])
+
+        assert crop_result.embeddings.shape == (1, 512)
+        assert crop_result.kept_indices == [0]
+        # A crop covering the entire image is preprocessed and encoded identically
+        # to the full image, so the embeddings must match.
+        assert np.allclose(crop_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
+
+    def test_embed_frames__empty_input(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+
+        result = mobileclip.embed_frames(frames=[])
+
+        assert result.embeddings.shape == (0, 512)
+        assert result.kept_indices == []
+
+    def test_embed_frames__matches_embed_images(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+        cat_image_path = FIXTURES_DIR / "cat.jpg"
+        with Image.open(cat_image_path) as image:
+            cat_pil_image = image.convert("RGB")
+
+        frame_result = mobileclip.embed_frames(frames=[cat_pil_image])
+        image_result = mobileclip.embed_images(paths=[str(cat_image_path)])
+
+        assert frame_result.embeddings.shape == (1, 512)
+        assert frame_result.kept_indices == [0]
+        # An in-memory PIL image is preprocessed and encoded identically to the same
+        # image loaded from disk, so the embeddings must match.
+        assert np.allclose(frame_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
+
+    def test_embed_text(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+
+        result = mobileclip.embed_text(texts=["a cat"])
+
+        assert result.kept_indices == [0]
+        assert result.embeddings.shape == (1, 512)
+
+        # Normalise and test a few values.
+        embedding_normed = result.embeddings[0]
+        embedding_normed /= np.linalg.norm(embedding_normed)
+        assert np.isclose(embedding_normed[0], 0.0072, atol=1e-4)
+        assert np.isclose(embedding_normed[1], 0.0242, atol=1e-4)
+        assert np.isclose(embedding_normed[2], 0.0922, atol=1e-4)
+        assert np.isclose(embedding_normed[3], 0.0159, atol=1e-4)
+
+    def test_embed_text__empty_input(self) -> None:
+        mobileclip = MobileCLIPEmbedder()
+
+        result = mobileclip.embed_text(texts=[])
+
+        assert result.embeddings.shape == (0, 512)
+        assert result.embeddings.dtype == np.float32
+        assert result.kept_indices == []
+
+    def test_classification(self) -> None:
+        """End-to-end test for embedding consistency.
+
+        Embed texts "a cat", "a dog" and "a tiger". Compare with
+        "cat.jpg" image embedding using cosine distance.
+        Pick a classification with softmax.
+        """
+        mobileclip = MobileCLIPEmbedder()
+
+        # Embed texts.
+        text_emb = torch.from_numpy(
+            mobileclip.embed_text(texts=["a cat", "a dog", "a tiger"]).embeddings
+        )
+        text_emb /= text_emb.norm(dim=-1, keepdim=True)
+
+        # Embed image.
+        cat_image_path = FIXTURES_DIR / "cat.jpg"
+        cat_image_emb = torch.from_numpy(
+            mobileclip.embed_images(paths=[str(cat_image_path)]).embeddings[0]
+        )
+        cat_image_emb /= cat_image_emb.norm(dim=-1, keepdim=True)
+
+        # Compute softmax similarity as in ml-mobileclip repo example.
+        text_probs = (100.0 * cat_image_emb @ text_emb.T).softmax(dim=-1)
+        assert np.isclose(text_probs[0], 1.0, atol=1e-3)
+        assert np.isclose(text_probs[1], 0.0, atol=1e-3)
+        assert np.isclose(text_probs[2], 0.0, atol=1e-3)

--- a/lightly_studio/tests/embed/test_mobileclip_embedder.py
+++ b/lightly_studio/tests/embed/test_mobileclip_embedder.py
@@ -65,28 +65,28 @@ class TestMobileCLIPEmbedder:
         # to the full image, so the embeddings must match.
         assert np.allclose(crop_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
 
-    def test_embed_frames__empty_input(self) -> None:
+    def test_embed_images_pil__empty_input(self) -> None:
         mobileclip = MobileCLIPEmbedder()
 
-        result = mobileclip.embed_frames(frames=[])
+        result = mobileclip.embed_images_pil(images=[])
 
         assert result.embeddings.shape == (0, 512)
         assert result.kept_indices == []
 
-    def test_embed_frames__matches_embed_images(self) -> None:
+    def test_embed_images_pil__matches_embed_images(self) -> None:
         mobileclip = MobileCLIPEmbedder()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
         with Image.open(cat_image_path) as image:
             cat_pil_image = image.convert("RGB")
 
-        frame_result = mobileclip.embed_frames(frames=[cat_pil_image])
+        pil_image_result = mobileclip.embed_images_pil(images=[cat_pil_image])
         image_result = mobileclip.embed_images(paths=[str(cat_image_path)])
 
-        assert frame_result.embeddings.shape == (1, 512)
-        assert frame_result.kept_indices == [0]
+        assert pil_image_result.embeddings.shape == (1, 512)
+        assert pil_image_result.kept_indices == [0]
         # An in-memory PIL image is preprocessed and encoded identically to the same
         # image loaded from disk, so the embeddings must match.
-        assert np.allclose(frame_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
+        assert np.allclose(pil_image_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
 
     def test_embed_text(self) -> None:
         mobileclip = MobileCLIPEmbedder()


### PR DESCRIPTION
## What has changed and why?

Adds `MobileCLIPEmbedder` next to `perception_encoder_embedder.py`, duplicating `MobileCLIPEmbeddingGenerator` onto the capability interfaces `ImagePathEmbedder`, `ImageCropPathEmbedder`, `ImagePILEmbedder` and `TextEmbedder`. Same move as #2209 did for the Perception Encoder.

- `embed_text` is batched: `list[str]` → `EmbeddingResult`. `embed_pil_images` → `embed_frames`, also returning `EmbeddingResult`. `show_progress` is gone.
- No `VideoPathEmbedder`: MobileCLIP cannot embed a whole video, only its frames.
- `MobileCLIPEmbeddingGenerator` is untouched and still what production uses. Migrating its callers is follow-up work, as on #2209.

## How has it been tested?

`tests/embed/test_mobileclip_embedder.py`, ported from the generator's tests. It keeps the reference values for `cat.jpg` and `"a cat"`, so the port is checked to produce the same vectors, and adds empty-input cases. 9 passed, `make static-checks` clean.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Reviewer: @michal-lightly, or @JonasWurst.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MobileCLIP-based image and text embeddings in a shared 512-dimensional space.
  * Supports image files, image crops, in-memory images, and text inputs.
  * Automatically selects available hardware and caches the required model.

* **Tests**
  * Added coverage for embedding outputs, empty inputs, image crops, and image-text classification similarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->