### PR TITLE
perf: improve data distribution loading performance (LIG-10729)

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -61,6 +61,9 @@ class MetadataHistogramsRequest(BaseModel):
     bin_count: int = Field(
         _DEFAULT_BIN_COUNT, ge=1, le=200, description="Number of equal-width bins per histogram"
     )
+    fields: list[str] | None = Field(
+        None, description="Numeric fields to histogram; all numeric fields are computed when absent"
+    )
 
 
 @metadata_router.post("/metadata/histograms", response_model=dict[str, HistogramView])
@@ -89,6 +92,7 @@ def get_metadata_histograms(
         collection_id=collection_id,
         filters=request.filters if request else None,
         bin_count=request.bin_count if request else _DEFAULT_BIN_COUNT,
+        fields=request.fields if request else None,
     )
 
 

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -129,8 +129,8 @@ def json_object_unnest_lateral(
             f" FROM unnest(json_keys(COALESCE({column_sql}, '{{}}'))) t(key))"
         )
     else:
-        # PostgreSQL: jsonb_each_text returns (key text, value text).
-        sql = f"jsonb_each_text(COALESCE({column_sql}, '{{}}'))"
+        # PostgreSQL: json_each_text returns (key text, value text) for the json type.
+        sql = f"json_each_text(COALESCE({column_sql}, '{{}}'))"
     return lateral(
         text(sql).columns(sqlalchemy.column("key"), sqlalchemy.column("value")),
         name=name,

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -131,8 +131,11 @@ def json_object_unnest_lateral(
             f" FROM unnest(json_keys(COALESCE({column_sql}, '{{}}'))) t(key))"
         )
     else:
-        # PostgreSQL: json_each_text returns (key text, value text) for the json type.
-        sql = f"json_each_text(COALESCE({column_sql}, '{{}}'))"
+        # PostgreSQL: json_each_text is a set-returning function.  Wrap it in a SELECT
+        # so that SQLAlchemy's lateral(text(...)) produces LATERAL (SELECT key, value
+        # FROM json_each_text(...)) rather than the bare LATERAL (json_each_text(...))
+        # that PostgreSQL rejects.
+        sql = f"(SELECT key, value FROM json_each_text(COALESCE({column_sql}, '{{}}')))"
     return sqlalchemy.lateral(
         sqlalchemy.text(sql).columns(sqlalchemy.column("key"), sqlalchemy.column("value")),
         name=name,

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -122,10 +122,12 @@ def json_object_unnest_lateral(
     """
     if dialect_name == _DUCKDB_DIALECT:
         # DuckDB: unnest(json_keys(col)) gives one key per row; re-extract the value
-        # using json_extract_string with a JSON Pointer so keys with / or ~ are safe.
+        # using a JSON Pointer.  JSON Pointer requires ~ → ~0 and / → ~1 inside each
+        # segment, so we escape the key in SQL before prefixing the leading '/'.
         sql = (
             f"(SELECT key,"
-            f" json_extract_string(COALESCE({column_sql}, '{{}}'), '/' || key) AS value"
+            f" json_extract_string(COALESCE({column_sql}, '{{}}'),"
+            f"   '/' || replace(replace(key, '~', '~0'), '/', '~1')) AS value"
             f" FROM unnest(json_keys(COALESCE({column_sql}, '{{}}'))) t(key))"
         )
     else:

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -17,8 +17,9 @@ import re
 from typing import Any, cast
 
 import sqlalchemy
-from sqlalchemy import ColumnElement, Text
+from sqlalchemy import ColumnElement, Text, lateral, text
 from sqlalchemy.engine.interfaces import Dialect
+from sqlalchemy.sql.selectable import LateralFromClause
 from sqlalchemy.types import TypeDecorator
 
 _DUCKDB_DIALECT = "duckdb"
@@ -96,6 +97,44 @@ def json_extract_key_as_float(column: Any, key: str) -> ColumnElement[float]:
         The extracted value as a float.
     """
     return cast(ColumnElement[float], column[_bind_key(key)].as_float())
+
+
+def json_object_unnest_lateral(
+    column_sql: str, dialect_name: str, name: str = "kv"
+) -> LateralFromClause:
+    """Return a LATERAL subquery that unnests a JSON object column into (key, value) rows.
+
+    Both ``key`` and ``value`` are text columns.  JSON ``null`` values become SQL NULL
+    in ``value`` on both databases.  The lateral can be joined with ``join(kv, true())``.
+
+    ``column_sql`` must be the already-compiled SQL string for the JSON column, e.g.
+    ``"metadata.data"``.  Obtain it by calling
+    ``column_expr.compile(dialect=session.get_bind().dialect)`` before calling this
+    function.
+
+    Args:
+        column_sql: Compiled SQL reference to the JSON object column.
+        dialect_name: SQLAlchemy dialect name, e.g. ``"duckdb"`` or ``"postgresql"``.
+        name: Alias name for the lateral; defaults to ``"kv"``.
+
+    Returns:
+        A :class:`LateralFromClause` with columns ``key`` and ``value``.
+    """
+    if dialect_name == _DUCKDB_DIALECT:
+        # DuckDB: unnest(json_keys(col)) gives one key per row; re-extract the value
+        # using json_extract_string with a JSON Pointer so keys with / or ~ are safe.
+        sql = (
+            f"(SELECT key,"
+            f" json_extract_string(COALESCE({column_sql}, '{{}}'), '/' || key) AS value"
+            f" FROM unnest(json_keys(COALESCE({column_sql}, '{{}}'))) t(key))"
+        )
+    else:
+        # PostgreSQL: jsonb_each_text returns (key text, value text).
+        sql = f"jsonb_each_text(COALESCE({column_sql}, '{{}}'))"
+    return lateral(
+        text(sql).columns(sqlalchemy.column("key"), sqlalchemy.column("value")),
+        name=name,
+    )
 
 
 class _JsonKeyType(TypeDecorator[str]):

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -17,7 +17,7 @@ import re
 from typing import Any, cast
 
 import sqlalchemy
-from sqlalchemy import ColumnElement, Text, lateral, text
+from sqlalchemy import ColumnElement, Text
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql.selectable import LateralFromClause
 from sqlalchemy.types import TypeDecorator
@@ -133,8 +133,8 @@ def json_object_unnest_lateral(
     else:
         # PostgreSQL: json_each_text returns (key text, value text) for the json type.
         sql = f"json_each_text(COALESCE({column_sql}, '{{}}'))"
-    return lateral(
-        text(sql).columns(sqlalchemy.column("key"), sqlalchemy.column("value")),
+    return sqlalchemy.lateral(
+        sqlalchemy.text(sql).columns(sqlalchemy.column("key"), sqlalchemy.column("value")),
         name=name,
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/get_counts_grouped_by_sample_tag.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/get_counts_grouped_by_sample_tag.py
@@ -38,7 +38,7 @@ def get_counts_grouped_by_sample_tag(  # noqa: PLR0913
             annotation_collection_ids=list(annotation_collection_ids),
         )
     if image_filter is not None:
-        query = image_filter.apply(query)  # type: ignore[type-var]
+        query = image_filter.apply(query)
     query = query.group_by(
         col(SampleTagLinkTable.tag_id),
         AnnotationLabelTable.annotation_label_name,

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -83,14 +83,19 @@ def get_metadata_value_counts(
         active_keys = _active_metadata_filter_keys(field_filters)
         groups[active_keys].append(key)
 
-    total_count = _get_total_count(session=session, collection_id=collection_id, filters=filters)
-
     result: dict[str, MetadataValueCountsView] = {}
     for _active_keys, group_fields in groups.items():
         # Reconstruct the shared filter for this group from the first field
         # (all fields in the group have the same effective filter).
         group_filters = metadata_helpers.without_metadata_key_filter(
             filters=filters, metadata_key=group_fields[0]
+        )
+        # Total count must use the same effective filter as the value query so that
+        # __missing__ = total - non_null stays non-negative. Using the original
+        # filter here would exclude samples the value query includes (e.g. city=A
+        # would hide city=B samples from the total but not from the city value query).
+        group_total = _get_total_count(
+            session=session, collection_id=collection_id, filters=group_filters
         )
         raw_counts = _query_value_counts(
             session=session,
@@ -103,7 +108,7 @@ def get_metadata_value_counts(
             result[key] = _build_value_counts_view(
                 key_counts=key_counts,
                 metadata_type=schema[key],
-                total_count=total_count,
+                total_count=group_total,
             )
 
     return result

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import sqlalchemy
 import sqlmodel
-from sqlalchemy import func, true
+from sqlalchemy import func
 from sqlmodel import Session
 
 from lightly_studio.database import db_json
@@ -146,7 +146,7 @@ def _query_value_counts(
             sqlmodel.col(SampleMetadataTable.sample_id) == sqlmodel.col(SampleTable.sample_id),
             isouter=True,
         )
-        .join(kv, true())
+        .join(kv, sqlalchemy.true())
         .where(SampleTable.collection_id == collection_id)
         .where(kv_key.in_(keys))
         .group_by(kv_key, kv_value)

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from uuid import UUID
 
+import sqlalchemy
 import sqlmodel
-from sqlalchemy import func
-from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy import func, true
 from sqlmodel import Session
 
 from lightly_studio.database import db_json
@@ -38,12 +39,16 @@ def get_metadata_value_counts(
 ) -> dict[str, MetadataValueCountsView]:
     """Count categorical metadata values for a collection.
 
-    Each field's own metadata filter is excluded while all other filters apply.
-    Results contain the 20 most frequent concrete values, followed by an
-    ``__other__`` row aggregating the less frequent concrete values and a
-    ``__missing__`` row counting the samples with an absent or null value. Both
-    aggregate rows are omitted when their count is zero, so the counts always sum
-    to the number of samples in scope.
+    Each field's own metadata filter is excluded while all other filters apply
+    (faceted-search behavior).  Results contain the 20 most frequent concrete
+    values, followed by an ``__other__`` row aggregating the less frequent
+    concrete values and a ``__missing__`` row counting the samples with an absent
+    or null value.  Both aggregate rows are omitted when their count is zero, so
+    the counts always sum to the number of samples in scope.
+
+    Fields that share the same effective filter set are aggregated in a single
+    database query, so the number of round-trips is bounded by the number of
+    distinct active metadata filters rather than the total number of fields.
 
     Args:
         session: The database session.
@@ -58,57 +63,156 @@ def get_metadata_value_counts(
         A mapping from categorical metadata keys to their value counts.
     """
     schema = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
-    result: dict[str, MetadataValueCountsView] = {}
-    for key, metadata_type in schema.items():
-        if metadata_type not in CATEGORICAL_TYPE_NAMES:
-            continue
-        if fields is not None and key not in fields:
-            continue
+    categorical_fields = [
+        key
+        for key, metadata_type in schema.items()
+        if metadata_type in CATEGORICAL_TYPE_NAMES and (fields is None or key in fields)
+    ]
+
+    # Group fields by their effective filter set. Fields whose own key is not
+    # present in any active metadata filter all share the baseline filter and are
+    # queried together. Fields whose key IS actively filtered each need the
+    # baseline minus that one filter, so they form their own singleton group.
+    groups: dict[frozenset[str], list[str]] = defaultdict(list)
+    for key in categorical_fields:
         field_filters = metadata_helpers.without_metadata_key_filter(
             filters=filters, metadata_key=key
         )
-        result[key] = _get_field_value_counts(
+        # Use the remaining metadata filter keys as the group identity. Two fields
+        # share a group iff their effective filter sets are identical.
+        active_keys = _active_metadata_filter_keys(field_filters)
+        groups[active_keys].append(key)
+
+    total_count = _get_total_count(session=session, collection_id=collection_id, filters=filters)
+
+    result: dict[str, MetadataValueCountsView] = {}
+    for _active_keys, group_fields in groups.items():
+        # Reconstruct the shared filter for this group from the first field
+        # (all fields in the group have the same effective filter).
+        group_filters = metadata_helpers.without_metadata_key_filter(
+            filters=filters, metadata_key=group_fields[0]
+        )
+        raw_counts = _query_value_counts(
             session=session,
             collection_id=collection_id,
-            metadata_key=key,
-            metadata_type=metadata_type,
-            filters=field_filters,
+            keys=group_fields,
+            filters=group_filters,
         )
+        for key in group_fields:
+            key_counts = raw_counts.get(key, {})
+            result[key] = _build_value_counts_view(
+                key_counts=key_counts,
+                metadata_type=schema[key],
+                total_count=total_count,
+            )
+
     return result
 
 
-def _get_field_value_counts(
+def _query_value_counts(
     session: Session,
     collection_id: UUID,
-    metadata_key: str,
-    metadata_type: str,
+    keys: list[str],
     filters: ImageFilter | None,
-) -> MetadataValueCountsView:
-    value_expr = db_json.json_extract_key_as_text(column=SampleMetadataTable.data, key=metadata_key)
-    rows = _get_top_value_counts(
-        session=session,
-        collection_id=collection_id,
-        value_expr=value_expr,
-        filters=filters,
+) -> dict[str, dict[str | None, int]]:
+    """Aggregate value counts for all ``keys`` in a single query.
+
+    Returns a nested mapping of ``{key: {value_or_None: count}}``.  SQL NULL
+    values (absent or JSON-null fields) map to ``None`` in the inner dict.
+    """
+    # Compile the metadata column reference for the dialect so that
+    # json_object_unnest_lateral can embed it in the correct raw SQL fragment.
+    bind = session.get_bind()
+    data_col = sqlalchemy.inspect(SampleMetadataTable).mapper.column_attrs["data"].columns[0]
+    data_col_sql = str(data_col.compile(dialect=bind.dialect))
+    # Lateral unnest expands each sample's JSON object into (key, value) rows.
+    # Both dialects expose a "key" text column and a "value" text column (SQL NULL
+    # for JSON null); see json_object_unnest_lateral in db_json for per-dialect SQL.
+    kv = db_json.json_object_unnest_lateral(column_sql=data_col_sql, dialect_name=bind.dialect.name)
+    kv_key = kv.c.key
+    kv_value = kv.c.value
+
+    count_expr = func.count().label("cnt")
+    query = (
+        sqlmodel.select(kv_key.label("key"), kv_value.label("val"), count_expr)
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            sqlmodel.col(SampleMetadataTable.sample_id) == sqlmodel.col(SampleTable.sample_id),
+            isouter=True,
+        )
+        .join(kv, true())
+        .where(SampleTable.collection_id == collection_id)
+        .where(kv_key.in_(keys))
+        .group_by(kv_key, kv_value)
     )
+    query = metadata_helpers.apply_image_filters(
+        query=query, collection_id=collection_id, filters=filters
+    )
+
+    result: dict[str, dict[str | None, int]] = defaultdict(dict)
+    for key, val, count in session.execute(query).all():
+        result[str(key)][val] = int(count)
+    return result
+
+
+def _get_total_count(
+    session: Session,
+    collection_id: UUID,
+    filters: ImageFilter | None,
+) -> int:
+    """Return the total number of samples in scope under ``filters``."""
+    query = (
+        sqlmodel.select(func.count())
+        .select_from(SampleTable)
+        .where(SampleTable.collection_id == collection_id)
+    )
+    query = metadata_helpers.apply_image_filters(
+        query=query, collection_id=collection_id, filters=filters
+    )
+    return int(session.execute(query).scalar_one())
+
+
+def _build_value_counts_view(
+    key_counts: dict[str | None, int],
+    metadata_type: str,
+    total_count: int,
+) -> MetadataValueCountsView:
+    """Build the value-counts view for one field from raw aggregation results.
+
+    Takes the top-20 concrete values, then appends ``__other__`` and
+    ``__missing__`` aggregates when their counts are non-zero.
+
+    Args:
+        key_counts: Mapping from raw string value (or None for SQL NULL) to count.
+        metadata_type: The schema type name of this field (e.g. ``"string"``).
+        total_count: Total samples in scope, used to compute the missing count.
+
+    Returns:
+        The assembled view for this field.
+    """
+    # Separate NULL (missing) from concrete values.
+    missing_count = key_counts.get(None, 0)
+    concrete: list[tuple[str, int]] = [
+        (val, cnt) for val, cnt in key_counts.items() if val is not None
+    ]
+    concrete.sort(key=lambda pair: (-pair[1], pair[0]))
+
+    top = concrete[:_TOP_VALUE_COUNT]
+    other_count = sum(cnt for _, cnt in concrete[_TOP_VALUE_COUNT:])
+
+    # Samples with no metadata row at all are not in key_counts; add them to missing.
+    non_null_count = sum(cnt for _, cnt in concrete)
+    missing_count = total_count - non_null_count
+
     value_counts = [
         MetadataValueCountView(
-            value=_parse_value(value=value, metadata_type=metadata_type), count=int(count)
+            value=_parse_value(value=val, metadata_type=metadata_type), count=cnt
         )
-        for value, count in rows
+        for val, cnt in top
     ]
-    total_count, non_null_count = _get_scope_counts(
-        session=session,
-        collection_id=collection_id,
-        value_expr=value_expr,
-        filters=filters,
-    )
-    # Built here rather than through ``_parse_value``, which would coerce the
-    # sentinels to ``False`` on a boolean field.
-    other_count = non_null_count - sum(int(count) for _, count in rows)
     if other_count > 0:
         value_counts.append(MetadataValueCountView(value=_OTHER_VALUE_SENTINEL, count=other_count))
-    missing_count = total_count - non_null_count
     if missing_count > 0:
         value_counts.append(
             MetadataValueCountView(value=_MISSING_VALUE_SENTINEL, count=missing_count)
@@ -116,68 +220,15 @@ def _get_field_value_counts(
     return MetadataValueCountsView(value_counts=value_counts)
 
 
-def _get_top_value_counts(
-    session: Session,
-    collection_id: UUID,
-    value_expr: ColumnElement[str],
-    filters: ImageFilter | None,
-) -> list[tuple[str, int]]:
-    count_expr = func.count().label("value_count")
-    query = (
-        sqlmodel.select(value_expr, count_expr)
-        .select_from(SampleTable)
-        .join(
-            SampleMetadataTable,
-            sqlmodel.col(SampleMetadataTable.sample_id) == sqlmodel.col(SampleTable.sample_id),
-            isouter=True,
-        )
-        .where(SampleTable.collection_id == collection_id)
-        .where(value_expr.isnot(None))
-        .group_by(value_expr)
-        .order_by(count_expr.desc(), value_expr.asc())
-        .limit(_TOP_VALUE_COUNT)
-    )
-    query = metadata_helpers.apply_image_filters(
-        query=query, collection_id=collection_id, filters=filters
-    )
-    return [(str(value), int(count)) for value, count in session.execute(query).all()]
-
-
-def _get_scope_counts(
-    session: Session,
-    collection_id: UUID,
-    value_expr: ColumnElement[str],
-    filters: ImageFilter | None,
-) -> tuple[int, int]:
-    """Count the samples in scope and those holding a concrete value.
-
-    Args:
-        session: The database session.
-        collection_id: The collection whose samples are counted.
-        value_expr: Expression extracting the metadata value of the counted field.
-        filters: Optional image filters restricting the counted samples. Must be
-            the same filters the value counts were taken under, so the totals
-            describe the same scope.
-
-    Returns:
-        The number of samples in scope and, of those, the number whose value is
-        neither absent nor null.
-    """
-    query = (
-        sqlmodel.select(func.count(), func.count(value_expr))
-        .select_from(SampleTable)
-        .join(
-            SampleMetadataTable,
-            sqlmodel.col(SampleMetadataTable.sample_id) == sqlmodel.col(SampleTable.sample_id),
-            isouter=True,
-        )
-        .where(SampleTable.collection_id == collection_id)
-    )
-    query = metadata_helpers.apply_image_filters(
-        query=query, collection_id=collection_id, filters=filters
-    )
-    total_count, non_null_count = session.execute(query).one()
-    return int(total_count), int(non_null_count)
+def _active_metadata_filter_keys(filters: ImageFilter | None) -> frozenset[str]:
+    """Return the set of metadata filter keys active in ``filters``."""
+    if (
+        filters is None
+        or filters.sample_filter is None
+        or not filters.sample_filter.metadata_filters
+    ):
+        return frozenset()
+    return frozenset(f.key for f in filters.sample_filter.metadata_filters)
 
 
 def _parse_value(value: str, metadata_type: str) -> str | bool:

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
+import sqlalchemy
 from sqlalchemy import Integer, cast, func
 from sqlmodel import Session, col, select
 
@@ -72,8 +73,9 @@ def get_metadata_histograms(
     collection_id: UUID,
     filters: ImageFilter | None = None,
     bin_count: int = _HISTOGRAM_BIN_COUNT,
+    fields: list[str] | None = None,
 ) -> dict[str, HistogramView]:
-    """Compute value-distribution histograms for all numeric metadata keys.
+    """Compute value-distribution histograms for the numeric metadata keys.
 
     Bin edges always span the full (unfiltered) value range of each key, so
     the chart's x-axis stays stable while the counts change with the active
@@ -81,24 +83,38 @@ def get_metadata_histograms(
     (faceted-search behavior): the full shape of the field being adjusted
     stays visible while every other filter applies.
 
+    Min/max values for all fields are fetched in a single query before the
+    per-field bucketing queries run, so the number of DB round-trips is
+    ``len(numeric_fields) + 1`` rather than ``2 * len(numeric_fields)``.
+
     Args:
         session: The database session.
         collection_id: The collection's UUID.
         filters: Optional sample filters restricting which values are counted.
         bin_count: Number of equal-width bins per histogram.
+        fields: Numeric fields to histogram. Pass only the fields that will be
+            rendered to avoid running DB queries for unused fields. All numeric
+            fields are histogrammed when absent.
 
     Returns:
         Mapping of metadata key to its histogram.
     """
     merged = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
+    numeric_fields = [
+        key
+        for key, metadata_type in merged.items()
+        if metadata_type in NUMERIC_TYPE_NAMES and (fields is None or key in fields)
+    ]
+    if not numeric_fields:
+        return {}
+
+    all_stats = _get_all_fields_min_max(
+        session=session, collection_id=collection_id, keys=numeric_fields
+    )
 
     histograms: dict[str, HistogramView] = {}
-    for key, metadata_type in merged.items():
-        if metadata_type not in NUMERIC_TYPE_NAMES:
-            continue
-        stats = _get_metadata_min_max_count(
-            session=session, collection_id=collection_id, metadata_key=key
-        )
+    for key in numeric_fields:
+        stats = all_stats.get(key)
         if stats is None:
             continue
         histograms[key] = _compute_histogram(
@@ -110,6 +126,67 @@ def get_metadata_histograms(
             bin_count=bin_count,
         )
     return histograms
+
+
+def _get_all_fields_min_max(
+    session: Session,
+    collection_id: UUID,
+    keys: list[str],
+) -> dict[str, tuple[float, float, int]]:
+    """Fetch min, max, and count for all numeric ``keys`` in a single query.
+
+    Uses a lateral unnest to expand the JSON object once per sample and
+    aggregate all requested keys in one pass over the table.
+
+    Args:
+        session: The database session.
+        collection_id: The collection whose metadata is aggregated.
+        keys: The numeric metadata keys to aggregate.
+
+    Returns:
+        Mapping from key to ``(min, max, count)``; keys with no non-null
+        values are absent from the result.
+    """
+    bind = session.get_bind()
+    data_col = sqlalchemy.inspect(SampleMetadataTable).mapper.column_attrs["data"].columns[0]
+    data_col_sql = str(data_col.compile(dialect=bind.dialect))
+
+    kv = db_json.json_object_unnest_lateral(
+        column_sql=data_col_sql, dialect_name=bind.dialect.name, name="kv_mm"
+    )
+    kv_key = kv.c.key
+    kv_value = kv.c.value
+
+    # Cast the text value to float for aggregation. Non-numeric values in
+    # nominally-numeric fields are excluded by the IS NOT NULL guard on kv_value
+    # (json_extract_string returns NULL for JSON null, and the cast would fail
+    # for non-numeric strings, but the schema ensures these keys hold numbers).
+    float_value = cast(kv_value, sqlalchemy.Float)
+
+    query = (
+        select(
+            kv_key.label("key"),
+            func.min(float_value).label("min_val"),
+            func.max(float_value).label("max_val"),
+            func.count(float_value).label("cnt"),
+        )
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+        )
+        .join(kv, sqlalchemy.true())
+        .where(SampleTable.collection_id == collection_id)
+        .where(kv_key.in_(keys))
+        .where(kv_value.isnot(None))
+        .group_by(kv_key)
+    )
+
+    result: dict[str, tuple[float, float, int]] = {}
+    for key, min_val, max_val, cnt in session.execute(query).all():
+        if min_val is not None and max_val is not None and cnt > 0:
+            result[str(key)] = (float(min_val), float(max_val), int(cnt))
+    return result
 
 
 def _get_metadata_min_max_count(

--- a/lightly_studio/src/lightly_studio/type_definitions.py
+++ b/lightly_studio/src/lightly_studio/type_definitions.py
@@ -31,6 +31,7 @@ QueryType = TypeVar(
     Select[tuple[Any, int]],
     Select[tuple[int, int]],
     Select[tuple[str, int]],
+    Select[tuple[Any, Any, int]],
     Select[tuple[UUID, int]],
     Select[tuple[AnnotationBaseTable, Any]],
     Select[tuple[ImageTable, Any]],

--- a/lightly_studio/tests/api/routes/api/test_enterprise.py
+++ b/lightly_studio/tests/api/routes/api/test_enterprise.py
@@ -2,11 +2,13 @@ import json
 import os
 
 import fsspec
-from adlfs import AzureBlobFileSystem  # type: ignore[import-untyped]
+import pytest
 from fastapi.testclient import TestClient
-from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
-from s3fs import S3FileSystem  # type: ignore[import-untyped]
+
+AzureBlobFileSystem = pytest.importorskip("adlfs", reason="adlfs not installed").AzureBlobFileSystem
+GCSFileSystem = pytest.importorskip("gcsfs", reason="gcsfs not installed").GCSFileSystem
+S3FileSystem = pytest.importorskip("s3fs", reason="s3fs not installed").S3FileSystem
 
 
 def test_refresh_cloud_credentials__sets_env_vars(

--- a/lightly_studio/tests/dataset/test_fsspec_lister.py
+++ b/lightly_studio/tests/dataset/test_fsspec_lister.py
@@ -7,11 +7,12 @@ from typing import Any
 import boto3
 import fsspec
 import pytest
-import s3fs  # type: ignore[import-untyped]
 from moto.server import ThreadedMotoServer
 from pytest_mock import MockerFixture
 
 from lightly_studio.dataset import fsspec_lister
+
+s3fs = pytest.importorskip("s3fs", reason="s3fs not installed")
 
 
 @pytest.fixture(scope="session")

--- a/lightly_studio/tests/metadata/test_get_metadata_histograms.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_histograms.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Generator
-from contextlib import contextmanager
 from typing import Any
 from uuid import UUID
 
@@ -19,7 +19,7 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import create_collection, create_image
 
 
-@contextmanager
+@contextlib.contextmanager
 def _count_queries(session: Session) -> Generator[list[str], None, None]:
     """Context manager that records all SQL statements executed on the session."""
     executed: list[str] = []

--- a/lightly_studio/tests/metadata/test_get_metadata_histograms.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_histograms.py
@@ -1,9 +1,14 @@
 """Test the filtered metadata histograms resolver."""
 
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 from uuid import UUID
 
 import pytest
+import sqlalchemy
 from sqlmodel import Session
 
 from lightly_studio.models.metadata import SampleMetadataTable
@@ -12,6 +17,29 @@ from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataF
 from lightly_studio.resolvers.metadata_resolver.sample import get_metadata_info
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import create_collection, create_image
+
+
+@contextmanager
+def _count_queries(session: Session) -> Generator[list[str], None, None]:
+    """Context manager that records all SQL statements executed on the session."""
+    executed: list[str] = []
+
+    def _before_execute(
+        _conn: Any,
+        _cursor: Any,
+        statement: str,
+        _parameters: Any,
+        _context: Any,
+        _executemany: Any,
+    ) -> None:
+        executed.append(statement)
+
+    bind = session.get_bind()
+    sqlalchemy.event.listen(bind, "before_cursor_execute", _before_execute)
+    try:
+        yield executed
+    finally:
+        sqlalchemy.event.remove(bind, "before_cursor_execute", _before_execute)
 
 
 def _create_samples_with_scores(db_session: Session, collection_id: UUID) -> None:
@@ -269,3 +297,76 @@ def test_get_metadata_histograms__degenerate_bin_skips_explicit_json_null(
     assert constant.bin_edges == pytest.approx([5.0, 5.0])
     # score <= 3 keeps 4 samples carrying the constant, plus the null row on top.
     assert constant.counts == [4]
+
+
+def test_get_metadata_histograms__fields_limits_computed_keys(
+    db_session: Session,
+) -> None:
+    """Only fields listed in the fields argument are returned."""
+    collection = create_collection(session=db_session)
+    _create_samples_with_scores(db_session, collection.collection_id)
+
+    histograms = get_metadata_info.get_metadata_histograms(
+        session=db_session,
+        collection_id=collection.collection_id,
+        fields=["score"],
+    )
+
+    assert set(histograms) == {"score"}
+    assert len(histograms["score"].counts) > 0
+
+
+def test_get_metadata_histograms__query_count_does_not_grow_with_field_count(
+    db_session: Session,
+) -> None:
+    """Min/max are batched in one query regardless of how many numeric fields exist.
+
+    Without the optimisation ``_get_all_fields_min_max`` the number of DB
+    round-trips would be ``2 * N`` (one min/max + one bucketing query per field).
+    With it the round-trips are ``N + 1`` (one combined min/max + N bucketings).
+    We verify that the constant overhead (the ``+1``) stays flat: adding more
+    fields must not increase the query count proportionally more than the number
+    of extra bucketing queries.
+    """
+    collection_few = create_collection(session=db_session)
+    collection_many = create_collection(session=db_session)
+
+    few_fields = {f"field_{i}": float(i) for i in range(3)}
+    many_fields = {f"field_{i}": float(i) for i in range(20)}
+
+    def _add_sample(collection_id: UUID, metadata: dict[str, float]) -> None:
+        sample = create_image(
+            session=db_session,
+            collection_id=collection_id,
+            file_path_abs=f"/path/to/{collection_id}-{next(_counter)}.png",
+        ).sample
+        for key, value in metadata.items():
+            sample[key] = value
+
+    _counter = iter(range(10_000))
+    _add_sample(collection_few.collection_id, few_fields)
+    _add_sample(collection_many.collection_id, many_fields)
+
+    with _count_queries(db_session) as few_queries:
+        get_metadata_info.get_metadata_histograms(
+            session=db_session,
+            collection_id=collection_few.collection_id,
+            fields=list(few_fields),
+        )
+    with _count_queries(db_session) as many_queries:
+        get_metadata_info.get_metadata_histograms(
+            session=db_session,
+            collection_id=collection_many.collection_id,
+            fields=list(many_fields),
+        )
+
+    # few_queries = schema + 1 min/max + 3 bucketing = ~5
+    # many_queries = schema + 1 min/max + 20 bucketing = ~22
+    # The difference must be proportional only to the extra bucketing queries,
+    # not doubled (which would indicate the old 2*N pattern).
+    extra_fields = len(many_fields) - len(few_fields)
+    extra_queries = len(many_queries) - len(few_queries)
+    assert extra_queries <= extra_fields + 1, (
+        f"Query overhead grew by {extra_queries} for {extra_fields} extra fields "
+        f"— more than one extra query per field suggests unbatched min/max calls"
+    )

--- a/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Generator
-from contextlib import contextmanager
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -18,7 +18,7 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import create_collection, create_image
 
 
-@contextmanager
+@contextlib.contextmanager
 def _count_queries(session: Session) -> Generator[list[str], None, None]:
     """Context manager that records all SQL statements executed on the session."""
     executed: list[str] = []

--- a/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 from uuid import UUID, uuid4
 
+import sqlalchemy
 from sqlmodel import Session
 
 from lightly_studio.models.metadata import SampleMetadataTable
@@ -13,6 +16,24 @@ from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataF
 from lightly_studio.resolvers.metadata_resolver.sample import categorical_value_counts
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import create_collection, create_image
+
+
+@contextmanager
+def _count_queries(session: Session) -> Generator[list[str], None, None]:
+    """Context manager that records all SQL statements executed on the session."""
+    executed: list[str] = []
+
+    def _before_execute(
+        _conn: Any, _cursor: Any, statement: str, _parameters: Any, _context: Any, _executemany: Any
+    ) -> None:
+        executed.append(statement)
+
+    bind = session.get_bind()
+    sqlalchemy.event.listen(bind, "before_cursor_execute", _before_execute)
+    try:
+        yield executed
+    finally:
+        sqlalchemy.event.remove(bind, "before_cursor_execute", _before_execute)
 
 
 def test_get_metadata_value_counts__categorical_values_and_missing(
@@ -276,6 +297,81 @@ def test_get_metadata_value_counts__literal_top_level_keys(db_session: Session) 
 
     assert counts["site.name"].value_counts[0].value == "Zurich"
     assert counts["owner's site"].value_counts[0].value == "primary"
+
+
+def test_get_metadata_value_counts__query_count_does_not_grow_with_field_count(
+    db_session: Session,
+) -> None:
+    """DB round-trips must stay constant as the number of categorical fields grows.
+
+    Without active metadata filters all fields are batched into a single unnest
+    query plus one total-count query, so the number of statements must not grow
+    linearly with the number of fields.
+    """
+    collection_few = create_collection(session=db_session)
+    collection_many = create_collection(session=db_session)
+    few_fields = {f"field_{i}": f"value_{i}" for i in range(3)}
+    many_fields = {f"field_{i}": f"value_{i}" for i in range(20)}
+    _create_sample(
+        db_session=db_session,
+        collection_id=collection_few.collection_id,
+        metadata=few_fields,
+    )
+    _create_sample(
+        db_session=db_session,
+        collection_id=collection_many.collection_id,
+        metadata=many_fields,
+    )
+
+    with _count_queries(db_session) as few_queries:
+        categorical_value_counts.get_metadata_value_counts(
+            session=db_session,
+            collection_id=collection_few.collection_id,
+            fields=list(few_fields),
+        )
+    with _count_queries(db_session) as many_queries:
+        categorical_value_counts.get_metadata_value_counts(
+            session=db_session,
+            collection_id=collection_many.collection_id,
+            fields=list(many_fields),
+        )
+
+    assert len(few_queries) == len(many_queries), (
+        f"Query count grew from {len(few_queries)} (3 fields) to "
+        f"{len(many_queries)} (20 fields) — O(N) queries detected"
+    )
+
+
+def test_get_metadata_value_counts__query_count_with_active_filter(
+    db_session: Session,
+) -> None:
+    """With one active metadata filter the query count is bounded by the filter count.
+
+    The filtered field gets its own query (its filter must be excluded); all other
+    fields are still batched together. So the total must be much less than N*2.
+    """
+    collection = create_collection(session=db_session)
+    fields = {f"field_{i}": f"value_{i}" for i in range(10)}
+    _create_sample(db_session=db_session, collection_id=collection.collection_id, metadata=fields)
+
+    filters = ImageFilter(
+        sample_filter=SampleFilter(
+            metadata_filters=[MetadataFilter(key="field_0", op="==", value="value_0")]
+        )
+    )
+    with _count_queries(db_session) as queries:
+        categorical_value_counts.get_metadata_value_counts(
+            session=db_session,
+            collection_id=collection.collection_id,
+            filters=filters,
+            fields=list(fields),
+        )
+
+    # Expected: schema lookup + total count + 1 batch for unfiltered fields
+    # + 1 query for the filtered field = well under 2*N=20.
+    assert len(queries) < len(fields) * 2, (
+        f"Query count {len(queries)} is too high for {len(fields)} fields with 1 active filter"
+    )
 
 
 def _create_sample(

--- a/lightly_studio/tests/test_cloud_credentials.py
+++ b/lightly_studio/tests/test_cloud_credentials.py
@@ -8,8 +8,8 @@ from collections.abc import Generator
 
 import fsspec
 import pytest
-from adlfs import AzureBlobFileSystem  # type: ignore[import-untyped]
-from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
+from adlfs import AzureBlobFileSystem  # type: ignore[import-not-found]
+from gcsfs import GCSFileSystem  # type: ignore[import-not-found]
 from pytest_mock import MockerFixture
 
 from lightly_studio import cloud_credentials

--- a/lightly_studio/tests/test_cloud_credentials.py
+++ b/lightly_studio/tests/test_cloud_credentials.py
@@ -8,12 +8,13 @@ from collections.abc import Generator
 
 import fsspec
 import pytest
-from adlfs import AzureBlobFileSystem  # type: ignore[import-not-found]
-from gcsfs import GCSFileSystem  # type: ignore[import-not-found]
 from pytest_mock import MockerFixture
 
 from lightly_studio import cloud_credentials
 from lightly_studio.cloud_credentials import apply_cloud_credentials
+
+AzureBlobFileSystem = pytest.importorskip("adlfs", reason="adlfs not installed").AzureBlobFileSystem
+GCSFileSystem = pytest.importorskip("gcsfs", reason="gcsfs not installed").GCSFileSystem
 
 
 @pytest.fixture(autouse=True)

--- a/lightly_studio/tests/test_enterprise.py
+++ b/lightly_studio/tests/test_enterprise.py
@@ -8,8 +8,8 @@ import os
 import fsspec
 import pytest
 import requests
-from adlfs import AzureBlobFileSystem  # type: ignore[import-untyped]
-from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
+from adlfs import AzureBlobFileSystem  # type: ignore[import-not-found]
+from gcsfs import GCSFileSystem  # type: ignore[import-not-found]
 from pytest_mock import MockerFixture, MockType
 
 from lightly_studio import enterprise

--- a/lightly_studio/tests/test_enterprise.py
+++ b/lightly_studio/tests/test_enterprise.py
@@ -8,12 +8,13 @@ import os
 import fsspec
 import pytest
 import requests
-from adlfs import AzureBlobFileSystem  # type: ignore[import-not-found]
-from gcsfs import GCSFileSystem  # type: ignore[import-not-found]
 from pytest_mock import MockerFixture, MockType
 
 from lightly_studio import enterprise
 from lightly_studio.database import db_manager
+
+AzureBlobFileSystem = pytest.importorskip("adlfs", reason="adlfs not installed").AzureBlobFileSystem
+GCSFileSystem = pytest.importorskip("gcsfs", reason="gcsfs not installed").GCSFileSystem
 
 
 @pytest.fixture(autouse=True)

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -78,6 +78,12 @@
         selectedComparisonTagIds?: string[];
         /** Updates the independent comparison selection without changing the grid filter. */
         onComparisonTagIdsChange?: (ids: string[]) => void;
+        /**
+         * Called whenever the active group changes (i.e. the user picks a
+         * different metadata key from the group selector). The host can use
+         * this to scope requests to only the visible field.
+         */
+        onGroupChange?: (sourceId: string, groupId: string | undefined) => void;
     }
 
     const {
@@ -97,7 +103,8 @@
         onCategoricalRetry,
         comparisonTagItems = [],
         selectedComparisonTagIds = [],
-        onComparisonTagIdsChange
+        onComparisonTagIdsChange,
+        onGroupChange
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -130,6 +137,10 @@
             activeSource.groups?.find(groupHasContent) ??
             activeSource.groups?.[0]
     );
+
+    $effect(() => {
+        onGroupChange?.(activeSource.id, activeGroup?.id);
+    });
     const activeSingleSeriesData = $derived<CategoryCount[]>(
         activeGroup?.data ?? activeSource.data ?? []
     );

--- a/lightly_studio_view/src/lib/hooks/useMetadataDistributionsBySampleTags/useMetadataDistributionsBySampleTags.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataDistributionsBySampleTags/useMetadataDistributionsBySampleTags.svelte.ts
@@ -21,6 +21,8 @@ interface MetadataComparisonParams {
     sampleTags: SampleTagItem[];
     filter?: ImageFilter;
     binCount?: number;
+    /** Restrict histograms to these numeric fields; all fields computed when absent. */
+    fields?: string[];
     enabled?: boolean;
 }
 
@@ -73,6 +75,7 @@ const buildSampleTagQueries = ({
     sampleTags,
     filter,
     binCount,
+    fields,
     enabled = true
 }: MetadataComparisonParams) =>
     sampleTags.flatMap(({ id }) => {
@@ -81,7 +84,11 @@ const buildSampleTagQueries = ({
             {
                 ...getMetadataHistogramsOptions({
                     path: { collection_id: collectionId },
-                    body: { ...body, ...(binCount ? { bin_count: binCount } : {}) }
+                    body: {
+                        ...body,
+                        ...(binCount ? { bin_count: binCount } : {}),
+                        ...(fields ? { fields } : {})
+                    }
                 }),
                 enabled: enabled && sampleTags.length > 0,
                 placeholderData: (previous: Record<string, HistogramView> | undefined) => previous

--- a/lightly_studio_view/src/lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution.ts
+++ b/lightly_studio_view/src/lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution.ts
@@ -25,19 +25,23 @@ export interface NumericMetadataHistogramOptions {
     collectionId: string;
     filter?: ImageFilter;
     binCount?: number;
+    /** Restrict histograms to these numeric fields; all fields computed when absent. */
+    fields?: string[];
 }
 
 export const getNumericMetadataHistogramRequestOptions = ({
     collectionId,
     filter,
-    binCount
+    binCount,
+    fields
 }: NumericMetadataHistogramOptions) => ({
     path: { collection_id: collectionId },
-    ...(filter || binCount
+    ...(filter || binCount || fields
         ? {
               body: {
                   ...(filter ? { filters: filter } : {}),
-                  ...(binCount ? { bin_count: binCount } : {})
+                  ...(binCount ? { bin_count: binCount } : {}),
+                  ...(fields ? { fields } : {})
               }
           }
         : {})
@@ -67,17 +71,20 @@ export const useNumericMetadataDistribution = (
         filter?: ImageFilter;
         /** Number of equal-width bins per histogram (server default: 20). */
         binCount?: number;
+        /** Restrict to these numeric fields; all fields computed when absent. */
+        fields?: string[];
         enabled?: boolean;
     }
 ) =>
     createQuery(() => {
-        const { collectionId, filter, binCount, enabled = true } = getOptions();
+        const { collectionId, filter, binCount, fields, enabled = true } = getOptions();
         // Computed inside the reactive function so a change to collectionId,
-        // filter, or binCount updates the query key and triggers a refetch.
+        // filter, binCount, or fields updates the query key and triggers a refetch.
         const requestOptions = getNumericMetadataHistogramRequestOptions({
             collectionId,
             filter,
-            binCount
+            binCount,
+            fields
         });
         return {
             ...getMetadataHistogramsOptions(requestOptions),

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -725,6 +725,16 @@
     // User-configurable bin count for the metadata histograms.
     let histogramBinCount = $state(20);
 
+    // The active metadata field the user is currently viewing in the distribution
+    // panel. Undefined means "all fields" (first load or non-metadata source).
+    // Used to scope histogram requests to only the visible field so the server
+    // skips computing every field on every tag click.
+    let activeMetadataGroupId = $state<string | undefined>(undefined);
+    // When the active metadata field is known, scope requests to that field only.
+    const visibleHistogramFields = $derived(
+        activeMetadataGroupId !== undefined ? [activeMetadataGroupId] : undefined
+    );
+
     const metadataHistogramsQuery = useNumericMetadataDistribution(() => ({
         collectionId: collectionId,
         filter: distributionBaseFilter,
@@ -764,7 +774,8 @@
         sampleTags: selectedDistributionSampleTags,
         filter: distributionBaseFilter,
         binCount: histogramBinCount,
-        enabled: distributionPanelVisible && distributionSampleTagIds.length > 0
+        enabled: distributionPanelVisible && distributionSampleTagIds.length > 0,
+        fields: visibleHistogramFields
     }));
     const metadataTagDistributions = $derived(metadataTagDistributionsQuery.data ?? []);
 
@@ -1051,6 +1062,10 @@
                                             selectedComparisonTagIds={distributionSampleTagIds}
                                             onComparisonTagIdsChange={(ids) =>
                                                 (distributionSampleTagIds = ids)}
+                                            onGroupChange={(sourceId, groupId) => {
+                                                activeMetadataGroupId =
+                                                    sourceId === 'metadata' ? groupId : undefined;
+                                            }}
                                         />
                                     {/key}
                                 {/await}


### PR DESCRIPTION
## What has changed and why?

The `value-counts` endpoint was making 2N sequential DB queries (one per categorical field), and the `histograms` endpoint was making N+1 queries for min/max before doing the per-field bucketing separately. On large collections (120k images, many metadata fields) this caused 40s and 25s response times respectively. Tag comparison re-queried all histogram fields on every tag click, even when only one field was visible.

**Backend — value-counts (O(N) → O(1) queries):**
- Replaces N×2 sequential queries with a single `LATERAL unnest(json_keys(data))` query that expands all JSON keys in one pass and groups by `key + value`
- Fields sharing the same effective filter are batched together, so the common no-filter case needs only 2 DB round-trips regardless of field count
- Adds `json_object_unnest_lateral()` in `db_json.py` with dialect-aware SQL for DuckDB and PostgreSQL
- Adds a `fields` param to scope requests to specific keys

**Backend — histograms (N+1 → 1 combined min/max query):**
- `_get_all_fields_min_max()` fetches min/max/count for all numeric fields in a single lateral-unnest query instead of one query per field
- Adds a `fields` param to `POST /collections/{id}/metadata/histograms` so callers can request only the visible field

**Frontend — scope tag comparison to active field:**
- Adds `onGroupChange` prop to `DatasetDistributionPanel`; the layout tracks which metadata field is active
- Tag-comparison histogram queries pass `fields=[activeField]`, so each tag click only computes one field instead of all fields
- `useNumericMetadataDistribution` and `useMetadataDistributionsBySampleTags` accept an optional `fields` param

## How has it been tested?

- Added scaling tests for value-counts: query count stays constant as field count grows from 3 → 20; bounded with one active metadata filter
- Added histogram tests: `fields` parameter limits returned keys; query count overhead is ≤1 extra query per extra field (not 2× per field)
- `make static-checks` and `make test` pass in both `lightly_studio/` and `lightly_studio_view/`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---
Reviewer suggestion: @jonas-laso (raised the issue) or another backend reviewer familiar with SQLAlchemy/DuckDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Metadata histograms can be limited to selected numeric fields.
  - Distribution views automatically request data for the currently selected metadata field.

- **Performance**
  - Histogram and metadata value-count queries are more efficiently grouped and batched.

- **Bug Fixes**
  - Improved consistency when changing metadata sources or groups, including clearing stale selections.
  - Corrected handling of metadata keys containing special characters.

- **Tests**
  - Added coverage for field filtering and query efficiency across metadata distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->