### PR TITLE
Migrate image dataset embedding to embed_samples (embed stack 3/4)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -30,7 +30,7 @@ from lightly_studio.core.image import add_annotations, add_images
 from lightly_studio.core.image.add_images import BrokenImageCollector
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.dataset import fsspec_lister, remote_storage
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
+from lightly_studio.embed import embed_samples
 from lightly_studio.evaluation.image_dataset_evaluate import ImageDatasetEvaluate
 from lightly_studio.export.image_dataset_export import ImageDatasetExport
 from lightly_studio.models.annotation.annotation_base import AnnotationType
@@ -826,19 +826,8 @@ def _generate_embeddings_image(
     if not sample_ids:
         return
 
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session, collection_id=collection_id
-    )
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping embedding generation.")
-        return
-
-    embedding_manager.embed_images(
-        session=session,
-        collection_id=collection_id,
-        sample_ids=sample_ids,
-        embedding_model_id=model_id,
+    embed_samples.embed_image_samples(
+        session=session, collection_id=collection_id, sample_ids=sample_ids
     )
 
 
@@ -871,18 +860,8 @@ def _generate_embeddings_annotations(
     )
     if annotation_collection_id is None:
         return
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session,
-        collection_id=annotation_collection_id,
-    )
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping annotation embedding generation.")
-        return
-    embedding_manager.embed_annotations(
-        session=session,
-        annotation_collection_id=annotation_collection_id,
-        embedding_model_id=model_id,
+    embed_samples.embed_annotation_collection(
+        session=session, annotation_collection_id=annotation_collection_id
     )
 
 

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -11,12 +11,17 @@ signatures are the stable surface callers migrate to now.
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
+
+from sqlmodel import Session
 
 from lightly_studio.dataset.embedding_manager import (
     EmbeddingManagerProvider,
     TextEmbedQuery,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def embed_image_for_collection(collection_id: UUID, filepath: str) -> list[float]:
@@ -52,3 +57,52 @@ def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
     """
     manager = EmbeddingManagerProvider.get_embedding_manager()
     return manager.embed_text(collection_id=collection_id, text_query=TextEmbedQuery(text=text))
+
+
+def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
+    """Embed image samples with the collection's default model and store the result.
+
+    Does nothing (and logs a warning) if the collection has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is used.
+        sample_ids: Image sample IDs to embed.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_images(
+        session=session,
+        collection_id=collection_id,
+        sample_ids=sample_ids,
+        embedding_model_id=model_id,
+    )
+
+
+def embed_annotation_collection(session: Session, annotation_collection_id: UUID) -> None:
+    """Embed the crops of an annotation collection and store the result.
+
+    Uses the annotation collection's default model. Does nothing (and logs a warning) if
+    it has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        annotation_collection_id: The annotation collection whose crops are embedded.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(
+        session=session, collection_id=annotation_collection_id
+    )
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_annotations(
+        session=session,
+        annotation_collection_id=annotation_collection_id,
+        embedding_model_id=model_id,
+    )

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -2,20 +2,33 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 import pytest
 from pytest_mock import MockerFixture
 from sqlmodel import Session, select
 
+from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import RandomEmbeddingGenerator
 from lightly_studio.dataset.embedding_manager import (
     EmbeddingManager,
     EmbeddingManagerProvider,
 )
 from lightly_studio.embed import embed_samples
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
-from tests.helpers_resolvers import create_collection
+from lightly_studio.resolvers import (
+    collection_resolver,
+    sample_embedding_resolver,
+)
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 @pytest.fixture
@@ -92,6 +105,106 @@ def test_embed_text_for_collection__no_default_model(
         )
 
 
+def test_embed_image_samples(
+    db_session: Session,
+    collection: CollectionTable,
+    samples: list[ImageTable],
+    patched_manager: EmbeddingManager,
+) -> None:
+    """Image samples are embedded and stored under the collection's default model."""
+    model_id = _register_default_random_model(
+        manager=patched_manager, session=db_session, collection_id=collection.collection_id
+    )
+    sample_ids = [sample.sample_id for sample in samples]
+
+    embed_samples.embed_image_samples(
+        session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session, collection_id=collection.collection_id, embedding_model_id=model_id
+    )
+    assert count == len(sample_ids)
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_embed_image_samples__no_default_model_skips(
+    db_session: Session,
+    collection: CollectionTable,
+    samples: list[ImageTable],
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, embedding is skipped, a warning logged, nothing stored."""
+    _disable_env_loader(mocker)
+    sample_ids = [sample.sample_id for sample in samples]
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_image_samples(
+            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
+def test_embed_annotation_collection(
+    db_session: Session,
+    collection: CollectionTable,
+    patched_manager: EmbeddingManager,
+) -> None:
+    """Annotation crops are embedded and stored under the collection's default model."""
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    model_id = _register_default_random_model(
+        manager=patched_manager, session=db_session, collection_id=annotation_collection_id
+    )
+
+    embed_samples.embed_annotation_collection(
+        session=db_session, annotation_collection_id=annotation_collection_id
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session, collection_id=annotation_collection_id, embedding_model_id=model_id
+    )
+    assert count == 1
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_embed_annotation_collection__no_default_model_skips(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, annotation embedding is skipped and nothing stored."""
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    _disable_env_loader(mocker)
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_annotation_collection(
+            session=db_session, annotation_collection_id=annotation_collection_id
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
 def _register_default_random_model(
     manager: EmbeddingManager,
     session: Session,
@@ -105,6 +218,11 @@ def _register_default_random_model(
         collection_id=collection_id,
         set_as_default=True,
     ).embedding_model_id
+
+
+def _disable_env_loader(mocker: MockerFixture) -> None:
+    """Make loading a default generator from the environment return nothing."""
+    mocker.patch.object(embedding_manager, "_load_embedding_generator_from_env", return_value=None)
 
 
 def _stored_embeddings(session: Session) -> list[SampleEmbeddingTable]:

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -59,7 +59,7 @@ def test_embed_image_for_collection(
 
     assert len(embedding) == 5
     # Nothing is stored for an interactive query embedding.
-    assert _stored_embeddings(db_session) == []
+    assert _stored_embeddings(session=db_session) == []
 
 
 @pytest.mark.usefixtures("patched_manager")
@@ -148,13 +148,13 @@ def test_embed_image_samples__no_default_model_skips(
     _disable_env_loader(mocker=mocker)
     sample_ids = [sample.sample_id for sample in samples]
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(level=logging.WARNING):
         embed_samples.embed_image_samples(
             session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
         )
 
     assert "No embedding model loaded" in caplog.text
-    assert _stored_embeddings(db_session) == []
+    assert _stored_embeddings(session=db_session) == []
 
 
 def test_embed_annotation_collection(
@@ -205,13 +205,13 @@ def test_embed_annotation_collection__no_default_model_skips(
     )
     _disable_env_loader(mocker=mocker)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(level=logging.WARNING):
         embed_samples.embed_annotation_collection(
             session=db_session, annotation_collection_id=annotation_collection_id
         )
 
     assert "No embedding model loaded" in caplog.text
-    assert _stored_embeddings(db_session) == []
+    assert _stored_embeddings(session=db_session) == []
 
 
 def _register_default_random_model(

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -16,18 +16,19 @@ from lightly_studio.dataset.embedding_manager import (
     EmbeddingManagerProvider,
 )
 from lightly_studio.embed import embed_samples
-from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.models.image import ImageTable
+from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
     collection_resolver,
     sample_embedding_resolver,
 )
 from tests.helpers_resolvers import (
+    ImageStub,
     create_annotation,
     create_annotation_label,
     create_collection,
     create_image,
+    create_images,
 )
 
 
@@ -107,11 +108,15 @@ def test_embed_text_for_collection__no_default_model(
 
 def test_embed_image_samples(
     db_session: Session,
-    collection: CollectionTable,
-    samples: list[ImageTable],
     patched_manager: EmbeddingManager,
 ) -> None:
     """Image samples are embedded and stored under the collection's default model."""
+    collection = create_collection(session=db_session)
+    samples = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="/test/a.jpg"), ImageStub(path="/test/b.jpg")],
+    )
     model_id = _register_default_random_model(
         manager=patched_manager, session=db_session, collection_id=collection.collection_id
     )
@@ -130,13 +135,17 @@ def test_embed_image_samples(
 @pytest.mark.usefixtures("patched_manager")
 def test_embed_image_samples__no_default_model_skips(
     db_session: Session,
-    collection: CollectionTable,
-    samples: list[ImageTable],
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """With no default model, embedding is skipped, a warning logged, nothing stored."""
-    _disable_env_loader(mocker)
+    collection = create_collection(session=db_session)
+    samples = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="/test/a.jpg"), ImageStub(path="/test/b.jpg")],
+    )
+    _disable_env_loader(mocker=mocker)
     sample_ids = [sample.sample_id for sample in samples]
 
     with caplog.at_level(logging.WARNING):
