### PR TITLE
Fix: Read videos ahead of decoding to speedup remote storage

### DIFF
--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -6,10 +6,11 @@ import itertools
 import logging
 import math
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
-from typing import cast
+from typing import BinaryIO, cast
 from uuid import UUID
 
 import av
@@ -36,11 +37,13 @@ from tqdm import tqdm
 
 from lightly_studio.core import labelformat_helpers, path_utils
 from lightly_studio.core.file_outcome_report import (
-    AlreadyPresentInputFileError,
     BrokenInputFileError,
+    FileOutcome,
     FileOutcomeReport,
+    InputFileError,
     MissingInputFileError,
 )
+from lightly_studio.dataset import remote_storage
 from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
@@ -56,12 +59,17 @@ from lightly_studio.resolvers import (
     video_frame_resolver,
     video_resolver,
 )
+from lightly_studio.utils import parallelize
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_VIDEO_CHANNEL = 0
 # Number of samples to process in a single batch
 SAMPLE_BATCH_SIZE = 128
+
+# Bound read-ahead; the current video and I/O buffers use additional memory.
+_MAX_FETCH_WORKERS = 3
+_MAX_BUFFERED_VIDEO_BYTES = 128 * 2**20
 
 # Video file extensions
 # These are commonly supported by PyAV/FFmpeg.
@@ -99,6 +107,15 @@ class VideoLoadContext:
     target_fps: float | None
     embed_frames: bool
     embedding_model_id: UUID | None
