### PR TITLE
Persist the remote embedding backend API key

### DIFF
--- a/lightly_studio/src/lightly_studio/migrations/versions/1788768000_b3c4d5e6f7a8_add_embedding_model_api_key.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1788768000_b3c4d5e6f7a8_add_embedding_model_api_key.py
@@ -1,0 +1,43 @@
+"""add the embedding_model api_key column.
+
+A remote embedding backend authenticates with a bearer token. The token is stored next to the
+``remote_embedder_url`` it belongs to, in a nullable ``api_key`` column; being optional, it needs
+no backfill. The downgrade drops the column, discarding any stored token.
+
+DuckDB builds its schema with ``create_all``, so this migration only matters for tracked Postgres
+databases.
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-09-07 10:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c4d5e6f7a8"
+down_revision: str | Sequence[str] | None = "a2b3c4d5e6f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "embedding_model",
+        sa.Column("api_key", sa.VARCHAR(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Drops ``api_key``. The stored tokens are lost and have to be set again after an upgrade.
+    """
+    op.drop_column("embedding_model", "api_key")

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -10,12 +10,24 @@ from sqlmodel import Field, SQLModel
 
 
 class EmbeddingModelBase(SQLModel):
-    """Base class for the EmbeddingModel."""
+    """Base class for the EmbeddingModel.
+
+    Attributes:
+        name: The name identifying the embedding model within its dataset.
+        embedding_dimension: The dimension of the embeddings the model produces.
+        dataset_id: The dataset owning the embedding model.
+        remote_embedder_url: The base URL of the remote embedding backend, if the model is
+            served remotely.
+        api_key: The bearer token sent to `remote_embedder_url`. It is a secret: it must never
+            reach a response model, so a route returning an embedding model needs a view model
+            that omits it. `repr=False` keeps it out of log lines that dump the row.
+    """
 
     name: str
     embedding_dimension: int
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
     remote_embedder_url: str | None = None
+    api_key: str | None = Field(default=None, repr=False)
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -10,23 +10,13 @@ from sqlmodel import Field, SQLModel
 
 
 class EmbeddingModelBase(SQLModel):
-    """Base class for the EmbeddingModel.
-
-    Attributes:
-        name: The name identifying the embedding model within its dataset.
-        embedding_dimension: The dimension of the embeddings the model produces.
-        dataset_id: The dataset owning the embedding model.
-        remote_embedder_url: The base URL of the remote embedding backend, if the model is
-            served remotely.
-        api_key: The bearer token sent to `remote_embedder_url`. It is a secret: it must never
-            reach a response model, so a route returning an embedding model needs a view model
-            that omits it. `repr=False` keeps it out of log lines that dump the row.
-    """
+    """Base class for the EmbeddingModel."""
 
     name: str
     embedding_dimension: int
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
     remote_embedder_url: str | None = None