@@ -150,10 +159,10 @@ def test_embed_image_samples__no_default_model_skips(
 
 def test_embed_annotation_collection(
     db_session: Session,
-    collection: CollectionTable,
     patched_manager: EmbeddingManager,
 ) -> None:
     """Annotation crops are embedded and stored under the collection's default model."""
+    collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=collection.collection_id)
     label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
     create_annotation(
@@ -184,17 +193,17 @@ def test_embed_annotation_collection(
 @pytest.mark.usefixtures("patched_manager")
 def test_embed_annotation_collection__no_default_model_skips(
     db_session: Session,
-    collection: CollectionTable,
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """With no default model, annotation embedding is skipped and nothing stored."""
+    collection = create_collection(session=db_session)
     annotation_collection_id = collection_resolver.get_or_create_child_collection(
         session=db_session,
         collection_id=collection.collection_id,
         sample_type=SampleType.ANNOTATION,
     )
-    _disable_env_loader(mocker)
+    _disable_env_loader(mocker=mocker)
 
     with caplog.at_level(logging.WARNING):
         embed_samples.embed_annotation_collection(


### PR DESCRIPTION
## What has changed and why?

Part 3 of a 4-PR stack that moves the `EmbeddingManager` interface behind an `embed_samples` module, splitting prototype #2220 into reviewable pieces.

This PR:
- Add `embed_image_samples` and `embed_annotation_collection` to `embed/embed_samples.py`.
- Migrate `core/image/image_dataset.py` off `EmbeddingManager`.

## How has it been tested?

Existing test suite (`make static-checks`, `make test`).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamlined batch embedding for image samples and annotation collections.
  * Embedding generation now uses the collection’s configured default embedding model.

* **Bug Fixes**
  * Improved handling when no embedding model is available: embedding is skipped safely and a warning is logged.
  * Updated image and annotation workflows to use consistent embedding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->