### PR TITLE
Rename embed_frames to embed_images_pil

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -1,7 +1,7 @@
 """Capability-split embedder interfaces.
 
 Defines the ``Embedder`` base class and one abstract subclass per input a model
-can embed: images and crops by path, videos, video frames, text, and images by
+can embed: images and crops by path, videos, PIL images, text, and images by
 bytes. A concrete model implements only the capabilities it supports, and
 callers pick an embedder by the capability they need.
 """
@@ -35,7 +35,7 @@ class Capability(str, Enum):
     """Ingest: video by fsspec path."""
 
     IMAGE_PIL = "image_pil"
-    """Ingest: video frame as a PIL image."""
+    """Ingest: image represented as a PIL image."""
 
     TEXT = "text"
     """Interactive: text query."""
@@ -129,7 +129,7 @@ class VideoPathEmbedder(Embedder):
 
 
 class ImagePILEmbedder(Embedder):
-    """Embeds video frames given as PIL images.
+    """Embeds images represented as PIL images.
 
     <span class="doc-badge doc-badge--beta">Beta</span>
     """
@@ -137,11 +137,11 @@ class ImagePILEmbedder(Embedder):
     __slots__ = ()
 
     @abstractmethod
-    def embed_frames(self, frames: list[Image]) -> EmbeddingResult:
-        """Embed a batch of video frames.
+    def embed_images_pil(self, images: list[Image]) -> EmbeddingResult:
+        """Embed a batch of PIL images.
 
         Args:
-            frames: The frames to embed, as PIL images.
+            images: The PIL images to embed.
 
         Returns:
             The embeddings and the indices of the inputs they cover.

--- a/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/perception_encoder_embedder.py
@@ -131,21 +131,21 @@ class PerceptionEncoderEmbedder(
             show_progress=True,
         )
 
-    def embed_frames(self, frames: list[Image.Image]) -> EmbeddingResult:
-        """Embed video frames with Perception Encoder.
+    def embed_images_pil(self, images: list[Image.Image]) -> EmbeddingResult:
+        """Embed PIL images with Perception Encoder.
 
         Args:
-            frames: The frames to embed, as PIL images.
+            images: The PIL images to embed.
 
         Returns:
             The embeddings and the indices of the inputs they cover.
         """
         embeddings = image_embedding.embed_pil_images_batched(
-            images=frames,
+            images=images,
             context=self._embedding_context(),
             show_progress=True,
         )
-        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(frames))))
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(images))))
 
     def _embedding_context(self) -> EmbeddingContext:
         """Build the model-specific configuration for batched image embedding."""

--- a/lightly_studio/src/lightly_studio/embed/random_embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/random_embedder.py
@@ -61,9 +61,9 @@ class RandomEmbedder(
         """Return a random vector for each video path."""
         return self._random_result(count=len(paths))
 
-    def embed_frames(self, frames: list[Image]) -> EmbeddingResult:
-        """Return a random vector for each frame."""
-        return self._random_result(count=len(frames))
+    def embed_images_pil(self, images: list[Image]) -> EmbeddingResult:
+        """Return a random vector for each PIL image."""
+        return self._random_result(count=len(images))
 
     def embed_text(self, texts: list[str]) -> EmbeddingResult:
         """Return a random vector for each text string."""

--- a/lightly_studio/tests/embed/test_perception_encoder_embedder.py
+++ b/lightly_studio/tests/embed/test_perception_encoder_embedder.py
@@ -89,27 +89,27 @@ class TestPerceptionEncoderEmbedder:
         # to the full image, so the embeddings must match.
         assert np.allclose(crop_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
 
-    def test_embed_frames__empty_input(self) -> None:
+    def test_embed_images_pil__empty_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
-        result = perception_encoder.embed_frames(frames=[])
+        result = perception_encoder.embed_images_pil(images=[])
 
         assert result.embeddings.shape == (0, 512)
         assert result.kept_indices == []
 
-    def test_embed_frames__matches_embed_images(self) -> None:
+    def test_embed_images_pil__matches_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
         with Image.open(cat_image_path) as image:
             cat_pil_image = image.convert("RGB")
 
-        frame_result = perception_encoder.embed_frames(frames=[cat_pil_image])
+        pil_image_result = perception_encoder.embed_images_pil(images=[cat_pil_image])
         image_result = perception_encoder.embed_images(paths=[str(cat_image_path)])
 
-        assert frame_result.embeddings.shape == (1, 512)
-        assert frame_result.kept_indices == [0]
+        assert pil_image_result.embeddings.shape == (1, 512)
+        assert pil_image_result.kept_indices == [0]
         # An in-memory PIL image is preprocessed and encoded identically to the same
         # image loaded from disk, so the embeddings must match.
-        assert np.allclose(frame_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
+        assert np.allclose(pil_image_result.embeddings[0], image_result.embeddings[0], atol=1e-4)
 
     def test_embed_videos(self) -> None:
         perception_encoder = PerceptionEncoderEmbedder()

--- a/lightly_studio/tests/embed/test_random_embedder.py
+++ b/lightly_studio/tests/embed/test_random_embedder.py
@@ -40,11 +40,11 @@ class TestRandomEmbedder:
         assert result.embeddings.shape == (3, 4)
         assert result.kept_indices == [0, 1, 2]
 
-    def test_embed_frames(self) -> None:
+    def test_embed_images_pil(self) -> None:
         embedder = RandomEmbedder(dimension=4)
-        frames = [Image.new("RGB", (2, 2))]
+        images = [Image.new("RGB", (2, 2))]
 
-        result = embedder.embed_frames(frames=frames)
+        result = embedder.embed_images_pil(images=images)
 
         assert result.embeddings.shape == (1, 4)
         assert result.kept_indices == [0]


### PR DESCRIPTION
## What has changed and why?

- Rename `embed_frames` to `embed_images_pil` to reflect that the capability accepts any PIL image, not only video frames.
- Align parameter names, docstrings, and tests with the broader API.

## How has it been tested?

- `uv run ruff check src/lightly_studio/embed/embedder.py src/lightly_studio/embed/perception_encoder_embedder.py src/lightly_studio/embed/random_embedder.py tests/embed/test_perception_encoder_embedder.py tests/embed/test_random_embedder.py`
- `uv run pytest tests/embed/test_random_embedder.py tests/embed/test_perception_encoder_embedder.py`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Alternative reviewer: @JonasWurst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Renamed the PIL image embedding API from `embed_frames` to `embed_images_pil`.
  * Updated embedding capabilities and descriptions to refer to general PIL images rather than video frames.
  * Updated supported embedders and related validation to use the renamed API.

* **Tests**
  * Updated embedding tests to reflect the new method name and image terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->