+    # Secret: `repr=False` keeps it out of logged rows, and it must never reach a response model.
     api_key: str | None = Field(default=None, repr=False)
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -39,6 +39,33 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     return db_model
 
 
+def set_api_key(
+    session: Session, embedding_model_id: UUID, api_key: str | None
+) -> EmbeddingModelTable:
+    """Set the API key of an embedding model, replacing any key already stored.
+
+    Args:
+        session: The database session.
+        embedding_model_id: The embedding model to update.
+        api_key: The bearer token for the remote embedding backend, or None to clear it.
+
+    Returns:
+        The updated embedding model.
+
+    Raises:
+        ValueError: If no embedding model with the given ID exists.
+    """
+    db_embedding_model = get_by_id(session=session, embedding_model_id=embedding_model_id)
+    if db_embedding_model is None:
+        raise ValueError(f"Embedding model with id {embedding_model_id} not found.")
+
+    db_embedding_model.api_key = api_key
+    session.add(db_embedding_model)
+    session.commit()
+    session.refresh(db_embedding_model)
+    return db_embedding_model
+
+
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by ID."""
     return session.exec(

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -306,3 +306,90 @@ def test_postgres_collection_embedding_model__backfills_all_models(
     finally:
         _restore_shared_database_to_head(engine=engine, engine_url=postgres_url)
         engine.dispose()
+
+
+def test_postgres_embedding_model_api_key__added_and_dropped(
+    postgres_url: str | None,
+) -> None:
+    """The API key migration adds a nullable column and the downgrade removes it again."""
+    if postgres_url is None:
+        pytest.skip("Requires --postgres")
+
+    _reset_postgres_database(engine_url=postgres_url)
+    normalized_url = db_url.ensure_psycopg3_driver(engine_url=postgres_url)
+    engine = create_engine(normalized_url)
+    config = db_migrations.get_alembic_config(engine_url=postgres_url)
+    dataset_id = "00000000-0000-0000-0000-000000000001"
+    model_id = "00000000-0000-0000-0000-000000000003"
+
+    try:
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="a2b3c4d5e6f7",
+        )
+        with engine.begin() as connection:
+            connection.execute(
+                statement=text("INSERT INTO dataset (dataset_id) VALUES (:dataset_id)"),
+                parameters={"dataset_id": dataset_id},
+            )
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO embedding_model (
+                        name, embedding_dimension, dataset_id, embedding_model_id, created_at
+                    ) VALUES (
+                        'model', 128, :dataset_id, :model_id, NOW()
+                    )
+                    """
+                ),
+                parameters={"dataset_id": dataset_id, "model_id": model_id},
+            )
+
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="head",
+        )
+        columns = db_migrations._get_inspector(engine=engine).get_columns(
+            table_name="embedding_model"
+        )
+        api_key_column = next(column for column in columns if column["name"] == "api_key")
+        assert api_key_column["nullable"] is True
+
+        # The existing row needs no backfill, and the column accepts a key.
+        with engine.begin() as connection:
+            assert (
+                connection.execute(
+                    statement=text("SELECT api_key FROM embedding_model")
+                ).scalar_one()
+                is None
+            )
+            connection.execute(
+                statement=text("UPDATE embedding_model SET api_key = 'secret'"),
+            )
+
+        config.attributes.pop("connection", None)
+        command.check(config)
+
+        # The downgrade drops the column and keeps the row.
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.downgrade,
+            revision="a2b3c4d5e6f7",
+        )
+        columns = db_migrations._get_inspector(engine=engine).get_columns(
+            table_name="embedding_model"
+        )
+        assert "api_key" not in {column["name"] for column in columns}
+        with engine.connect() as connection:
+            remaining = connection.execute(
+                statement=text("SELECT embedding_model_id FROM embedding_model")
+            ).scalar_one()
+        assert str(remaining) == model_id
+    finally:
+        _restore_shared_database_to_head(engine=engine, engine_url=postgres_url)
+        engine.dispose()

