### PR TITLE
Remove: Unused num_decode_threads option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   format and always writes the scikit-learn format, which is the only one LightlyStudio can load.
 - Drop the legacy `embedding_model_hash` field from the classifier export format. Classifiers
   exported by older versions can no longer be loaded.
+- Removed the unused num_decode_threads option for adding videos.
 
 ### Fixed
 

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -95,7 +95,6 @@ class VideoLoadContext:
     collection_id: UUID
     video_frames_collection_id: UUID
     video_channel: int
-    num_decode_threads: int | None
     target_fps: float | None
     embed_frames: bool
     embedding_model_id: UUID | None
@@ -106,7 +105,6 @@ def load_into_collection_from_paths(  # noqa: PLR0913
     collection_id: UUID,
     video_paths: Iterable[str],
     video_channel: int = DEFAULT_VIDEO_CHANNEL,
-    num_decode_threads: int | None = None,
     show_progress: bool = True,
     target_fps: float | None = None,
     embed_frames: bool = False,
@@ -119,8 +117,6 @@ def load_into_collection_from_paths(  # noqa: PLR0913
         sample_type == SampleType.VIDEO.
         video_paths: An iterable of file paths to the videos to load.
         video_channel: The video channel from which frames are loaded.
-        num_decode_threads: Optional override for the number of FFmpeg decode threads.
-            If omitted, the available CPU cores - 1 (max 16) are used.
         show_progress: Whether to display a progress bar and final summary of loading results.
         target_fps: Optional target frame rate for subsampling. When set below the source
             frame rate, only selected frames are kept. frame_number values remain
@@ -172,7 +168,6 @@ def load_into_collection_from_paths(  # noqa: PLR0913
         collection_id=collection_id,
         video_frames_collection_id=video_frames_collection_id,
         video_channel=video_channel,
-        num_decode_threads=num_decode_threads,
         target_fps=target_fps,
         embed_frames=effective_embed_frames,
         embedding_model_id=embedding_model_id,
@@ -284,7 +279,6 @@ def _load_single_video(
                     context=extraction_context,
                     video_container=video_container,
                     video_channel=context.video_channel,
-                    num_decode_threads=context.num_decode_threads,
                     target_fps=context.target_fps,
                 )
             except (OSError, FFmpegError) as e:
@@ -472,7 +466,6 @@ def _create_video_frame_samples(
     context: FrameExtractionContext,
     video_container: InputContainer,
     video_channel: int,
-    num_decode_threads: int | None = None,
     target_fps: float | None = None,
 ) -> list[UUID]:
     """Create video frame samples for a video by parsing all frames.
@@ -484,7 +477,6 @@ def _create_video_frame_samples(
         context: Frame extraction context (session, dataset and parent video).
         video_container: The PyAV container with the opened video.
         video_channel: The video channel from which frames are loaded.
-        num_decode_threads: Optional override for FFmpeg decode thread count.
         target_fps: Optional target frame rate for subsampling. If set and lower than the
             source frame rate, only a subset of frames is persisted; kept frames retain
             their original frame_number. If omitted, all frames are persisted.
@@ -496,7 +488,7 @@ def _create_video_frame_samples(
     samples_to_create: list[VideoFrameCreate] = []
     pil_frames: list[Image.Image] = []
     video_stream = video_container.streams.video[video_channel]
-    _configure_stream_threading(video_stream=video_stream, num_decode_threads=num_decode_threads)
+    _configure_stream_threading(video_stream=video_stream)
 
     # Get time base for converting PTS to seconds
     time_base = video_stream.time_base if video_stream.time_base else None
@@ -576,7 +568,9 @@ def _flush_frame_batch(
     return created_sample_ids
 
 
-def _configure_stream_threading(video_stream: VideoStream, num_decode_threads: int | None) -> None:
+def _configure_stream_threading(
+    video_stream: VideoStream, num_decode_threads: int | None = None
+) -> None:
     """Configure codec-level threading for faster decode when available."""
     codec_context = getattr(video_stream, "codec_context", None)
     if codec_context is None:

--- a/lightly_studio/src/lightly_studio/core/video/create_video.py
+++ b/lightly_studio/src/lightly_studio/core/video/create_video.py
@@ -21,8 +21,6 @@ class CreateVideo(CreateSample):
     """The file path of the video to be created."""
     video_channel: int = DEFAULT_VIDEO_CHANNEL
     """The video channel to be used for loading the video."""
-    num_decode_threads: int | None = None
-    """The number of threads to use for decoding the video."""
 
     def create_in_collection(self, session: Session, collection_id: UUID) -> UUID:
         """Create a video sample in the specified collection.
@@ -42,7 +40,6 @@ class CreateVideo(CreateSample):
             collection_id=collection_id,
             video_paths=[self.path],
             video_channel=self.video_channel,
-            num_decode_threads=self.num_decode_threads,
             show_progress=False,
         )
         if len(video_path_to_id) != 1:

--- a/lightly_studio/src/lightly_studio/core/video/video_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_dataset.py
@@ -120,7 +120,6 @@ class VideoDataset(BaseSampleDataset[VideoSample]):
         self,
         path: PathLike,
         allowed_extensions: Iterable[str] | None = None,
-        num_decode_threads: int | None = None,
         embed: bool = True,
         embed_frames: bool = True,
         target_fps: float | None = None,
@@ -133,8 +132,6 @@ class VideoDataset(BaseSampleDataset[VideoSample]):
             allowed_extensions: An iterable container of allowed video file
                 extensions in lowercase, including the leading dot. If None,
                 uses default VIDEO_EXTENSIONS.
-            num_decode_threads: Optional override for the number of FFmpeg decode threads.
-                If omitted, the available CPU cores - 1 (max 16) are used.
             embed: If True, generate embeddings for the newly added videos.
             embed_frames: If True, generate image embeddings for the extracted video frames
                 during decoding.
@@ -157,7 +154,6 @@ class VideoDataset(BaseSampleDataset[VideoSample]):
             session=self.session,
             collection_id=self.collection_id,
             video_paths=video_paths,
-            num_decode_threads=num_decode_threads,
             target_fps=target_fps,
             embed_frames=embed_frames,
         )

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -231,7 +231,6 @@ def _fail_after_frame_creation(
         context: FrameExtractionContext,
         video_container: InputContainer,
         video_channel: int,
-        num_decode_threads: int | None = None,
         target_fps: float | None = None,
     ) -> list[UUID]:
         video = video_resolver.get_by_id(session=context.session, sample_id=context.video_sample_id)
@@ -255,7 +254,6 @@ def _fail_after_frame_creation(
             context=context,
             video_container=video_container,
             video_channel=video_channel,
-            num_decode_threads=num_decode_threads,
             target_fps=target_fps,
         )
 


### PR DESCRIPTION
## What has changed and why?

- add_videos_from_path accepted a num_decode_threads setting that let you pick how many CPU threads decode a video.
- we never passed it in the codebase, and the code always worked out a sensible number on its own.
- We remove the option so there's one less knob to get wrong. Video decoding still uses all available cores.

## How has it been tested?

- Update tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed the unused `num_decode_threads` option from video-loading and dataset APIs.
  * Video decoding now automatically determines thread usage based on available CPU cores, with a capped limit.
  * Updated the changelog to document this removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->