### PR TITLE
Move embedding_utils into embed package (embed stack 1/4)

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/collection.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection.py
@@ -15,7 +15,7 @@ from lightly_studio.api.routes.api.status import (
 )
 from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.database.db_manager import SessionDep
-from lightly_studio.dataset import embedding_utils
+from lightly_studio.embed import embedding_utils
 from lightly_studio.models.collection import (
     CollectionCreate,
     CollectionOverviewView,

--- a/lightly_studio/src/lightly_studio/embed/embedding_utils.py
+++ b/lightly_studio/src/lightly_studio/embed/embedding_utils.py
@@ -4,14 +4,17 @@ from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.resolvers import (
+    collection_embedding_model_resolver,
     sample_embedding_resolver,
 )
 
 
 def collection_has_embeddings(session: Session, collection_id: UUID) -> bool:
     """Check if there are any embeddings available for the given collection.
+
+    Resolves the collection's default embedding model from the database and reports whether
+    any embeddings are stored for it. Does not load the model.
 
     Args:
         session: Database session for resolver operations.
@@ -20,13 +23,12 @@ def collection_has_embeddings(session: Session, collection_id: UUID) -> bool:
     Returns:
         True if embeddings exist for the collection, False otherwise.
     """
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
+    model_id = collection_embedding_model_resolver.get_default_by_collection_id(
         session=session,
         collection_id=collection_id,
     )
     if model_id is None:
-        # No default embedding model loaded for this collection.
+        # No default embedding model registered for this collection.
         return False
 
     return (

--- a/lightly_studio/tests/api/routes/api/test_collection.py
+++ b/lightly_studio/tests/api/routes/api/test_collection.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import (
@@ -14,7 +13,6 @@ from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_OK,
 )
-from lightly_studio.dataset.embedding_manager import EmbeddingManager
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import collection_resolver
 from tests.helpers_resolvers import (
@@ -238,22 +236,16 @@ def test_read_collections_overview(test_client: TestClient, db_session: Session)
 def test_has_embeddings(
     test_client: TestClient,
     db_session: Session,
-    mocker: MockerFixture,
 ) -> None:
     col_id = create_collection(session=db_session).collection_id
     embedding_model_id = create_embedding_model(
-        session=db_session, collection_id=col_id
+        session=db_session, collection_id=col_id, set_as_default=True
     ).embedding_model_id
-    mock_get_model = mocker.patch.object(
-        EmbeddingManager, "load_or_get_default_model", return_value=embedding_model_id
-    )
 
     # Initially, the collection has no embeddings.
     response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() is False
-    mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
-    mock_get_model.reset_mock()
 
     # Add an embedding to the collection.
     create_samples_with_embeddings(
@@ -267,7 +259,6 @@ def test_has_embeddings(
     response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() is True
-    mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
 
 
 @pytest.mark.postgres_only  # Deep copying is enterprise-only (PostgreSQL-backed).

--- a/lightly_studio/tests/embed/test_embedding_utils.py
+++ b/lightly_studio/tests/embed/test_embedding_utils.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from pytest_mock import MockerFixture
 from sqlmodel import Session
 
-from lightly_studio.dataset import embedding_utils
-from lightly_studio.dataset.embedding_manager import EmbeddingManager
+from lightly_studio.embed import embedding_utils
 from tests.helpers_resolvers import (
     ImageStub,
     create_collection,
@@ -13,25 +11,17 @@ from tests.helpers_resolvers import (
 )
 
 
-def test_collection_has_embeddings(db_session: Session, mocker: MockerFixture) -> None:
+def test_collection_has_embeddings(db_session: Session) -> None:
     col_id = create_collection(session=db_session).collection_id
     embedding_model_id = create_embedding_model(
-        session=db_session, collection_id=col_id
+        session=db_session, collection_id=col_id, set_as_default=True
     ).embedding_model_id
-    mock_get_model = mocker.patch.object(
-        EmbeddingManager, "load_or_get_default_model", return_value=embedding_model_id
-    )
 
     # Initially, the collection has no embeddings.
     assert not embedding_utils.collection_has_embeddings(
         session=db_session,
         collection_id=col_id,
     )
-    mock_get_model.assert_called_once_with(
-        session=db_session,
-        collection_id=col_id,
-    )
-    mock_get_model.reset_mock()
 
     # Add an embedding to the collection.
     create_samples_with_embeddings(
@@ -43,10 +33,6 @@ def test_collection_has_embeddings(db_session: Session, mocker: MockerFixture) -
 
     # Now, the collection should report having embeddings.
     assert embedding_utils.collection_has_embeddings(
-        session=db_session,
-        collection_id=col_id,
-    )
-    mock_get_model.assert_called_once_with(
         session=db_session,
         collection_id=col_id,
     )


### PR DESCRIPTION
## What has changed and why?

Part 1 of a 4-PR stack that moves the `EmbeddingManager` interface behind an `embed_samples` module, splitting prototype #2220 into reviewable pieces.

This PR:
- Move `embedding_utils` from `dataset/` into the `embed/` package.
- Make `collection_has_embeddings` resolve the default model from the DB directly — no `EmbeddingManager`, no model-load side effect.

## How has it been tested?

Existing test suite (`make static-checks`, `make test`).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Collection embedding checks now use the registered default embedding model without loading it, improving efficiency while preserving existing results.
  - Collections without a default embedding model are correctly reported as having no embeddings.

- **Tests**
  - Updated coverage verifies embedding status using configured default models and removes reliance on mocked model-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->