--- a/lightly_studio/tests/models/test_embedding_model.py
+++ b/lightly_studio/tests/models/test_embedding_model.py
@@ -1,0 +1,120 @@
+"""Tests for the EmbeddingModel secret handling."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel
+
+from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
+from lightly_studio.resolvers import embedding_model_resolver
+from tests.helpers_resolvers import create_collection
+
+_API_KEY = "super-secret-token"
+
+
+def test_embedding_model_table__api_key_absent_from_repr(db_session: Session) -> None:
+    """Dumping the row into a log line must not leak the API key."""
+    collection = create_collection(session=db_session)
+    embedding_model = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="remote_model",
+            embedding_dimension=128,
+            remote_embedder_url="https://embedder.example.com",
+            api_key=_API_KEY,
+        ),
+    )
+
+    assert _API_KEY not in repr(embedding_model)
+    assert _API_KEY not in str(embedding_model)
+    assert "remote_model" in repr(embedding_model)
+
+
+def test_embedding_model_table__api_key_absent_from_log_line(
+    db_session: Session, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A log line that dumps the row must not contain the API key."""
+    collection = create_collection(session=db_session)
+    embedding_model = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="remote_model",
+            embedding_dimension=128,
+            api_key=_API_KEY,
+        ),
+    )
+
+    logger = logging.getLogger(__name__)
+    with caplog.at_level(logging.INFO, logger=__name__):
+        logger.info("Resolved embedding model %s", embedding_model)
+        logger.info(f"Resolved embedding model {embedding_model}")
+
+    assert _API_KEY not in caplog.text
+    assert "remote_model" in caplog.text
+
+
+def test_embedding_model_table__api_key_absent_from_response_models(
+    test_client: TestClient,
+) -> None:
+    """No route may return the API key, so no response schema may declare it."""
+    schemas = test_client.get("/openapi.json").json()["components"]["schemas"]
+
+    leaking = [name for name, schema in schemas.items() if "api_key" in _properties(schema=schema)]
+    assert leaking == []
+
+
+def test_embedding_model_table__api_key_round_trips(db_session: Session) -> None:
+    """The API key is persisted and readable through the resolver."""
+    collection = create_collection(session=db_session)
+    created = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="remote_model",
+            embedding_dimension=128,
+            remote_embedder_url="https://embedder.example.com",
+            api_key=_API_KEY,
+        ),
+    )
+
+    stored = embedding_model_resolver.get_by_id(
+        session=db_session, embedding_model_id=created.embedding_model_id
+    )
+    assert stored is not None
+    assert stored.api_key == _API_KEY
+    assert stored.remote_embedder_url == "https://embedder.example.com"
+
+
+def test_embedding_model_table__api_key_defaults_to_none(db_session: Session) -> None:
+    """A locally served model carries no API key."""
+    collection = create_collection(session=db_session)
+    created = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="local_model",
+            embedding_dimension=128,
+        ),
+    )
+
+    assert created.api_key is None
+
+
+def test_embedding_model_table__api_key_is_nullable() -> None:
+    """The column must be nullable so existing rows need no backfill."""
+    columns = SQLModel.metadata.tables[EmbeddingModelTable.__tablename__].columns
+    assert columns["api_key"].nullable is True
+
+
+def _properties(schema: dict[str, Any]) -> set[str]:
+    """Collect the property names of a schema, including its `anyOf` and `allOf` branches."""
+    names = set(schema.get("properties", {}))
+    for branch in schema.get("anyOf", []) + schema.get("allOf", []) + schema.get("oneOf", []):
+        names |= _properties(schema=branch)
+    return names

--- a/lightly_studio/tests/models/test_embedding_model.py
+++ b/lightly_studio/tests/models/test_embedding_model.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, SQLModel
+from sqlmodel import Session
 
-from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
+from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import create_collection
 
