### PR TITLE
Migrate video dataset embedding to embed_samples (embed stack 4/4)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -44,7 +44,7 @@ from lightly_studio.core.file_outcome_report import (
     MissingInputFileError,
 )
 from lightly_studio.dataset import remote_storage
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
+from lightly_studio.embed import embed_samples
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
 )
@@ -92,7 +92,6 @@ class FrameExtractionContext:
     collection_id: UUID
     video_sample_id: UUID
     embed_frames: bool = False
-    embedding_model_id: UUID | None = None
 
 
 @dataclass
@@ -106,7 +105,6 @@ class VideoLoadContext:
     num_decode_threads: int | None
     target_fps: float | None
     embed_frames: bool
-    embedding_model_id: UUID | None
 
 
 @dataclass
@@ -173,16 +171,11 @@ def load_into_collection_from_paths(  # noqa: PLR0913
     video_frames_collection_id = collection_resolver.get_or_create_child_collection(
         session=session, collection_id=collection_id, sample_type=SampleType.VIDEO_FRAME
     )
-    embedding_model_id: UUID | None = None
-    if embed_frames:
-        embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-        embedding_model_id = embedding_manager.load_or_get_default_model(
-            session=session,
-            collection_id=video_frames_collection_id,
-        )
-        if embedding_model_id is None:
-            logger.warning("No embedding model loaded. Skipping frame embedding generation.")
-    effective_embed_frames = embed_frames and embedding_model_id is not None
+    effective_embed_frames = embed_frames and embed_samples.collection_has_default_embedder(
+        session=session, collection_id=video_frames_collection_id
+    )
+    if embed_frames and not effective_embed_frames:
+        logger.warning("No embedding model loaded. Skipping frame embedding generation.")
 
     load_context = VideoLoadContext(
         session=session,
@@ -192,7 +185,6 @@ def load_into_collection_from_paths(  # noqa: PLR0913
         num_decode_threads=num_decode_threads,
         target_fps=target_fps,
         embed_frames=effective_embed_frames,
-        embedding_model_id=embedding_model_id,
     )
 
     paths_to_load: list[str] = []
@@ -326,7 +318,6 @@ def _load_single_video(
                 collection_id=context.video_frames_collection_id,
                 video_sample_id=video_sample_ids[0],
                 embed_frames=context.embed_frames,
-                embedding_model_id=context.embedding_model_id,
             )
             try:
                 frame_sample_ids = _create_video_frame_samples(
@@ -612,14 +603,12 @@ def _flush_frame_batch(
         collection_id=context.collection_id,
     )
 
-    if context.embed_frames and context.embedding_model_id is not None and pil_frames:
-        embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-        embedding_manager.embed_and_store_pil_images(
+    if context.embed_frames and pil_frames:
+        embed_samples.embed_frame_samples(
             session=context.session,
-            embedding_model_id=context.embedding_model_id,
+            collection_id=context.collection_id,
             sample_ids=created_sample_ids,
-            images=pil_frames,
-            show_progress=False,
+            pil_frames=pil_frames,
         )
 
     return created_sample_ids

--- a/lightly_studio/src/lightly_studio/core/video/video_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_dataset.py
@@ -20,7 +20,7 @@ from lightly_studio.core.video.add_videos import VIDEO_EXTENSIONS
 from lightly_studio.core.video.video_frame_dataset import VideoFrameDataset
 from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.dataset import fsspec_lister
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
+from lightly_studio.embed import embed_samples
 from lightly_studio.export.video_dataset_export import VideoDatasetExport
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
@@ -280,19 +280,8 @@ def _generate_embeddings_video(
     if not sample_ids:
         return
 
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session, collection_id=collection_id
-    )
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping embedding generation.")
-        return
-
-    embedding_manager.embed_videos(
-        session=session,
-        collection_id=collection_id,
-        sample_ids=sample_ids,
-        embedding_model_id=model_id,
+    embed_samples.embed_video_samples(
+        session=session, collection_id=collection_id, sample_ids=sample_ids
     )
 
 

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
+from PIL.Image import Image
 from sqlmodel import Session
 
 from lightly_studio.dataset.embedding_manager import (
@@ -59,6 +60,29 @@ def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
     return manager.embed_text(collection_id=collection_id, text_query=TextEmbedQuery(text=text))
 
 
+def collection_has_default_embedder(session: Session, collection_id: UUID) -> bool:
+    """Ensure the collection's default embedding model is loaded and report whether it exists.
+
+    This is an ensure-and-check, not a pure peek: on the first call for a collection,
+    ``load_or_get_default_model`` loads and registers the collection's default embedding
+    model as a side effect, then this returns whether a usable default model is (now)
+    available.
+
+    This differs from ``embedding_utils.collection_has_embeddings``, which checks whether
+    embeddings are already *stored* for the collection.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is ensured.
+
+    Returns:
+        True if the collection has a usable default embedding model, False otherwise.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    return model_id is not None
+
+
 def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
     """Embed image samples with the collection's default model and store the result.
 
@@ -76,6 +100,30 @@ def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[
         return
 
     manager.embed_images(
+        session=session,
+        collection_id=collection_id,
+        sample_ids=sample_ids,
+        embedding_model_id=model_id,
+    )
+
+
+def embed_video_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
+    """Embed video samples with the collection's default model and store the result.
+
+    Does nothing (and logs a warning) if the collection has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is used.
+        sample_ids: Video sample IDs to embed.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_videos(
         session=session,
         collection_id=collection_id,
         sample_ids=sample_ids,
@@ -105,4 +153,35 @@ def embed_annotation_collection(session: Session, annotation_collection_id: UUID
         session=session,
         annotation_collection_id=annotation_collection_id,
         embedding_model_id=model_id,
+    )
+
+
+def embed_frame_samples(
+    session: Session,
+    collection_id: UUID,
+    sample_ids: list[UUID],
+    pil_frames: list[Image],
+) -> None:
+    """Embed the frames of a single video and store the result.
+
+    Uses the frame collection's default model. Does nothing (and logs a warning) if it
+    has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The video-frame collection whose default embedding model is used.
+        sample_ids: Frame sample IDs the embeddings are stored for.
+        pil_frames: The frames to embed, in the same order as ``sample_ids``.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_and_store_pil_images(
+        session=session,
+        embedding_model_id=model_id,
+        sample_ids=sample_ids,
+        images=pil_frames,
     )

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -60,29 +60,6 @@ def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
     return manager.embed_text(collection_id=collection_id, text_query=TextEmbedQuery(text=text))
 
 
-def collection_has_default_embedder(session: Session, collection_id: UUID) -> bool:
-    """Ensure the collection's default embedding model is loaded and report whether it exists.
-
-    This is an ensure-and-check, not a pure peek: on the first call for a collection,
-    ``load_or_get_default_model`` loads and registers the collection's default embedding
-    model as a side effect, then this returns whether a usable default model is (now)
-    available.
-
-    This differs from ``embedding_utils.collection_has_embeddings``, which checks whether
-    embeddings are already *stored* for the collection.
-
-    Args:
-        session: Database session for resolver operations.
-        collection_id: The collection whose default embedding model is ensured.
-
-    Returns:
-        True if the collection has a usable default embedding model, False otherwise.
-    """
-    manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
-    return model_id is not None
-
-
 def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
     """Embed image samples with the collection's default model and store the result.
 
@@ -186,3 +163,26 @@ def embed_frame_samples(
         images=pil_frames,
         show_progress=False,
     )
+
+
+def collection_has_default_embedder(session: Session, collection_id: UUID) -> bool:
+    """Ensure the collection's default embedding model is loaded and report whether it exists.
+
+    This is an ensure-and-check, not a pure peek: on the first call for a collection,
+    ``load_or_get_default_model`` loads and registers the collection's default embedding
+    model as a side effect, then this returns whether a usable default model is (now)
+    available.
+
+    This differs from ``embedding_utils.collection_has_embeddings``, which checks whether
+    embeddings are already *stored* for the collection.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is ensured.
+
+    Returns:
+        True if the collection has a usable default embedding model, False otherwise.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    return model_id is not None

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -84,30 +84,6 @@ def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[
     )
 
 
-def embed_video_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
-    """Embed video samples with the collection's default model and store the result.
-
-    Does nothing (and logs a warning) if the collection has no usable default model.
-
-    Args:
-        session: Database session for resolver operations.
-        collection_id: The collection whose default embedding model is used.
-        sample_ids: Video sample IDs to embed.
-    """
-    manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping embedding generation.")
-        return
-
-    manager.embed_videos(
-        session=session,
-        collection_id=collection_id,
-        sample_ids=sample_ids,
-        embedding_model_id=model_id,
-    )
-
-
 def embed_annotation_collection(session: Session, annotation_collection_id: UUID) -> None:
     """Embed the crops of an annotation collection and store the result.
 
@@ -129,6 +105,30 @@ def embed_annotation_collection(session: Session, annotation_collection_id: UUID
     manager.embed_annotations(
         session=session,
         annotation_collection_id=annotation_collection_id,
+        embedding_model_id=model_id,
+    )
+
+
+def embed_video_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
+    """Embed video samples with the collection's default model and store the result.
+
+    Does nothing (and logs a warning) if the collection has no usable default model.
+
+    Args:
+        session: Database session for resolver operations.
+        collection_id: The collection whose default embedding model is used.
+        sample_ids: Video sample IDs to embed.
+    """
+    manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        logger.warning("No embedding model loaded. Skipping embedding generation.")
+        return
+
+    manager.embed_videos(
+        session=session,
+        collection_id=collection_id,
+        sample_ids=sample_ids,
         embedding_model_id=model_id,
     )
 

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -184,4 +184,5 @@ def embed_frame_samples(
         embedding_model_id=model_id,
         sample_ids=sample_ids,
         images=pil_frames,
+        show_progress=False,
     )

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -463,7 +463,6 @@ def test__create_video_frame_samples__embed_frames(
             collection_id=video_frames_collection_id,
             video_sample_id=video_sample_id,
             embed_frames=True,
-            embedding_model_id=model_id,
         ),
         video_container=video_container,
         video_channel=0,

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -242,7 +242,7 @@ def test_embed_video_samples(
     video_ids = create_videos(
         session=db_session,
         collection_id=video_collection.collection_id,
-        videos=[VideoStub(path=f"/videos/video_{index}.mp4") for index in range(3)],
+        videos=[VideoStub(path="/videos/video_0.mp4"), VideoStub(path="/videos/video_1.mp4")],
     )
     model_id = _register_default_random_model(
         manager=patched_manager, session=db_session, collection_id=video_collection.collection_id

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -125,66 +125,6 @@ def test_embed_text_for_collection__no_default_model(
         )
 
 
-@pytest.mark.usefixtures("patched_manager")
-def test_collection_has_default_embedder__loads_and_reports_true(
-    db_session: Session,
-    mocker: MockerFixture,
-) -> None:
-    """The helper ensures the default is loaded, then reports it is available.
-
-    The check is ensure-and-check: no default exists up front, and the first call
-    registers one as a side effect before returning True.
-    """
-    collection = create_collection(session=db_session)
-    mocker.patch.object(
-        embedding_manager,
-        "_load_embedding_generator_from_env",
-        return_value=RandomEmbeddingGenerator(),
-    )
-    # No default embedding model exists before the call.
-    assert (
-        collection_embedding_model_resolver.get_default_by_collection_id(
-            session=db_session, collection_id=collection.collection_id
-        )
-        is None
-    )
-
-    has_default = embed_samples.collection_has_default_embedder(
-        session=db_session, collection_id=collection.collection_id
-    )
-
-    assert has_default is True
-    # The call registered a default model as its side effect.
-    assert (
-        collection_embedding_model_resolver.get_default_by_collection_id(
-            session=db_session, collection_id=collection.collection_id
-        )
-        is not None
-    )
-
-
-@pytest.mark.usefixtures("patched_manager")
-def test_collection_has_default_embedder__false_when_none_loadable(
-    db_session: Session,
-    mocker: MockerFixture,
-) -> None:
-    """The helper reports False when no default model can be loaded."""
-    collection = create_collection(session=db_session)
-    _disable_env_loader(mocker=mocker)
-
-    has_default = embed_samples.collection_has_default_embedder(
-        session=db_session, collection_id=collection.collection_id
-    )
-
-    assert has_default is False
-    assert (
-        collection_embedding_model_resolver.get_default_by_collection_id(
-            session=db_session, collection_id=collection.collection_id
-        )
-        is None
-    )
-
-
 def test_embed_image_samples(
     db_session: Session,
     patched_manager: EmbeddingManager,
@@ -441,6 +381,66 @@ def test_embed_frame_samples__no_default_model_skips(
 
     assert "No embedding model loaded" in caplog.text
     assert _stored_embeddings(session=db_session) == []
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_collection_has_default_embedder__loads_and_reports_true(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """The helper ensures the default is loaded, then reports it is available.
+
+    The check is ensure-and-check: no default exists up front, and the first call
+    registers one as a side effect before returning True.
+    """
+    collection = create_collection(session=db_session)
+    mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=RandomEmbeddingGenerator(),
+    )
+    # No default embedding model exists before the call.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+    has_default = embed_samples.collection_has_default_embedder(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert has_default is True
+    # The call registered a default model as its side effect.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is not None
+    )
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_collection_has_default_embedder__false_when_none_loadable(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """The helper reports False when no default model can be loaded."""
+    collection = create_collection(session=db_session)
+    _disable_env_loader(mocker=mocker)
+
+    has_default = embed_samples.collection_has_default_embedder(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert has_default is False
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
 
 
 def _register_default_random_model(

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
+import numpy as np
 import pytest
+from numpy.typing import NDArray
+from PIL import Image
 from pytest_mock import MockerFixture
 from sqlmodel import Session, select
 
@@ -19,6 +22,7 @@ from lightly_studio.embed import embed_samples
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
+    collection_embedding_model_resolver,
     collection_resolver,
     sample_embedding_resolver,
 )
@@ -29,6 +33,11 @@ from tests.helpers_resolvers import (
     create_collection,
     create_image,
     create_images,
+)
+from tests.resolvers.video.helpers import (
+    VideoStub,
+    create_video_with_frames,
+    create_videos,
 )
 
 
@@ -106,6 +115,66 @@ def test_embed_text_for_collection__no_default_model(
         )
 
 
+@pytest.mark.usefixtures("patched_manager")
+def test_collection_has_default_embedder__loads_and_reports_true(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """The helper ensures the default is loaded, then reports it is available.
+
+    The check is ensure-and-check: no default exists up front, and the first call
+    registers one as a side effect before returning True.
+    """
+    mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=RandomEmbeddingGenerator(),
+    )
+    # No default embedding model exists before the call.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+    has_default = embed_samples.collection_has_default_embedder(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert has_default is True
+    # The call registered a default model as its side effect.
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is not None
+    )
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_collection_has_default_embedder__false_when_none_loadable(
+    db_session: Session,
+    collection: CollectionTable,
+    mocker: MockerFixture,
+) -> None:
+    """The helper reports False when no default model can be loaded."""
+    _disable_env_loader(mocker)
+
+    has_default = embed_samples.collection_has_default_embedder(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert has_default is False
+    assert (
+        collection_embedding_model_resolver.get_default_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+
 def test_embed_image_samples(
     db_session: Session,
     patched_manager: EmbeddingManager,
@@ -155,6 +224,57 @@ def test_embed_image_samples__no_default_model_skips(
 
     assert "No embedding model loaded" in caplog.text
     assert _stored_embeddings(session=db_session) == []
+
+
+def test_embed_video_samples(
+    db_session: Session,
+    patched_manager: EmbeddingManager,
+) -> None:
+    """Video samples are embedded and stored under the collection's default model."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        videos=[VideoStub(path=f"/videos/video_{index}.mp4") for index in range(3)],
+    )
+    model_id = _register_default_random_model(
+        manager=patched_manager, session=db_session, collection_id=video_collection.collection_id
+    )
+
+    embed_samples.embed_video_samples(
+        session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        embedding_model_id=model_id,
+    )
+    assert count == len(video_ids)
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_embed_video_samples__no_default_model_skips(
+    db_session: Session,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, video embedding is skipped and nothing stored."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        videos=[VideoStub(path="/videos/video_0.mp4")],
+    )
+    _disable_env_loader(mocker)
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_video_samples(
+            session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
 
 
 def test_embed_annotation_collection(
@@ -212,6 +332,115 @@ def test_embed_annotation_collection__no_default_model_skips(
 
     assert "No embedding model loaded" in caplog.text
     assert _stored_embeddings(session=db_session) == []
+
+
+def test_embed_frame_samples(
+    db_session: Session,
+    patched_manager: EmbeddingManager,
+) -> None:
+    """Video frames are embedded and stored for the given frame sample IDs."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    frames = create_video_with_frames(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        video=VideoStub(duration_s=1.0, fps=3.0),
+    )
+    model_id = _register_default_random_model(
+        manager=patched_manager,
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+    )
+    pil_frames = [Image.new("RGB", (2, 2)) for _ in frames.frame_sample_ids]
+
+    embed_samples.embed_frame_samples(
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        sample_ids=frames.frame_sample_ids,
+        pil_frames=pil_frames,
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        embedding_model_id=model_id,
+    )
+    assert count == len(frames.frame_sample_ids)
+
+
+def test_embed_frame_samples__matches_frames_to_sample_ids_in_order(
+    db_session: Session,
+    patched_manager: EmbeddingManager,
+) -> None:
+    """Each frame's embedding is stored against the sample ID at the same position."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    frames = create_video_with_frames(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        video=VideoStub(duration_s=1.0, fps=3.0),
+    )
+    # One distinct color per frame, so the stored vector identifies its source frame.
+    colors = [(10, 20, 30), (40, 50, 60), (70, 80, 90)]
+    assert len(frames.frame_sample_ids) == len(colors)
+    pil_frames = [Image.new("RGB", (2, 2), color=color) for color in colors]
+
+    model_id = patched_manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=_FirstPixelEmbeddingGenerator(),
+        collection_id=frames.video_frames_collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+    embed_samples.embed_frame_samples(
+        session=db_session,
+        collection_id=frames.video_frames_collection_id,
+        sample_ids=frames.frame_sample_ids,
+        pil_frames=pil_frames,
+    )
+
+    rows = sample_embedding_resolver.get_by_sample_ids(
+        session=db_session, sample_ids=frames.frame_sample_ids, embedding_model_id=model_id
+    )
+    assert len(rows) == len(colors)
+    for row, color in zip(rows, colors):
+        assert list(row.embedding) == pytest.approx(list(color))
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_embed_frame_samples__no_default_model_skips(
+    db_session: Session,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, frame embedding is skipped and nothing stored."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    frames = create_video_with_frames(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        video=VideoStub(duration_s=1.0, fps=3.0),
+    )
+    pil_frames = [Image.new("RGB", (2, 2)) for _ in frames.frame_sample_ids]
+    _disable_env_loader(mocker)
+
+    with caplog.at_level(logging.WARNING):
+        embed_samples.embed_frame_samples(
+            session=db_session,
+            collection_id=frames.video_frames_collection_id,
+            sample_ids=frames.frame_sample_ids,
+            pil_frames=pil_frames,
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(db_session) == []
+
+
+class _FirstPixelEmbeddingGenerator(RandomEmbeddingGenerator):
+    """Embeds each PIL image as its top-left pixel's RGB, so frame order is verifiable."""
+
+    def embed_pil_images(
+        self, images: list[Image.Image], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        _ = show_progress
+        return np.array([image.getpixel((0, 0)) for image in images], dtype=np.float32)
 
 
 def _register_default_random_model(

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -41,14 +41,6 @@ from tests.resolvers.video.helpers import (
 )
 
 
-@pytest.fixture
-def patched_manager(mocker: MockerFixture) -> EmbeddingManager:
-    """Route embed_samples to a fresh manager so tests never touch the shared singleton."""
-    manager = EmbeddingManager()
-    mocker.patch.object(EmbeddingManagerProvider, "get_embedding_manager", return_value=manager)
-    return manager
-
-
 class _FirstPixelEmbeddingGenerator(RandomEmbeddingGenerator):
     """Embeds each PIL image as its top-left pixel's RGB, so frame order is verifiable."""
 
@@ -57,6 +49,14 @@ class _FirstPixelEmbeddingGenerator(RandomEmbeddingGenerator):
     ) -> NDArray[np.float32]:
         _ = show_progress
         return np.array([image.getpixel((0, 0)) for image in images], dtype=np.float32)
+
+
+@pytest.fixture
+def patched_manager(mocker: MockerFixture) -> EmbeddingManager:
+    """Route embed_samples to a fresh manager so tests never touch the shared singleton."""
+    manager = EmbeddingManager()
+    mocker.patch.object(EmbeddingManagerProvider, "get_embedding_manager", return_value=manager)
+    return manager
 
 
 def test_embed_image_for_collection(
@@ -176,57 +176,6 @@ def test_embed_image_samples__no_default_model_skips(
     assert _stored_embeddings(session=db_session) == []
 
 
-def test_embed_video_samples(
-    db_session: Session,
-    patched_manager: EmbeddingManager,
-) -> None:
-    """Video samples are embedded and stored under the collection's default model."""
-    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
-    video_ids = create_videos(
-        session=db_session,
-        collection_id=video_collection.collection_id,
-        videos=[VideoStub(path=f"/videos/video_{index}.mp4") for index in range(3)],
-    )
-    model_id = _register_default_random_model(
-        manager=patched_manager, session=db_session, collection_id=video_collection.collection_id
-    )
-
-    embed_samples.embed_video_samples(
-        session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
-    )
-
-    count = sample_embedding_resolver.get_embedding_count(
-        session=db_session,
-        collection_id=video_collection.collection_id,
-        embedding_model_id=model_id,
-    )
-    assert count == len(video_ids)
-
-
-@pytest.mark.usefixtures("patched_manager")
-def test_embed_video_samples__no_default_model_skips(
-    db_session: Session,
-    mocker: MockerFixture,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """With no default model, video embedding is skipped and nothing stored."""
-    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
-    video_ids = create_videos(
-        session=db_session,
-        collection_id=video_collection.collection_id,
-        videos=[VideoStub(path="/videos/video_0.mp4")],
-    )
-    _disable_env_loader(mocker=mocker)
-
-    with caplog.at_level(level=logging.WARNING):
-        embed_samples.embed_video_samples(
-            session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
-        )
-
-    assert "No embedding model loaded" in caplog.text
-    assert _stored_embeddings(session=db_session) == []
-
-
 def test_embed_annotation_collection(
     db_session: Session,
     patched_manager: EmbeddingManager,
@@ -278,6 +227,57 @@ def test_embed_annotation_collection__no_default_model_skips(
     with caplog.at_level(level=logging.WARNING):
         embed_samples.embed_annotation_collection(
             session=db_session, annotation_collection_id=annotation_collection_id
+        )
+
+    assert "No embedding model loaded" in caplog.text
+    assert _stored_embeddings(session=db_session) == []
+
+
+def test_embed_video_samples(
+    db_session: Session,
+    patched_manager: EmbeddingManager,
+) -> None:
+    """Video samples are embedded and stored under the collection's default model."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        videos=[VideoStub(path=f"/videos/video_{index}.mp4") for index in range(3)],
+    )
+    model_id = _register_default_random_model(
+        manager=patched_manager, session=db_session, collection_id=video_collection.collection_id
+    )
+
+    embed_samples.embed_video_samples(
+        session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
+    )
+
+    count = sample_embedding_resolver.get_embedding_count(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        embedding_model_id=model_id,
+    )
+    assert count == len(video_ids)
+
+
+@pytest.mark.usefixtures("patched_manager")
+def test_embed_video_samples__no_default_model_skips(
+    db_session: Session,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no default model, video embedding is skipped and nothing stored."""
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=video_collection.collection_id,
+        videos=[VideoStub(path="/videos/video_0.mp4")],
+    )
+    _disable_env_loader(mocker=mocker)
+
+    with caplog.at_level(level=logging.WARNING):
+        embed_samples.embed_video_samples(
+            session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
         )
 
     assert "No embedding model loaded" in caplog.text

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -49,6 +49,16 @@ def patched_manager(mocker: MockerFixture) -> EmbeddingManager:
     return manager
 
 
+class _FirstPixelEmbeddingGenerator(RandomEmbeddingGenerator):
+    """Embeds each PIL image as its top-left pixel's RGB, so frame order is verifiable."""
+
+    def embed_pil_images(
+        self, images: list[Image.Image], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        _ = show_progress
+        return np.array([image.getpixel((0, 0)) for image in images], dtype=np.float32)
+
+
 def test_embed_image_for_collection(
     db_session: Session,
     patched_manager: EmbeddingManager,
@@ -431,16 +441,6 @@ def test_embed_frame_samples__no_default_model_skips(
 
     assert "No embedding model loaded" in caplog.text
     assert _stored_embeddings(db_session) == []
-
-
-class _FirstPixelEmbeddingGenerator(RandomEmbeddingGenerator):
-    """Embeds each PIL image as its top-left pixel's RGB, so frame order is verifiable."""
-
-    def embed_pil_images(
-        self, images: list[Image.Image], show_progress: bool = True
-    ) -> NDArray[np.float32]:
-        _ = show_progress
-        return np.array([image.getpixel((0, 0)) for image in images], dtype=np.float32)
 
 
 def _register_default_random_model(

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -128,7 +128,6 @@ def test_embed_text_for_collection__no_default_model(
 @pytest.mark.usefixtures("patched_manager")
 def test_collection_has_default_embedder__loads_and_reports_true(
     db_session: Session,
-    collection: CollectionTable,
     mocker: MockerFixture,
 ) -> None:
     """The helper ensures the default is loaded, then reports it is available.
@@ -136,6 +135,7 @@ def test_collection_has_default_embedder__loads_and_reports_true(
     The check is ensure-and-check: no default exists up front, and the first call
     registers one as a side effect before returning True.
     """
+    collection = create_collection(session=db_session)
     mocker.patch.object(
         embedding_manager,
         "_load_embedding_generator_from_env",
@@ -166,11 +166,11 @@ def test_collection_has_default_embedder__loads_and_reports_true(
 @pytest.mark.usefixtures("patched_manager")
 def test_collection_has_default_embedder__false_when_none_loadable(
     db_session: Session,
-    collection: CollectionTable,
     mocker: MockerFixture,
 ) -> None:
     """The helper reports False when no default model can be loaded."""
-    _disable_env_loader(mocker)
+    collection = create_collection(session=db_session)
+    _disable_env_loader(mocker=mocker)
 
     has_default = embed_samples.collection_has_default_embedder(
         session=db_session, collection_id=collection.collection_id
@@ -276,15 +276,15 @@ def test_embed_video_samples__no_default_model_skips(
         collection_id=video_collection.collection_id,
         videos=[VideoStub(path="/videos/video_0.mp4")],
     )
-    _disable_env_loader(mocker)
+    _disable_env_loader(mocker=mocker)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(level=logging.WARNING):
         embed_samples.embed_video_samples(
             session=db_session, collection_id=video_collection.collection_id, sample_ids=video_ids
         )
 
     assert "No embedding model loaded" in caplog.text
-    assert _stored_embeddings(db_session) == []
+    assert _stored_embeddings(session=db_session) == []
 
 
 def test_embed_annotation_collection(
@@ -429,9 +429,9 @@ def test_embed_frame_samples__no_default_model_skips(
         video=VideoStub(duration_s=1.0, fps=3.0),
     )
     pil_frames = [Image.new("RGB", (2, 2)) for _ in frames.frame_sample_ids]
-    _disable_env_loader(mocker)
+    _disable_env_loader(mocker=mocker)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(level=logging.WARNING):
         embed_samples.embed_frame_samples(
             session=db_session,
             collection_id=frames.video_frames_collection_id,
@@ -440,7 +440,7 @@ def test_embed_frame_samples__no_default_model_skips(
         )
 
     assert "No embedding model loaded" in caplog.text
-    assert _stored_embeddings(db_session) == []
+    assert _stored_embeddings(session=db_session) == []
 
 
 def _register_default_random_model(


### PR DESCRIPTION
## What has changed and why?

Part 4 of a 4-PR stack that moves the `EmbeddingManager` interface behind an `embed_samples` module, splitting prototype #2220 into reviewable pieces.

This PR:
- Add `collection_has_default_embedder`, `embed_video_samples`, and `embed_frame_samples` to `embed/embed_samples.py`.
- Migrate `core/video/video_dataset.py` and `add_videos.py` off `EmbeddingManager`.

## How has it been tested?

New unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Video and frame samples now use the collection’s default embedding model during ingestion.
  - Added support for generating embeddings for video frames and associating them with the correct samples.

- **Bug Fixes**
  - When no default embedding model is available, embedding is skipped and a warning is provided instead of storing incomplete results.

- **Refactor**
  - Unified video and frame embedding workflows for more consistent behavior across ingestion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->