### PR TITLE
Return a clear error when text embedding has no live encoder

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
@@ -51,8 +51,6 @@ def embed_text(
             detail=f"{exc}",
         ) from None
     except Exception:
-        # The exception comes from a caller-supplied generator, so its text is not ours
-        # to forward to the client. It goes to the log instead.
         logger.exception("Error embedding text")
         raise HTTPException(
             status_code=HTTP_STATUS_INTERNAL_SERVER_ERROR,

--- a/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -15,6 +16,8 @@ from lightly_studio.dataset.embedding_manager import (
     EmbeddingManagerProvider,
     TextEmbedQuery,
 )
+
+logger = logging.getLogger(__name__)
 
 text_embedding_router = APIRouter()
 # Define a type alias for the EmbeddingManager dependency
@@ -46,6 +49,15 @@ def embed_text(
         raise HTTPException(
             status_code=HTTP_STATUS_INTERNAL_SERVER_ERROR,
             detail=f"{exc}",
+        ) from None
+    except Exception as exc:
+        logger.exception("Error embedding text")
+        raise HTTPException(
+            status_code=HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            detail=(
+                "Could not embed the text query. The embedding model of this collection "
+                f"has no text encoder available for live queries: {exc}"
+            ),
         ) from None
 
     return text_embeddings

--- a/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
@@ -50,13 +50,16 @@ def embed_text(
             status_code=HTTP_STATUS_INTERNAL_SERVER_ERROR,
             detail=f"{exc}",
         ) from None
-    except Exception as exc:
+    except Exception:
+        # The exception comes from a caller-supplied generator, so its text is not ours
+        # to forward to the client. It goes to the log instead.
         logger.exception("Error embedding text")
         raise HTTPException(
             status_code=HTTP_STATUS_INTERNAL_SERVER_ERROR,
             detail=(
-                "Could not embed the text query. The embedding model of this collection "
-                f"has no text encoder available for live queries: {exc}"
+                "Could not embed the text query. This collection's embedding model may "
+                "have no text encoder for live queries, for example when the collection "
+                "was imported with precomputed embeddings. See the server log for details."
             ),
         ) from None
 

--- a/lightly_studio/tests/api/routes/api/test_text_embedding.py
+++ b/lightly_studio/tests/api/routes/api/test_text_embedding.py
@@ -1,6 +1,8 @@
+import logging
 from collections.abc import Mapping
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
@@ -98,15 +100,14 @@ def test_embed_text__no_text_encoder(
     )
 
     assert response.status_code == HTTP_STATUS_INTERNAL_SERVER_ERROR
-    detail = response.json()["detail"]
-    assert "no text encoder available for live queries" in detail
-    assert "Generator has no text encoder" in detail
+    assert "no text encoder for live queries" in response.json()["detail"]
 
 
-def test_embed_text__unrelated_error_is_not_masked(
+def test_embed_text__unrelated_error_is_logged(
     db_session: Session,
     mocker: MockerFixture,
     test_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
 
@@ -121,10 +122,13 @@ def test_embed_text__unrelated_error_is_not_masked(
         side_effect=RuntimeError("CUDA out of memory"),
     )
 
-    response = test_client.get(
-        f"/api/text_embedding/for_collection/{collection_id!s}",
-        params={"query_text": "sample"},
-    )
+    with caplog.at_level(logging.ERROR):
+        response = test_client.get(
+            f"/api/text_embedding/for_collection/{collection_id!s}",
+            params={"query_text": "sample"},
+        )
 
     assert response.status_code == HTTP_STATUS_INTERNAL_SERVER_ERROR
-    assert "CUDA out of memory" in response.json()["detail"]
+    # The detail stays generic, but the real cause must reach the log.
+    assert "CUDA out of memory" not in response.json()["detail"]
+    assert "CUDA out of memory" in caplog.text

--- a/lightly_studio/tests/api/routes/api/test_text_embedding.py
+++ b/lightly_studio/tests/api/routes/api/test_text_embedding.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_INTERNAL_SERVER_ERROR,
     HTTP_STATUS_OK,
 )
 from lightly_studio.dataset.embedding_manager import (
@@ -71,3 +72,59 @@ def test_embed_text_embedding_invalid_model_id(
     )
     assert response.status_code == 500
     assert response.json() == {"detail": f"No embedding model found with ID {test_uuid}"}
+
+
+def test_embed_text__no_text_encoder(
+    db_session: Session,
+    mocker: MockerFixture,
+    test_client: TestClient,
+) -> None:
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+
+    mocker.patch.object(
+        EmbeddingManagerProvider,
+        "get_embedding_manager",
+        return_value=EmbeddingManager(),
+    )
+    mocker.patch.object(
+        EmbeddingManager,
+        "embed_text",
+        side_effect=NotImplementedError("Generator has no text encoder"),
+    )
+
+    response = test_client.get(
+        f"/api/text_embedding/for_collection/{collection_id!s}",
+        params={"query_text": "sample"},
+    )
+
+    assert response.status_code == HTTP_STATUS_INTERNAL_SERVER_ERROR
+    detail = response.json()["detail"]
+    assert "no text encoder available for live queries" in detail
+    assert "Generator has no text encoder" in detail
+
+
+def test_embed_text__unrelated_error_is_not_masked(
+    db_session: Session,
+    mocker: MockerFixture,
+    test_client: TestClient,
+) -> None:
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+
+    mocker.patch.object(
+        EmbeddingManagerProvider,
+        "get_embedding_manager",
+        return_value=EmbeddingManager(),
+    )
+    mocker.patch.object(
+        EmbeddingManager,
+        "embed_text",
+        side_effect=RuntimeError("CUDA out of memory"),
+    )
+
+    response = test_client.get(
+        f"/api/text_embedding/for_collection/{collection_id!s}",
+        params={"query_text": "sample"},
+    )
+
+    assert response.status_code == HTTP_STATUS_INTERNAL_SERVER_ERROR
+    assert "CUDA out of memory" in response.json()["detail"]


### PR DESCRIPTION
## What has changed and why?

- A collection imported with precomputed embeddings has no runnable text encoder, so a text query cannot work by construction. Today that failure is ugly: the `embed_text` route only catches `ValueError`, so a generator raising `NotImplementedError` (as the shipped `example_load_existing_embeddings.py` does) propagates as an unhandled 500 with no message.
- Add a catch-all `except Exception` fallback to the route that logs the exception and returns a 500 explaining that this collection's embedding model has no text encoder available for live queries. This mirrors the pattern the image embedding route already uses.
- A catch-all is used instead of enumerating exception types because `embed_text` is on the base `EmbeddingGenerator` protocol that every generator structurally satisfies, so there is no capability check possible ahead of the call and no guarantee what a non-implementing generator raises.

## How has it been tested?

- New test: a generator whose `embed_text` raises `NotImplementedError` returns a 500 with the explanatory message.
- New test: an unrelated failure (`RuntimeError`) is still surfaced in the detail and not masked.
- `make static-checks` and `make test` pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @michal-lightly. Alternative: @MalteEbner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved error handling for live text embedding queries.
* Requests now return a clear server error when a collection lacks a text encoder.
* Unexpected embedding failures now return a stable, generic error message instead of exposing backend details.
* Diagnostic information for unexpected failures is preserved in server logs to support troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->