### PR TITLE
Add embed_samples interface and migrate callers off EmbeddingManager

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image_embedding.py
@@ -10,29 +10,21 @@ from pathlib import Path
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 from fastapi import Path as FastAPIPath
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_INTERNAL_SERVER_ERROR
-from lightly_studio.dataset.embedding_manager import (
-    EmbeddingManager,
-    EmbeddingManagerProvider,
-)
+from lightly_studio.embed import embed_samples
 
 logger = logging.getLogger(__name__)
 
 image_embedding_router = APIRouter()
-EmbeddingManagerDep = Annotated[
-    EmbeddingManager,
-    Depends(lambda: EmbeddingManagerProvider.get_embedding_manager()),  # noqa: PLW0108
-]
 
 
 @image_embedding_router.post(
     "/image_embedding/from_file/for_collection/{collection_id}", response_model=list[float]
 )
 def embed_image_from_file(
-    embedding_manager: EmbeddingManagerDep,
     collection_id: Annotated[UUID, FastAPIPath(title="The ID of the collection.")],
     file: Annotated[UploadFile, File(description="The image file to embed.")],
     embedding_model_id: Annotated[
@@ -41,6 +33,11 @@ def embed_image_from_file(
     ] = None,
 ) -> list[float]:
     """Retrieve embeddings for the uploaded image file."""
+    if embedding_model_id is not None:
+        raise NotImplementedError(
+            "Per-request embedding model override is not supported; the collection's "
+            "default embedding model is always used."
+        )
     try:
         suffix = Path(file.filename).suffix if file.filename else ".jpg"
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
@@ -48,10 +45,8 @@ def embed_image_from_file(
             tmp_path = tmp.name
 
         try:
-            return embedding_manager.compute_image_embedding(
-                collection_id=collection_id,
-                filepath=tmp_path,
-                embedding_model_id=embedding_model_id,
+            return embed_samples.embed_image_for_collection(
+                collection_id=collection_id, filepath=tmp_path
             )
         finally:
             if os.path.exists(tmp_path):

--- a/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
@@ -5,30 +5,20 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query
 
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_INTERNAL_SERVER_ERROR,
 )
-from lightly_studio.dataset.embedding_manager import (
-    EmbeddingManager,
-    EmbeddingManagerProvider,
-    TextEmbedQuery,
-)
+from lightly_studio.embed import embed_samples
 
 text_embedding_router = APIRouter()
-# Define a type alias for the EmbeddingManager dependency
-EmbeddingManagerDep = Annotated[
-    EmbeddingManager,
-    Depends(lambda: EmbeddingManagerProvider.get_embedding_manager()),  # noqa: PLW0108
-]
 
 
 @text_embedding_router.get(
     "/text_embedding/for_collection/{collection_id}", response_model=list[float]
 )
 def embed_text(
-    embedding_manager: EmbeddingManagerDep,
     collection_id: Annotated[UUID, Path(title="The ID of the collection for which to embed.")],
     query_text: str = Query(..., description="The text to embed."),
     embedding_model_id: Annotated[
@@ -37,10 +27,14 @@ def embed_text(
     ] = None,
 ) -> list[float]:
     """Retrieve embeddings for the input text."""
+    if embedding_model_id is not None:
+        raise NotImplementedError(
+            "Per-request embedding model override is not supported; the collection's "
+            "default embedding model is always used."
+        )
     try:
-        text_embeddings = embedding_manager.embed_text(
-            collection_id=collection_id,
-            text_query=TextEmbedQuery(text=query_text, embedding_model_id=embedding_model_id),
+        text_embeddings = embed_samples.embed_text_for_collection(
+            collection_id=collection_id, text=query_text
         )
     except ValueError as exc:
         raise HTTPException(

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -30,7 +30,7 @@ from lightly_studio.core.image import add_annotations, add_images
 from lightly_studio.core.image.add_images import BrokenImageCollector
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.dataset import fsspec_lister, remote_storage
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
+from lightly_studio.embed import embed_samples
 from lightly_studio.evaluation.image_dataset_evaluate import ImageDatasetEvaluate
 from lightly_studio.export.image_dataset_export import ImageDatasetExport
 from lightly_studio.models.annotation.annotation_base import AnnotationType
@@ -826,19 +826,8 @@ def _generate_embeddings_image(
     if not sample_ids:
         return
 
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session, collection_id=collection_id
-    )
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping embedding generation.")
-        return
-
-    embedding_manager.embed_images(
-        session=session,
-        collection_id=collection_id,
-        sample_ids=sample_ids,
-        embedding_model_id=model_id,
+    embed_samples.embed_image_samples(
+        session=session, collection_id=collection_id, sample_ids=sample_ids
     )
 
 
@@ -871,18 +860,8 @@ def _generate_embeddings_annotations(
     )
     if annotation_collection_id is None:
         return
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session,
-        collection_id=annotation_collection_id,
-    )
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping annotation embedding generation.")
-        return
-    embedding_manager.embed_annotations(
-        session=session,
-        annotation_collection_id=annotation_collection_id,
-        embedding_model_id=model_id,
+    embed_samples.embed_annotation_collection(
+        session=session, annotation_collection_id=annotation_collection_id
     )
 
 

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -44,7 +44,7 @@ from lightly_studio.core.file_outcome_report import (
     MissingInputFileError,
 )
 from lightly_studio.dataset import remote_storage
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
+from lightly_studio.embed import embed_samples
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
 )
@@ -92,7 +92,6 @@ class FrameExtractionContext:
     collection_id: UUID
     video_sample_id: UUID
     embed_frames: bool = False
-    embedding_model_id: UUID | None = None
 
 
 @dataclass
@@ -106,7 +105,6 @@ class VideoLoadContext:
     num_decode_threads: int | None
     target_fps: float | None
     embed_frames: bool
-    embedding_model_id: UUID | None
 
 
 @dataclass
@@ -173,16 +171,11 @@ def load_into_collection_from_paths(  # noqa: PLR0913
     video_frames_collection_id = collection_resolver.get_or_create_child_collection(
         session=session, collection_id=collection_id, sample_type=SampleType.VIDEO_FRAME
     )
-    embedding_model_id: UUID | None = None
-    if embed_frames:
-        embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-        embedding_model_id = embedding_manager.load_or_get_default_model(
-            session=session,
-            collection_id=video_frames_collection_id,
-        )
-        if embedding_model_id is None:
-            logger.warning("No embedding model loaded. Skipping frame embedding generation.")
-    effective_embed_frames = embed_frames and embedding_model_id is not None
+    effective_embed_frames = embed_frames and embed_samples.collection_has_default_embedder(
+        session=session, collection_id=video_frames_collection_id
+    )
+    if embed_frames and not effective_embed_frames:
+        logger.warning("No embedding model loaded. Skipping frame embedding generation.")
 
     load_context = VideoLoadContext(
         session=session,
@@ -192,7 +185,6 @@ def load_into_collection_from_paths(  # noqa: PLR0913
         num_decode_threads=num_decode_threads,
         target_fps=target_fps,
         embed_frames=effective_embed_frames,
-        embedding_model_id=embedding_model_id,
     )
 
     paths_to_load: list[str] = []
@@ -326,7 +318,6 @@ def _load_single_video(
                 collection_id=context.video_frames_collection_id,
                 video_sample_id=video_sample_ids[0],
                 embed_frames=context.embed_frames,
-                embedding_model_id=context.embedding_model_id,
             )
             try:
                 frame_sample_ids = _create_video_frame_samples(
@@ -612,14 +603,12 @@ def _flush_frame_batch(
         collection_id=context.collection_id,
     )
 
-    if context.embed_frames and context.embedding_model_id is not None and pil_frames:
-        embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-        embedding_manager.embed_and_store_pil_images(
+    if context.embed_frames and pil_frames:
+        embed_samples.embed_frame_samples(
             session=context.session,
-            embedding_model_id=context.embedding_model_id,
+            collection_id=context.collection_id,
             sample_ids=created_sample_ids,
-            images=pil_frames,
-            show_progress=False,
+            pil_frames=pil_frames,
         )
 
     return created_sample_ids

--- a/lightly_studio/src/lightly_studio/core/video/video_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_dataset.py
@@ -20,7 +20,7 @@ from lightly_studio.core.video.add_videos import VIDEO_EXTENSIONS
 from lightly_studio.core.video.video_frame_dataset import VideoFrameDataset
 from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.dataset import fsspec_lister
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
+from lightly_studio.embed import embed_samples
 from lightly_studio.export.video_dataset_export import VideoDatasetExport
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
@@ -280,19 +280,8 @@ def _generate_embeddings_video(
     if not sample_ids:
         return
 
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session, collection_id=collection_id
-    )
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping embedding generation.")
-        return
-
-    embedding_manager.embed_videos(
-        session=session,
-        collection_id=collection_id,
-        sample_ids=sample_ids,
-        embedding_model_id=model_id,
+    embed_samples.embed_video_samples(
+        session=session, collection_id=collection_id, sample_ids=sample_ids
     )
 
 

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -1,0 +1,187 @@
+"""Class-free interface for embedding samples and queries.
+
+Wraps the shared embedding logic behind plain module functions so callers no longer
+reach for the ``EmbeddingManager`` singleton, resolve the default model, and check it
+by hand. Each function resolves the collection's default embedding model itself.
+
+The functions currently delegate to the ``EmbeddingManager`` singleton. The internals
+will be swapped for the capability-typed ``EmbedderRegistry`` later; the function
+signatures are the stable surface callers migrate to now.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from PIL.Image import Image
+from sqlmodel import Session
+
+from lightly_studio.dataset.embedding_manager import (
+    EmbeddingManagerProvider,
+    TextEmbedQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def embed_image_for_collection(collection_id: UUID, filepath: str) -> list[float]:
+    """Embed a single image with the collection's default model, without storing it.
+
+    Args:
+        collection_id: The collection whose default embedding model is used.
+        filepath: fsspec path or URL of the image to embed.
+
+    Returns:
+        The embedding as a list of floats.
+
+    Raises:
+        ValueError: If the collection has no default embedding model, or the model does
+            not support images.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    return manager.compute_image_embedding(collection_id=collection_id, filepath=filepath)
+
+
+def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
+    """Embed a text query with the collection's default model, without storing it.
+
+    Args:
+        collection_id: The collection whose default embedding model is used.
+        text: The text to embed.
+
+    Returns:
+        The embedding as a list of floats.
+
+    Raises:
+        ValueError: If the collection has no default embedding model.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    return manager.embed_text(collection_id=collection_id, text_query=TextEmbedQuery(text=text))
+
+
+def collection_has_default_embedder(session: Session, collection_id: UUID) -> bool:
+    """Ensure the collection's default embedding model is loaded and report whether it exists.
+
+    This is an ensure-and-check, not a pure peek: on the first call for a collection,
+    ``load_or_get_default_model`` loads and registers the collection's default embedding
+    model as a side effect, then this returns whether a usable default model is (now)
+    available.
+
+    This differs from ``embedding_utils.collection_has_embeddings``, which checks whether
+    embeddings are already *stored* for the collection.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is ensured.
+
+    Returns:
+        True if the collection has a usable default embedding model, False otherwise.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    return model_id is not None
+
+
+def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
+    """Embed image samples with the collection's default model and store the result.
+
+    Does nothing (and logs a warning) if the collection has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is used.
+        sample_ids: Image sample IDs to embed.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_images(
+        session=session,
+        collection_id=collection_id,
+        sample_ids=sample_ids,
+        embedding_model_id=model_id,
+    )
+
+
+def embed_video_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
+    """Embed video samples with the collection's default model and store the result.
+
+    Does nothing (and logs a warning) if the collection has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is used.
+        sample_ids: Video sample IDs to embed.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_videos(
+        session=session,
+        collection_id=collection_id,
+        sample_ids=sample_ids,
+        embedding_model_id=model_id,
+    )
+
+
+def embed_annotation_collection(session: Session, annotation_collection_id: UUID) -> None:
+    """Embed the crops of an annotation collection and store the result.
+
+    Uses the annotation collection's default model. Does nothing (and logs a warning) if
+    it has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        annotation_collection_id: The annotation collection whose crops are embedded.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(
+        session=session, collection_id=annotation_collection_id
+    )
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_annotations(
+        session=session,
+        annotation_collection_id=annotation_collection_id,
+        embedding_model_id=model_id,
+    )
+
+
+def embed_frame_samples(
+    session: Session,
+    collection_id: UUID,
+    sample_ids: list[UUID],
+    pil_frames: list[Image],
+) -> None:
+    """Embed the frames of a single video and store the result.
+
+    Uses the frame collection's default model. Does nothing (and logs a warning) if it
+    has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The video-frame collection whose default embedding model is used.
+        sample_ids: Frame sample IDs the embeddings are stored for.
+        pil_frames: The frames to embed, in the same order as ``sample_ids``.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_and_store_pil_images(
+        session=session,
+        embedding_model_id=model_id,
+        sample_ids=sample_ids,
+        images=pil_frames,
+    )

--- a/lightly_studio/tests/api/routes/api/test_image_embedding.py
+++ b/lightly_studio/tests/api/routes/api/test_image_embedding.py
@@ -1,3 +1,6 @@
+from uuid import uuid4
+
+import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
@@ -73,3 +76,16 @@ def test_embed_image_from_file_error(
 
     assert response.status_code == HTTP_STATUS_INTERNAL_SERVER_ERROR
     assert "Embedding failed" in response.json()["detail"]
+
+
+def test_embed_image_from_file__model_override_not_supported(test_client: TestClient) -> None:
+    # A per-request embedding model override is not supported: passing an
+    # embedding_model_id must raise instead of silently using the collection default.
+    files = {"file": ("test_image.jpg", b"fake image content", "image/jpeg")}
+
+    with pytest.raises(NotImplementedError, match="model override is not supported"):
+        test_client.post(
+            f"/api/image_embedding/from_file/for_collection/{uuid4()!s}",
+            params={"embedding_model_id": str(uuid4())},
+            files=files,
+        )

--- a/lightly_studio/tests/api/routes/api/test_text_embedding.py
+++ b/lightly_studio/tests/api/routes/api/test_text_embedding.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
@@ -46,28 +47,14 @@ def test_embed_text(db_session: Session, mocker: MockerFixture, test_client: Tes
     assert response.json() == [0.1, 0.2, 0.3]
 
 
-def test_embed_text_embedding_invalid_model_id(
-    db_session: Session,
-    mocker: MockerFixture,
-    test_client: TestClient,
-) -> None:
-    # Make the request to the `/samples` endpoint
-    # Create a db as the text_embeddings defaults to root_collection
-    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
-
-    mocker.patch.object(
-        EmbeddingManagerProvider,
-        "get_embedding_manager",
-        return_value=EmbeddingManager(),
-    )
-    test_uuid = uuid4()
-
-    response = test_client.get(
-        f"/api/text_embedding/for_collection/{collection_id!s}",
-        params={
-            "query_text": "sample",
-            "embedding_model_id": str(test_uuid),
-        },
-    )
-    assert response.status_code == 500
-    assert response.json() == {"detail": f"No embedding model found with ID {test_uuid}"}
+def test_embed_text__model_override_not_supported(test_client: TestClient) -> None:
+    # A per-request embedding model override is not supported: passing an
+    # embedding_model_id must raise instead of silently using the collection default.
+    with pytest.raises(NotImplementedError, match="model override is not supported"):
+        test_client.get(
+            f"/api/text_embedding/for_collection/{uuid4()!s}",
+            params={
+                "query_text": "sample",
+                "embedding_model_id": str(uuid4()),
+            },
+        )

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -463,7 +463,6 @@ def test__create_video_frame_samples__embed_frames(
             collection_id=video_frames_collection_id,
             video_sample_id=video_sample_id,
             embed_frames=True,
-            embedding_model_id=model_id,
         ),
         video_container=video_container,
         video_channel=0,

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -1,0 +1,460 @@
+"""Tests for the class-free embed_samples interface."""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+from PIL import Image
+from pytest_mock import MockerFixture
+from sqlmodel import Session, select
+
+from lightly_studio.dataset import embedding_manager
+from lightly_studio.dataset.embedding_generator import RandomEmbeddingGenerator
+from lightly_studio.dataset.embedding_manager import (
+    EmbeddingManager,
+    EmbeddingManagerProvider,
+)
+from lightly_studio.embed import embed_samples
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.models.image import ImageTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.resolvers import (
+    collection_embedding_model_resolver,
+    collection_resolver,
+    sample_embedding_resolver,
+)
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+from tests.resolvers.video.helpers import (
+    VideoStub,
+    create_video_with_frames,
+    create_videos,
+)
+
+# Dimension of the RandomEmbeddingGenerator registered as the default in these tests.
+_MODEL_DIMENSION = 3
+
+
+def test_embed_image_for_collection(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """A single image is embedded with the collection's default model, unstored."""
+    manager = _fresh_manager(mocker)
+    _register_default(manager=manager, session=db_session, collection_id=collection.collection_id)
+
+    embedding = embed_samples.embed_image_for_collection(
+        collection_id=collection.collection_id, filepath="/path/to/image.jpg"
+    )
+
+    assert len(embedding) == _MODEL_DIMENSION
+    # Nothing is stored for an interactive query embedding.
+    assert _stored_embeddings(db_session) == []
+
+
+def test_embed_image_for_collection__no_default_model(
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """Without a default model the interactive image path raises a clear error."""
+    _fresh_manager(mocker)
+
+    with pytest.raises(ValueError, match="No embedding_model_id provided and no default embedding"):
+        embed_samples.embed_image_for_collection(
+            collection_id=collection.collection_id, filepath="/path/to/image.jpg"
+        )
+
+
+def test_embed_text_for_collection(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """A text query is embedded with the collection's default model."""
+    manager = _fresh_manager(mocker)
+    _register_default(manager=manager, session=db_session, collection_id=collection.collection_id)
+
+    embedding = embed_samples.embed_text_for_collection(
+        collection_id=collection.collection_id, text="a red car"
+    )
+
+    assert len(embedding) == _MODEL_DIMENSION
+
+
+def test_embed_text_for_collection__no_default_model(
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """Without a default model the interactive text path raises a clear error."""
+    _fresh_manager(mocker)
+
+    with pytest.raises(ValueError, match="No embedding_model_id provided and no default embedding"):
+        embed_samples.embed_text_for_collection(
+            collection_id=collection.collection_id, text="a red car"
+        )
+
+
+def test_collection_has_default_embedder__loads_and_reports_true(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """The helper ensures the default is loaded, then reports it is available.
+
+    The check is ensure-and-check: no default exists up front, and the first call
+    registers one as a side effect before returning True.
+    """
+    _fresh_manager(mocker)
+    mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=RandomEmbeddingGenerator(),
+    )
+    # No default embedding model exists before the call.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+    has_default = embed_samples.collection_has_default_embedder(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert has_default is True
+    # The call registered a default model as its side effect.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is not None
+    )
+
+
+def test_collection_has_default_embedder__false_when_none_loadable(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """The helper reports False when no default model can be loaded."""
+    _fresh_manager(mocker)
+    _disable_env_loader(mocker)
+
+    has_default = embed_samples.collection_has_default_embedder(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert has_default is False
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+
+def test_embed_image_samples(
+    db_session: Session,
+    collection: CollectionTable,
+    samples: list[ImageTable],
+    mocker: MockerFixture,
+) -> None:
+    """Image samples are embedded and stored under the collection's default model."""
+    manager = _fresh_manager(mocker)
+    model_id = _register_default(
+        manager=manager, session=db_session, collection_id=collection.collection_id
+    )
+    sample_ids = [sample.sample_id for sample in samples]
+
+    embed_samples.embed_image_samples(
+        session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session, collection_id=collection.collection_id, embedding_model_id=model_id
+    )
+    assert count == len(sample_ids)
+
+
+def test_embed_image_samples__no_default_model_skips(
+    db_session: Session,
+    collection: CollectionTable,
+    samples: list[ImageTable],
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, embedding is skipped, a warning logged, nothing stored."""
+    _fresh_manager(mocker)
+    _disable_env_loader(mocker)
+    sample_ids = [sample.sample_id for sample in samples]
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_image_samples(
+            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
+def test_embed_video_samples(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """Video samples are embedded and stored under the collection's default model."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        videos=[VideoStub(path=f"/videos/video_{index}.mp4") for index in range(3)],
+    )
+    manager = _fresh_manager(mocker)
+    model_id = _register_default(
+        manager=manager, session=db_session, collection_id=video_collection.collection_id
+    )
+
+    embed_samples.embed_video_samples(
+        session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        embedding_model_id=model_id,
+    )
+    assert count == len(video_ids)
+
+
+def test_embed_video_samples__no_default_model_skips(
+    db_session: Session,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, video embedding is skipped and nothing stored."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        videos=[VideoStub(path="/videos/video_0.mp4")],
+    )
+    _fresh_manager(mocker)
+    _disable_env_loader(mocker)
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_video_samples(
+            session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
+def test_embed_annotation_collection(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """Annotation crops are embedded and stored under the collection's default model."""
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    manager = _fresh_manager(mocker)
+    model_id = _register_default(
+        manager=manager, session=db_session, collection_id=annotation_collection_id
+    )
+
+    embed_samples.embed_annotation_collection(
+        session=db_session, annotation_collection_id=annotation_collection_id
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session, collection_id=annotation_collection_id, embedding_model_id=model_id
+    )
+    assert count == 1
+
+
+def test_embed_annotation_collection__no_default_model_skips(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, annotation embedding is skipped and nothing stored."""
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    _fresh_manager(mocker)
+    _disable_env_loader(mocker)
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_annotation_collection(
+            session=db_session, annotation_collection_id=annotation_collection_id
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
+def test_embed_frame_samples(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """Video frames are embedded and stored for the given frame sample IDs."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    frames = create_video_with_frames(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        video=VideoStub(duration_s=1.0, fps=3.0),
+    )
+    manager = _fresh_manager(mocker)
+    model_id = _register_default(
+        manager=manager,
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+    )
+    pil_frames = [Image.new("RGB", (2, 2)) for _ in frames.frame_sample_ids]
+
+    embed_samples.embed_frame_samples(
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        sample_ids=frames.frame_sample_ids,
+        pil_frames=pil_frames,
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        embedding_model_id=model_id,
+    )
+    assert count == len(frames.frame_sample_ids)
+
+
+def test_embed_frame_samples__matches_frames_to_sample_ids_in_order(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """Each frame's embedding is stored against the sample ID at the same position."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    frames = create_video_with_frames(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        video=VideoStub(duration_s=1.0, fps=3.0),
+    )
+    # One distinct color per frame, so the stored vector identifies its source frame.
+    colors = [(10, 20, 30), (40, 50, 60), (70, 80, 90)]
+    assert len(frames.frame_sample_ids) == len(colors)
+    pil_frames = [Image.new("RGB", (2, 2), color=color) for color in colors]
+
+    manager = _fresh_manager(mocker)
+    model_id = _register_default(
+        manager=manager,
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        generator=_FirstPixelEmbeddingGenerator(),
+    )
+
+    embed_samples.embed_frame_samples(
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        sample_ids=frames.frame_sample_ids,
+        pil_frames=pil_frames,
+    )
+
+    rows = sample_embedding_resolver.get_by_sample_ids(
+        session=db_session, sample_ids=frames.frame_sample_ids, embedding_model_id=model_id
+    )
+    assert len(rows) == len(colors)
+    for row, color in zip(rows, colors):
+        assert list(row.embedding) == pytest.approx(list(color))
+
+
+def test_embed_frame_samples__no_default_model_skips(
+    db_session: Session,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, frame embedding is skipped and nothing stored."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    frames = create_video_with_frames(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        video=VideoStub(duration_s=1.0, fps=3.0),
+    )
+    pil_frames = [Image.new("RGB", (2, 2)) for _ in frames.frame_sample_ids]
+    _fresh_manager(mocker)
+    _disable_env_loader(mocker)
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_frame_samples(
+            session=db_session,
+            collection_id=frames.video_frames_collection_id,
+            sample_ids=frames.frame_sample_ids,
+            pil_frames=pil_frames,
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
+class _FirstPixelEmbeddingGenerator(RandomEmbeddingGenerator):
+    """Embeds each PIL image as its top-left pixel's RGB, so frame order is verifiable."""
+
+    def embed_pil_images(
+        self, images: list[Image.Image], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        _ = show_progress
+        return np.array([image.getpixel((0, 0)) for image in images], dtype=np.float32)
+
+
+def _fresh_manager(mocker: MockerFixture) -> EmbeddingManager:
+    """Route embed_samples to a fresh manager so tests never touch the shared singleton."""
+    manager = EmbeddingManager()
+    mocker.patch.object(EmbeddingManagerProvider, "get_embedding_manager", return_value=manager)
+    return manager
+
+
+def _disable_env_loader(mocker: MockerFixture) -> None:
+    """Make loading a default generator from the environment return nothing."""
+    mocker.patch.object(embedding_manager, "_load_embedding_generator_from_env", return_value=None)
+
+
+def _register_default(
+    manager: EmbeddingManager,
+    session: Session,
+    collection_id: UUID,
+    generator: RandomEmbeddingGenerator | None = None,
+) -> UUID:
+    """Register an embedding generator as the collection's default and return its model ID."""
+    return manager.register_embedding_model(
+        session=session,
+        embedding_generator=generator or RandomEmbeddingGenerator(dimension=_MODEL_DIMENSION),
+        collection_id=collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+
+def _stored_embeddings(session: Session) -> list[SampleEmbeddingTable]:
+    """Return every stored sample embedding, for asserting the skip path stores nothing."""
+    return list(session.exec(select(SampleEmbeddingTable)).all())


### PR DESCRIPTION
## What has changed and why?

First step of moving embedding off the `EmbeddingManager` singleton.

- New `embed/embed_samples.py`: class-free, stable interface for embedding samples and queries. Each function resolves the collection's default model itself.
- Internals still delegate to `EmbeddingManager` — the backend will be swapped for `EmbedderRegistry` later, behind these same signatures.
- Migrated all callers: `image_dataset`, `video_dataset`, both embedding API routes, `add_videos`.
- API routes now reject a per-request `embedding_model_id` with `NotImplementedError` instead of honoring it — the collection default is always used.
- `add_videos` uses the new `collection_has_default_embedder` gate and `embed_frame_samples`, dropping `embedding_model_id` from its load contexts.
- `collection_has_embeddings` left on the old path (moves in a later phase).

## How has it been tested?

- New `tests/embed/test_embed_samples.py` covering every function (happy paths, no-default skip/error paths, helper side effect, frame ordering).
- `make static-checks` clean; existing embedding, dataset, video, and API-route tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)