+
+
+@dataclass
+class _FetchedVideo:
+    """Fetched bytes, an input error, or no content when buffering was skipped."""
+
+    path: str
+    content: bytes | None = None
+    error: InputFileError | None = None
 
 
 def load_into_collection_from_paths(  # noqa: PLR0913
@@ -178,24 +195,29 @@ def load_into_collection_from_paths(  # noqa: PLR0913
         embedding_model_id=embedding_model_id,
     )
 
-    # TODO(Malte, 07/2026): Parallelize video indexing across videos with
-    # parallelize.thread_imap_lazy (one task per whole video, never split a video;
-    # workers and prefetch stay bounded) to overlap remote reads. Decode single-threaded
-    # per video and keep DB writes and embedding on a single thread, as neither the
-    # session nor the model is thread-safe.
-    for video_path in tqdm(
-        video_paths_list,
+    paths_to_load: list[str] = []
+    for video_path in video_paths_list:
+        if video_path in seen_or_existing_paths:
+            report.record(path=video_path, outcome=FileOutcome.ALREADY_PRESENT)
+            continue
+        seen_or_existing_paths.add(video_path)
+        paths_to_load.append(video_path)
+
+    fetched_videos = tqdm(
+        _fetch_videos(video_paths=paths_to_load),
         desc="Loading frames from videos",
         unit=" video",
+        total=len(paths_to_load),
         disable=not show_progress,
-    ):
-        with report.track(path=video_path):
-            video_sample_id, frame_sample_ids = _load_single_video(
-                context=load_context,
-                video_path=video_path,
-                seen_or_existing_paths=seen_or_existing_paths,
+    )
+    for fetched in fetched_videos:
+        with report.track(path=fetched.path):
+            if fetched.error is not None:
+                raise fetched.error
+            video_sample_id, frame_sample_ids = _load_video_from(
+                context=load_context, fetched=fetched
             )
-            created_video_path_to_id[video_path] = video_sample_id
+            created_video_path_to_id[fetched.path] = video_sample_id
             created_video_frame_sample_ids.extend(frame_sample_ids)
 
     report.log_summary()
@@ -204,34 +226,60 @@ def load_into_collection_from_paths(  # noqa: PLR0913
     return created_video_path_to_id, created_video_frame_sample_ids
 
 
+def _fetch_videos(video_paths: list[str]) -> Iterator[_FetchedVideo]:
+    """Prefetch bytes; decoding, database writes, and embedding stay on the caller."""
+    yield from parallelize.thread_imap_lazy(
+        function=_fetch_video, iterable=video_paths, max_workers=_MAX_FETCH_WORKERS
+    )
+
+
+def _fetch_video(video_path: str) -> _FetchedVideo:
+    """Buffer small remote videos; return input errors so ingestion can continue."""
+    try:
+        fs, fs_path = fsspec.core.url_to_fs(url=video_path)
+        video_size = fs.info(fs_path).get("size")
+        if (
+            not remote_storage.is_remote(video_path)
+            or video_size is None
+            or video_size > _MAX_BUFFERED_VIDEO_BYTES
+        ):
+            return _FetchedVideo(path=video_path)
+        return _FetchedVideo(path=video_path, content=fs.cat_file(fs_path))
+    except FileNotFoundError:
+        return _FetchedVideo(path=video_path, error=MissingInputFileError())
+    except OSError:
+        return _FetchedVideo(path=video_path, error=BrokenInputFileError())
+
+
+def _load_video_from(context: VideoLoadContext, fetched: _FetchedVideo) -> tuple[UUID, list[UUID]]:
+    """Decode buffered bytes or open the original file."""
+    if fetched.content is not None:
+        return _load_single_video(
+            context=context, video_path=fetched.path, video_file=BytesIO(fetched.content)
+        )
+    # ``_load_single_video`` takes ownership of the file object and closes it.
+    fs, fs_path = fsspec.core.url_to_fs(url=fetched.path)
+    return _load_single_video(
+        context=context, video_path=fetched.path, video_file=fs.open(path=fs_path, mode="rb")
+    )
+
+
 def _load_single_video(
     context: VideoLoadContext,
     video_path: str,
-    seen_or_existing_paths: set[str],
+    video_file: BinaryIO,
 ) -> tuple[UUID, list[UUID]]:
     """Load one video and its frames, returning the created video and frame sample IDs.
 
-    Raises a ``FileOutcomeReport`` error (already-present, missing, or broken) when the
-    video cannot be loaded, so the caller's ``report.track`` block can record the outcome.
+    Raises a ``FileOutcomeReport`` error (broken) when the video cannot be loaded, so the
+    caller's ``report.track`` block can record the outcome.
     """
-    # Skip paths already in the database or already seen in this call.
-    if video_path in seen_or_existing_paths:
-        raise AlreadyPresentInputFileError()
-    seen_or_existing_paths.add(video_path)
-
-    # Detect a missing path proactively: FileNotFoundError is unreliable across
-    # fsspec backends and is a subclass of OSError, which we treat as broken.
-    fs, fs_path = fsspec.core.url_to_fs(url=video_path)
-    if not fs.exists(fs_path):
-        raise MissingInputFileError()
-
-    video_file = fs.open(path=fs_path, mode="rb")
     try:
         # Open the container first: if this fails there is nothing to close, so the
         # failed open is translated into a broken-file signal at this I/O boundary.
         try:
             # Open video container for reading (returns InputContainer)
-            video_container = container.open(file=video_file)
+            video_container = container.open(file=video_file, mode="r")
         except (OSError, FFmpegError) as e:
             raise BrokenInputFileError() from e
 
@@ -242,7 +290,8 @@ def _load_single_video(
                 video_stream = video_container.streams.video[context.video_channel]
 
                 # Get video metadata
-                framerate = float(video_stream.average_rate) or 0.0
+                # average_rate is None for streams with no declared rate.
+                framerate = float(video_stream.average_rate) if video_stream.average_rate else 0.0
                 video_width = video_stream.width or 0
                 video_height = video_stream.height or 0
                 if video_stream.duration and video_stream.time_base:

--- a/lightly_studio/src/lightly_studio/dataset/remote_storage.py
+++ b/lightly_studio/src/lightly_studio/dataset/remote_storage.py
@@ -11,9 +11,14 @@ from lightly_studio.dataset import env
 _LOCAL_PROTOCOLS = frozenset(("file", "local"))
 
 
+def is_remote(path: str) -> bool:
+    """Return whether the path lives on remote storage rather than a local filesystem."""
+    return fsspec.utils.get_protocol(path) not in _LOCAL_PROTOCOLS
+
+
 def image_probe_workers(paths: Iterable[str]) -> int:
     """Return the configured worker count when any path is remote, otherwise one."""
-    if any(fsspec.utils.get_protocol(path) not in _LOCAL_PROTOCOLS for path in paths):
+    if any(is_remote(path) for path in paths):
         return env.LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS
     return 1
 

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -266,6 +266,79 @@ def _fail_after_frame_creation(
     )
 
 
+@pytest.mark.parametrize("reported_size", [None, 128 * 2**20, 128 * 2**20 + 1])
+def test_load_into_collection_from_paths__reads_remote_videos(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture, reported_size: int | None
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    local_path = create_video_file(output_path=tmp_path / "video.mp4", num_frames=5, fps=5)
+    remote_path = _write_to_memory_filesystem(local_path=local_path, name="video.mp4")
+
+    fs, _ = fsspec.core.url_to_fs(url=remote_path)
+    mocker.patch.object(type(fs), "info", return_value={"size": reported_size})
+    download = mocker.spy(type(fs), "cat_file")
+
+    video_path_to_id, frame_sample_ids = add_videos.load_into_collection_from_paths(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video_paths=[remote_path, remote_path],
+        show_progress=False,
+    )
+
+    assert set(video_path_to_id) == {remote_path}
+    video = video_resolver.get_by_id(session=db_session, sample_id=video_path_to_id[remote_path])
+    assert video is not None
+    assert video.file_path_abs == remote_path
+    assert video.fps == 5
+    assert sorted(frame.frame_number for frame in video.frames) == list(range(5))
+    assert download.call_count == (reported_size == 128 * 2**20)
+    assert len(frame_sample_ids) == 5
+
+
+def test__fetch_video__leaves_local_files_unread(tmp_path: Path, mocker: MockerFixture) -> None:
+    """A local file is decoded straight from disk, so reading it up front is skipped."""
+    local_path = create_video_file(output_path=tmp_path / "video.mp4", num_frames=2, fps=1)
+
+    fs, _ = fsspec.core.url_to_fs(url=str(local_path))
+    download = mocker.spy(type(fs), "cat_file")
+
+    fetched = add_videos._fetch_video(video_path=str(local_path))
+
+    assert fetched.error is None
+    assert fetched.content is None
+    download.assert_not_called()
+
+
+def test_load_into_collection_from_paths__continues_after_download_failure(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    local_path = create_video_file(output_path=tmp_path / "video.mp4", num_frames=2, fps=1)
+    remote_path = _write_to_memory_filesystem(local_path=local_path, name="broken.mp4")
+    fs, _ = fsspec.core.url_to_fs(url=remote_path)
+    mocker.patch.object(type(fs), "cat_file", side_effect=OSError("Download failed"))
+
+    with caplog.at_level("INFO"):
+        videos, frames = add_videos.load_into_collection_from_paths(
+            session=db_session,
+            collection_id=collection.collection_id,
+            video_paths=[remote_path, str(local_path)],
+            show_progress=False,
+        )
+
+    assert set(videos) == {str(local_path)}
+    assert len(frames) == 2
+    assert "broken=1" in caplog.text
+
+
+def _write_to_memory_filesystem(local_path: Path, name: str) -> str:
+    """Copy a file onto fsspec's in-memory filesystem and return its remote-style path."""
+    memory_path = f"memory://videos/{name}"
+    filesystem, filesystem_path = fsspec.core.url_to_fs(url=memory_path)
+    filesystem.pipe_file(filesystem_path, local_path.read_bytes())
+    return memory_path
+
+
 def test__create_video_frame_samples(db_session: Session, tmp_path: Path) -> None:
     """Test _create_video_frame_samples function directly."""
     collection = create_collection(db_session, sample_type=SampleType.VIDEO)

--- a/lightly_studio/tests/dataset/test_remote_storage.py
+++ b/lightly_studio/tests/dataset/test_remote_storage.py
@@ -7,6 +7,20 @@ from pytest_mock import MockerFixture
 from lightly_studio.dataset import env, remote_storage
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/videos/a.mp4", False),
+        ("file:///videos/a.mp4", False),
+        ("local:///videos/a.mp4", False),
+        ("s3://bucket/a.mp4", True),
+        ("gs://bucket/a.mp4", True),
+    ],
+)
+def test_is_remote(path: str, expected: bool) -> None:
+    assert remote_storage.is_remote(path=path) is expected
+
+
 def test_image_probe_workers(mocker: MockerFixture) -> None:
     mocker.patch.object(env, "LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS", 7)
 


### PR DESCRIPTION
## What has changed and why?

- When fetching videos from remote storage we prefetch now bigger chunks of the individual video files to reduce overhead from latency.
- This speeds up processing with cloud storage in high latency environments (e.g. processing videos from a bucket in a different cloud provider or country)
- We limit prefetching to 128MB to avoid memory issues.

## How has it been tested?

- new unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for ingesting videos from remote storage locations.
  - Video ingestion now loads multiple videos in parallel for improved throughput.
  - Duplicate video paths are automatically ignored.

- **Bug Fixes**
  - Failed video downloads are reported as broken items while processing continues for remaining videos.
  - Local videos are loaded directly without unnecessary upfront buffering.

- **Reliability**
  - Added handling for remote and local paths across supported storage protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->