### PR TITLE
Rename the release workflows to prepare → draft → finish

### DIFF
--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -1,6 +1,6 @@
 """Command-line entry point for the release tooling.
 
-Backs the "Prepare Release" and "Publish Release" GitHub Actions workflows.
+Backs the "Prepare Release" and "Draft Release" GitHub Actions workflows.
 Each subcommand does one small, independently testable piece of preparing or
 publishing a release: promoting the changelog, assembling the release notes,
 and guarding against a handful of ways those can quietly go wrong. Bumping

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -45,6 +45,6 @@ def render_pr_body(section_body: str, version: str) -> str:
         f"{_GUARDS}\n\n"
         f"{_CHECKLIST}\n\n"
         f"Merging tags this commit and opens a **draft** GitHub release. Nothing is public "
-        f"until the wheel is on PyPI and someone runs Undraft Release; PyPI and the docs are "
+        f"until the wheel is on PyPI and someone runs Finish Release; PyPI and the docs are "
         f"still manual.\n"
     )

--- a/.github/scripts/prepare_release/release_notes.py
+++ b/.github/scripts/prepare_release/release_notes.py
@@ -1,6 +1,6 @@
 """Assemble the GitHub release body: the changelog section, then GitHub's own notes.
 
-Backs the "Publish Release" workflow. The `CHANGELOG.md` section leads because
+Backs the "Draft Release" workflow. The `CHANGELOG.md` section leads because
 it is the text the team edited and reviewed on the release PR; GitHub's
 auto-generated notes follow as the full commit-level record.
 

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -6,7 +6,7 @@ reimplemented here - it already parses/writes real TOML and handles more
 than plain X.Y.Z (alpha/beta/rc/post/dev), which regex-based text editing
 kept getting subtly wrong in review. This module keeps the guard that `uv`
 has no way to know about - whether Labelformat itself needs a release first -
-and a plain reader for the Publish Release workflow, which must learn the
+and a plain reader for the Draft Release workflow, which must learn the
 version to tag without resolving the project environment first. That reader
 matches a line rather than parsing TOML: `tomllib` is 3.11+, and this CLI has
 to stay importable on whatever `python3` a runner or a laptop provides.

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,4 +1,4 @@
-name: Publish Release
+name: Draft Release
 
 on:
   # Merging the "Bump version to X.Y.Z" pull request is the decision to
@@ -22,7 +22,7 @@ env:
   PYTHONPATH: ${{ github.workspace }}/.github/scripts
 
 jobs:
-  publish-release:
+  draft-release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -220,4 +220,4 @@ jobs:
             --draft \
             --title "${TAG}" \
             --notes-file "${RUNNER_TEMP}/release-notes.md"
-          echo "::notice::Draft release ${TAG} ready. Publish to PyPI, then un-draft it."
+          echo "::notice::Draft release ${TAG} ready. Run Finish Release once the wheel is on PyPI."

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -1,4 +1,4 @@
-name: Undraft Release
+name: Finish Release
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ permissions:
   contents: write
 
 jobs:
-  undraft-release:
+  finish-release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION


`publish_release.yml` does not publish — it resolves the version, tags the commit, and creates a **draft** release. `undraft_release.yml` is about to absorb the PyPI publish, after which "undraft" names the smaller half of what it does. The rename has to land before the PyPI trusted-publisher config is set up, because that config pins the workflow filename: renaming afterwards breaks publishing with a 403 that surfaces only after the tag and GitHub release already exist.

| File | Trigger | Does |
| -- | -- | -- |
| `prepare_release.yml` | dispatch | opens the "Bump version to X.Y.Z" PR |
| `draft_release.yml` | push on `lightly_studio/pyproject.toml` | tag + draft release |
| `finish_release.yml` | dispatch(tag) | PyPI → un-draft |

## Changes

- `git mv publish_release.yml draft_release.yml`, `name: Draft Release`, job id `draft-release`.
- `git mv undraft_release.yml finish_release.yml`, `name: Finish Release`, job id `finish-release`.
- Draft Release's closing notice now names Finish Release.
- The release-PR body and four tooling docstrings name the new workflows.

No behaviour change, no new permissions, nothing to configure. The "PyPI is still manual" clause in the PR body stays — it is true until LIG-10555 lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow terminology to use “Draft Release” and “Finish Release.”
  * Clarified that releases remain in draft status until the Finish Release workflow is run.

* **Workflow Updates**
  * Renamed release workflow steps and completion guidance to reflect the updated release process.
  * Updated related release documentation and notifications for consistency.
  * Clarified that Finish Release should be run after the package is uploaded to PyPI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->