### PR TITLE
Make the generated release notes publishable without hand-editing

### DIFF
--- a/.github/scripts/prepare_release/release_notes.py
+++ b/.github/scripts/prepare_release/release_notes.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import re
 
-# Discord caps a message body at 4096 characters, so the marker sits before the
-# generated section rather than at the end of the notes.
-DISCORD_STOP_MARKER = "<!-- STOP DISCORD MESSAGE -->"
+# The changelog section starts at "### Added", so it needs a heading of its own
+# to sit level with the "## What's Changed" of the generated half below it.
+_CHANGELOG_HEADING = "## Changelog"
 
 # Ticket ids as they occur in this repo's PR titles: leading "LIG-10603: ",
 # leading "LIG-10374 ", and trailing "(LIG-10323)" or "(LIG-10089, 2/3)". A
@@ -44,8 +44,8 @@ def render_release_notes(changelog_section: str, generated_notes: str) -> str:
         The Markdown body for the GitHub release.
     """
     return (
+        f"{_CHANGELOG_HEADING}\n\n"
         f"{changelog_section.strip()}\n\n"
-        f"{DISCORD_STOP_MARKER}\n\n"
         f"{sanitize_generated_notes(generated_notes).strip()}\n"
     )
 

--- a/.github/scripts/tests/test_release_notes.py
+++ b/.github/scripts/tests/test_release_notes.py
@@ -21,18 +21,7 @@ def test_render_release_notes():
         changelog_section="### Added\n\n- A thing.", generated_notes="## What's Changed\n* A by @d"
     )
 
-    assert body == (
-        "### Added\n\n- A thing.\n\n<!-- STOP DISCORD MESSAGE -->\n\n## What's Changed\n* A by @d\n"
-    )
-
-
-# Discord caps the message body, so the marker must precede the generated notes.
-def test_render_release_notes__marker_precedes_the_generated_notes():
-    body = release_notes.render_release_notes(
-        changelog_section="### Added\n\n- A thing.", generated_notes="## What's Changed\n* A by @d"
-    )
-
-    assert body.index(release_notes.DISCORD_STOP_MARKER) < body.index("What's Changed")
+    assert body == ("## Changelog\n\n### Added\n\n- A thing.\n\n## What's Changed\n* A by @d\n")
 
 
 def test_sanitize_generated_notes():

--- a/.github/workflows/undraft_release.yml
+++ b/.github/workflows/undraft_release.yml
@@ -43,11 +43,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
           REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        # A release's author is whichever identity's token created it, so a
+        # workflow-created release always reads as github-actions[bot]. This
+        # workflow is dispatch-triggered, so the actor is the person who
+        # decided to release; the notes name them instead. Appending it here
+        # rather than when drafting keeps it out of a draft nobody published,
+        # and the draft check above keeps a re-run from adding it twice.
         run: |
           set -euo pipefail
           if [ "$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq .isDraft)" != "true" ]; then
             echo "::error::${TAG} is not a draft release."
             exit 1
           fi
-          gh release edit "${TAG}" --repo "${REPO}" --draft=false
+          gh release view "${TAG}" --repo "${REPO}" --json body --jq .body \
+            > "${RUNNER_TEMP}/release-notes.md"
+          printf '\nReleased by @%s\n' "${ACTOR}" >> "${RUNNER_TEMP}/release-notes.md"
+          gh release edit "${TAG}" --repo "${REPO}" \
+            --draft=false \
+            --notes-file "${RUNNER_TEMP}/release-notes.md"
           echo "::notice::Published ${TAG}."


### PR DESCRIPTION
## What has changed and why?

Publishing `v1.1.0` needed three hand edits to the drafted release body, and every hand edit is a
chance to fork the release object (that is how the duplicate draft in LIG-10759 happened). Two of
them were fixes to the renderer's output, so the renderer now makes them:

- Drop `DISCORD_STOP_MARKER` (`<!-- STOP DISCORD MESSAGE -->`) from the body. It reached users as a
  stray internal HTML comment and has no automated consumer - the boundary it marked is already
  visible, since GitHub's generated half always opens with `## What's Changed`.
- Emit a `## Changelog` heading above the changelog section, so both halves of the body sit at the
  same heading level instead of a bare `### Added` above `## What's Changed`.
- Name the releasing human: a release's author is whichever token created it, so a workflow-created
  release reads as `github-actions[bot]`. Undraft Release is dispatch-triggered, so the actor is the
  person who decided to release, and a `Released by @<actor>` line is appended when un-drafting.

## How has it been tested?

`make static-checks` and `make test` in `.github/scripts` (55 passed). `render_release_notes` is
covered by an exact-body assertion. The workflow change is not unit-testable; it will be exercised
by the next release, and the existing draft check keeps a re-run from appending the line twice.

Before merging, confirm with whoever posts the Discord announcement that nothing downstream greps
for the literal marker string.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Notes**
  - Improved release note formatting with a dedicated **Changelog** heading for clearer organization.
  - Published releases now include attribution identifying who released them.
  - Draft release validation remains in place to help prevent unintended publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->