@@ -67,49 +67,6 @@ def test_embedding_model_table__api_key_absent_from_response_models(
 
     leaking = [name for name, schema in schemas.items() if "api_key" in _properties(schema=schema)]
     assert leaking == []
-
-
-def test_embedding_model_table__api_key_round_trips(db_session: Session) -> None:
-    """The API key is persisted and readable through the resolver."""
-    collection = create_collection(session=db_session)
-    created = embedding_model_resolver.create(
-        session=db_session,
-        embedding_model=EmbeddingModelCreate(
-            dataset_id=collection.dataset_id,
-            name="remote_model",
-            embedding_dimension=128,
-            remote_embedder_url="https://embedder.example.com",
-            api_key=_API_KEY,
-        ),
-    )
-
-    stored = embedding_model_resolver.get_by_id(
-        session=db_session, embedding_model_id=created.embedding_model_id
-    )
-    assert stored is not None
-    assert stored.api_key == _API_KEY
-    assert stored.remote_embedder_url == "https://embedder.example.com"
-
-
-def test_embedding_model_table__api_key_defaults_to_none(db_session: Session) -> None:
-    """A locally served model carries no API key."""
-    collection = create_collection(session=db_session)
-    created = embedding_model_resolver.create(
-        session=db_session,
-        embedding_model=EmbeddingModelCreate(
-            dataset_id=collection.dataset_id,
-            name="local_model",
-            embedding_dimension=128,
-        ),
-    )
-
-    assert created.api_key is None
-
-
-def test_embedding_model_table__api_key_is_nullable() -> None:
-    """The column must be nullable so existing rows need no backfill."""
-    columns = SQLModel.metadata.tables[EmbeddingModelTable.__tablename__].columns
-    assert columns["api_key"].nullable is True
 
 
 def _properties(schema: dict[str, Any]) -> set[str]:

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 from sqlmodel import Session
 
@@ -225,3 +227,72 @@ def test_get_or_create__same_name_different_datasets(db_session: Session) -> Non
     assert model_2_by_name is not None
     assert model_1_by_name.embedding_model_id == model_1.embedding_model_id
     assert model_2_by_name.embedding_model_id == model_2.embedding_model_id
+
+
+def test_set_api_key(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    embedding_model = create_embedding_model(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    updated = embedding_model_resolver.set_api_key(
+        session=db_session,
+        embedding_model_id=embedding_model.embedding_model_id,
+        api_key="secret",
+    )
+
+    assert updated.api_key == "secret"
+    stored = embedding_model_resolver.get_by_id(
+        session=db_session, embedding_model_id=embedding_model.embedding_model_id
+    )
+    assert stored is not None
+    assert stored.api_key == "secret"
+
+
+def test_set_api_key__replaces_existing_key(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    embedding_model = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="remote_model",
+            embedding_dimension=128,
+            api_key="old_secret",
+        ),
+    )
+
+    updated = embedding_model_resolver.set_api_key(
+        session=db_session,
+        embedding_model_id=embedding_model.embedding_model_id,
+        api_key="new_secret",
+    )
+
+    assert updated.api_key == "new_secret"
+
+
+def test_set_api_key__clears_key(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    embedding_model = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            dataset_id=collection.dataset_id,
+            name="remote_model",
+            embedding_dimension=128,
+            api_key="secret",
+        ),
+    )
+
+    updated = embedding_model_resolver.set_api_key(
+        session=db_session, embedding_model_id=embedding_model.embedding_model_id, api_key=None
+    )
+
+    assert updated.api_key is None
+
+
+def test_set_api_key__unknown_model_raises(db_session: Session) -> None:
+    unknown_id = uuid4()
+
+    with pytest.raises(ValueError, match=f"Embedding model with id {unknown_id} not found."):
+        embedding_model_resolver.set_api_key(
+            session=db_session, embedding_model_id=unknown_id, api_key="secret"
+        )


### PR DESCRIPTION

## What has changed and why?

A remote embedding backend needs a bearer token, and the token had nowhere to live. This PR owns only the persistence layer.

- Nullable `api_key` column on `embedding_model`, next to `remote_embedder_url`, plus the Alembic migration.
- `embedding_model_resolver.set_api_key` to set, rotate or clear the key. Reading goes through the existing `get_by_id`.
- Both leak paths closed: `repr=False` keeps the key out of log lines that dump the row, and a test walks every OpenAPI schema so no route can return it.

Column instead of its own table because no route returns `EmbeddingModelTable` today. The cost is duplication per dataset, since `embedding_model` is unique on `(dataset_id, name)`; if backends get shared widely, a `remote_service` table is the better shape.

Not here: the `Authorization` header (LIG-10641), the GUI/Python surface (LIG-10740), encryption at rest.

## How has it been tested?

New tests for the resolver round trip, the key's absence from `repr`/`str`/a log line and from every OpenAPI schema, and the migration applying forward and back on Postgres.

```
cd lightly_studio
make static-checks               # pass
make test                        # 2430 passed, 44 skipped
make migration-check-postgresql  # No new upgrade operations detected
uv run pytest --postgres tests/database/test_db_migrations.py tests/models/test_embedding_model.py tests/resolvers/test_embedding_model_resolver.py  # 24 passed
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly (wrote the surrounding embedding model code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for securely storing API keys for remote embedding models.
  * API keys can be set, replaced, or cleared for existing embedding models.
  * Existing local embedding models continue to work without an API key by default.

* **Security**
  * API keys are excluded from logs, string representations, and API response schemas.

* **Bug Fixes**
  * Added validation when attempting to update an unknown embedding model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->