### PR TITLE
Fix: Speed up video thumbnails with using pyav instead of opencv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change the video decoding backend for the GUI from OpenCV to PyAV, resulting in up to 6× faster decoding performance for parallel streams when loading the grid view and scrolling.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio/src/lightly_studio/api/routes/video_frames_media.py
+++ b/lightly_studio/src/lightly_studio/api/routes/video_frames_media.py
@@ -6,31 +6,32 @@ import asyncio
 import io
 import threading
 from collections import OrderedDict
-from collections.abc import Generator
+from contextlib import ExitStack
 from dataclasses import dataclass
-from typing import Annotated, Any, cast
+from typing import Annotated, cast
 from uuid import UUID
 
-import cv2
+import av
 import fsspec
-import numpy as np
-import numpy.typing as npt
+from av.container import InputContainer
+from av.video.frame import VideoFrame
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response
+from PIL import Image
 from pydantic import BaseModel
 
 from lightly_studio.database import db_manager
 from lightly_studio.models.settings import GridViewThumbnailQualityType
 from lightly_studio.resolvers import video_frame_resolver
-from lightly_studio.utils.executor import get_media_executor
+from lightly_studio.utils import executor
 
 frames_router = APIRouter(prefix="/frames/media", tags=["frames streaming"])
 
 JPEG_QUALITY = 75
 
-# Thread-local cache for VideoCapture + stream (per thread, not shared)
+# Containers are thread-local because seeking and decoding mutate their state.
 _thread_local = threading.local()
-_CAP_CACHE_SIZE = 4
+_CONTAINER_CACHE_SIZE = 4
 
 
 @dataclass(frozen=True)
@@ -50,202 +51,122 @@ class FrameTransformQuery(BaseModel):
     max_height: int | None = Query(default=None, ge=1, le=4096)
 
 
-ROTATION_MAP: dict[int, Any] = {
-    0: None,
-    90: cv2.ROTATE_90_COUNTERCLOCKWISE,
-    180: cv2.ROTATE_180,
-    270: cv2.ROTATE_90_CLOCKWISE,
-}
-
-
-class FSSpecStreamReader(io.BufferedIOBase):
-    """Wrapper to make fsspec file objects compatible with cv2.VideoCapture's interface."""
-
-    def __init__(self, path: str) -> None:
-        """Initialize the stream reader.
-
-        Args:
-            path: Path to the video file (local path or cloud URL).
-        """
-        self.fs, self.fs_path = fsspec.core.url_to_fs(url=path)
-        self.file = self.fs.open(path=self.fs_path, mode="rb")
-        # Get file size for size() method
-        try:
-            self.file_size = self.file.size
-        except AttributeError:
-            # Fallback: seek to end to get size
-            current_pos = self.file.tell()
-            self.file.seek(0, 2)
-            self.file_size = self.file.tell()
-            self.file.seek(current_pos)
-
-    def read(self, n: int | None = -1) -> bytes:
-        """Read n bytes from the stream."""
-        return cast(bytes, self.file.read(n))
-
-    def read1(self, n: int = -1) -> bytes:
-        """Read up to n bytes from the stream (implementation for BufferedIOBase)."""
-        return cast(bytes, self.file.read(n))
-
-    def seek(self, offset: int, whence: int = 0) -> int:
-        """Seek to the given offset in the stream."""
-        return cast(int, self.file.seek(offset, whence))
-
-    def tell(self) -> int:
-        """Return the current position in the stream."""
-        return cast(int, self.file.tell())
-
-    def size(self) -> int:
-        """Return the total size of the stream."""
-        return cast(int, self.file_size)
-
-    def close(self) -> None:
-        """Close the stream."""
-        if not self.closed:
-            self.file.close()
-            super().close()
-
-    def __enter__(self) -> FSSpecStreamReader:
-        """Enter the context manager."""
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Exit the context manager and close the stream."""
-        self.close()
-
-
-def _get_cached_capture(video_path: str) -> cv2.VideoCapture:
-    """Get a cached VideoCapture for a video file, or create new if not cached.
-
-    This function implements a thread-local cache for VideoCapture objects and
-    their underlying fsspec stream. Each thread in the thread pool maintains its
-    own independent cache, allowing safe concurrent access without locking.
-
-    Args:
-        video_path: Path to the video file.
-
-    Returns:
-        Open cv2.VideoCapture object for the video.
-
-    Raises:
-        ValueError: If the video file cannot be opened.
-    """
-    if not hasattr(_thread_local, "cap_cache"):
-        _thread_local.cap_cache = OrderedDict()
-    cache: OrderedDict[str, tuple[cv2.VideoCapture, FSSpecStreamReader]] = _thread_local.cap_cache
-
+def _get_cached_container(video_path: str, reset: bool = False) -> InputContainer:
+    """Reuse a thread-local container; own both the decoder and its underlying file."""
+    if not hasattr(_thread_local, "container_cache"):
+        _thread_local.container_cache = OrderedDict()
+    cache: OrderedDict[str, tuple[InputContainer, ExitStack]] = _thread_local.container_cache
     if video_path in cache:
-        cap, stream = cache.pop(video_path)
-        if cap.isOpened():
-            cache[video_path] = (cap, stream)  # move to end
-            return cap
-        # stale entry
-        stream.close()
+        container, resources = cache.pop(video_path)
+        if not reset:
+            cache[video_path] = (container, resources)
+            return container
+        resources.close()
 
-    # open new
-    stream = FSSpecStreamReader(video_path)
-    cap = cv2.VideoCapture(cast(Any, stream), apiPreference=cv2.CAP_FFMPEG, params=())
-    if not cap.isOpened():
-        stream.close()
-        raise ValueError(f"Could not open video: {video_path}")
+    fs, fs_path = fsspec.core.url_to_fs(url=video_path)
+    with ExitStack() as resources:
+        if fsspec.utils.get_protocol(video_path) in {"s3", "gs", "gcs"}:
+            # Previews need sparse reads, not large sequential prefetches.
+            file = resources.enter_context(
+                fs.open(
+                    path=fs_path,
+                    mode="rb",
+                    block_size=256 * 2**10,
+                    cache_type="blockcache",
+                    cache_options={"maxblocks": 4},
+                )
+            )
+        else:
+            file = resources.enter_context(fs.open(path=fs_path, mode="rb"))
+        container = cast(InputContainer, resources.enter_context(av.open(file=file, mode="r")))
+        if not container.streams.video:
+            raise ValueError(f"No video stream in {video_path}")
+        cache[video_path] = (container, resources.pop_all())
+    while len(cache) > _CONTAINER_CACHE_SIZE:
+        _, (_, old_resources) = cache.popitem(last=False)
+        old_resources.close()
+    return container
 
-    cache[video_path] = (cap, stream)
-    # enforce cache size
-    while len(cache) > _CAP_CACHE_SIZE:
-        _, (old_cap, old_stream) = cache.popitem(last=False)
-        old_cap.release()
-        old_stream.close()
 
-    return cap
+def _decode_video_frame(
+    video_path: str,
+    frame_number: int,
+    frame_timestamp_pts: int,
+) -> VideoFrame:
+    """Seek by stored PTS, falling back to the original ordinal if no match exists."""
+    if frame_timestamp_pts != -1:
+        container = _get_cached_container(video_path=video_path)
+        stream = container.streams.video[0]
+        try:
+            container.seek(frame_timestamp_pts, stream=stream, backward=True, any_frame=False)
+            for frame in container.decode(stream):
+                if frame.pts == frame_timestamp_pts:
+                    return frame
+                if frame.pts is not None and frame.pts > frame_timestamp_pts:
+                    break
+        except av.FFmpegError:
+            # Some containers cannot seek; reopening also resets decoder state.
+            pass
+
+    container = _get_cached_container(video_path=video_path, reset=True)
+    for index, frame in enumerate(container.decode(video=0)):
+        if index == frame_number:
+            return frame
+    raise ValueError(f"No frame at index {frame_number}")
 
 
 def _process_video_frame(
     video_path: str,
     frame_number: int,
+    frame_timestamp_pts: int,
     rotation_deg: int,
     transform: FrameTransformOptions,
-) -> tuple[npt.NDArray[np.uint8], str]:
-    """Process a video frame (CPU-intensive work, runs in thread pool).
-
-    This function extracts a single frame from a video file, applies any necessary
-    transformations (rotation), and encodes it as PNG or JPEG. It uses a cached
-    VideoCapture object to avoid reopening the video file for each frame request,
-    which is especially beneficial for cloud-stored videos.
-
-    Args:
-        video_path: Path to the video file.
-        frame_number: Frame number to extract.
-        rotation_deg: Rotation in degrees.
-        transform: Transport-level resize and encoding options.
-
-    Returns:
-        Tuple of (encoded_buffer, media_type).
-
-    Raises:
-        ValueError: If frame cannot be processed.
-    """
-    cap = _get_cached_capture(video_path)
-
-    # Seek to the correct frame and read it
-    cap.set(cv2.CAP_PROP_POS_FRAMES, frame_number)
-    ret, frame = cap.read()
-    # Do not release/close; cached for reuse
-
-    if not ret:
-        raise ValueError(f"No frame at index {frame_number}")
-
-    # Apply counter-rotation if needed
-    rotate_code = ROTATION_MAP[rotation_deg]
-    if rotate_code is not None:
-        frame = cv2.rotate(src=frame, rotateCode=rotate_code)
-
+) -> tuple[bytes, str]:
+    """Decode, counter-rotate, resize and encode a frame in the media worker pool."""
+    frame = _decode_video_frame(
+        video_path=video_path,
+        frame_number=frame_number,
+        frame_timestamp_pts=frame_timestamp_pts,
+    )
+    image = Image.fromarray(frame.to_ndarray(format="rgb24"))
+    if rotation_deg:
+        image = image.rotate(angle=rotation_deg, expand=True)
+    buffer = io.BytesIO()
     if transform.quality == GridViewThumbnailQualityType.HIGH:
-        if transform.max_width is not None or transform.max_height is not None:
-            frame = _resize_frame(
-                frame=frame,
-                max_width=transform.max_width,
-                max_height=transform.max_height,
-            )
-        encode_params = [cv2.IMWRITE_JPEG_QUALITY, JPEG_QUALITY]
-        success, buffer = cv2.imencode(".jpg", frame, encode_params)
+        image = _resize_frame(
+            image=image,
+            max_width=transform.max_width,
+            max_height=transform.max_height,
+        )
+        image.save(buffer, format="JPEG", quality=JPEG_QUALITY, subsampling=2)
         media_type = "image/jpeg"
     else:
-        success, buffer = cv2.imencode(".png", frame)
+        image.save(buffer, format="PNG")
         media_type = "image/png"
-
-    if not success:
-        raise ValueError("Could not encode frame")
-
-    return buffer, media_type
+    return buffer.getvalue(), media_type
 
 
 def _resize_frame(
-    frame: npt.NDArray[np.uint8],
+    image: Image.Image,
     max_width: int | None,
     max_height: int | None,
-) -> npt.NDArray[np.uint8]:
+) -> Image.Image:
     """Resize a frame while preserving aspect ratio and avoiding upscaling."""
-    frame_height, frame_width = frame.shape[:2]
-    max_width = max_width or frame_width
-    max_height = max_height or frame_height
-    scale = min(max_width / frame_width, max_height / frame_height, 1)
-
-    if scale == 1:
-        return frame
-
-    target_size = (
-        max(1, round(frame_width * scale)),
-        max(1, round(frame_height * scale)),
+    scale = min(
+        (max_width or image.width) / image.width, (max_height or image.height) / image.height, 1
     )
-    return cv2.resize(frame, target_size, interpolation=cv2.INTER_AREA)
+    if scale == 1:
+        return image
+    size = (max(1, round(image.width * scale)), max(1, round(image.height * scale)))
+    return image.resize(size=size, resample=Image.Resampling.BOX)
 
 
 @frames_router.get("/{sample_id}")
 async def stream_frame(
     sample_id: UUID,
     transform_query: Annotated[FrameTransformQuery, Depends(FrameTransformQuery)],
-) -> StreamingResponse:
-    """Serve a single video frame as PNG/JPEG using StreamingResponse.
+) -> Response:
+    """Serve a single video frame as PNG/JPEG.
 
     Args:
         sample_id: The UUID of the video frame sample.
@@ -258,6 +179,7 @@ async def stream_frame(
         video_frame = video_frame_resolver.get_by_id(session=sess, sample_id=sample_id)
         video_path = video_frame.video.file_path_abs
         frame_number = video_frame.frame_number
+        frame_timestamp_pts = video_frame.frame_timestamp_pts
         rotation_deg = video_frame.rotation_deg
     if (
         transform_query.quality == GridViewThumbnailQualityType.HIGH
@@ -274,24 +196,22 @@ async def stream_frame(
     # Run CPU-intensive video processing in thread pool to avoid blocking event loop
     try:
         buffer, media_type = await asyncio.get_running_loop().run_in_executor(
-            get_media_executor("video_frame"),
+            executor.get_media_executor("video_frame"),
             _process_video_frame,
             video_path,
             frame_number,
+            frame_timestamp_pts,
             rotation_deg,
             transform,
         )
-    except ValueError as exc:
+    except (ValueError, av.FFmpegError) as exc:
         raise HTTPException(400, str(exc)) from exc
 
-    def frame_stream() -> Generator[bytes, None, None]:
-        yield buffer.tobytes()
-
-    return StreamingResponse(
-        frame_stream(),
+    return Response(
+        content=buffer,
         media_type=media_type,
         headers={
             "Cache-Control": "public, max-age=3600",
-            "Content-Length": str(buffer.nbytes),
+            "Content-Length": str(len(buffer)),
         },
     )

--- a/lightly_studio/tests/api/test_video_frames_media.py
+++ b/lightly_studio/tests/api/test_video_frames_media.py
@@ -2,20 +2,29 @@
 
 from __future__ import annotations
 
+import io
+import wave
+from collections.abc import Iterator
+from fractions import Fraction
 from pathlib import Path
+from typing import cast
 
+import av
 import cv2
+import fsspec
 import numpy as np
+import pytest
+from av.video.stream import VideoStream
 from fastapi.testclient import TestClient
+from PIL import Image
+from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 import lightly_studio.api.routes.video_frames_media as video_frames_media_module
 import lightly_studio.utils.executor as executor_module
-from lightly_studio.api.routes.video_frames_media import (
-    _CAP_CACHE_SIZE,
-    _get_cached_capture,
-)
+from lightly_studio.api.routes.video_frames_media import FrameTransformOptions
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.settings import GridViewThumbnailQualityType
 from tests.helpers_resolvers import create_collection
 from tests.resolvers.video.helpers import VideoStub, create_video_file, create_video_with_frames
 
@@ -143,105 +152,178 @@ def test_stream_frame_high_requires_bounds(
     assert response.status_code == 400
 
 
-def test_get_cached_capture_creates_new(
-    tmp_path: Path,
+@pytest.fixture(autouse=True)
+def clear_container_cache() -> Iterator[None]:
+    yield
+    cache = getattr(video_frames_media_module._thread_local, "container_cache", {})
+    for _, resources in cache.values():
+        resources.close()
+    cache.clear()
+
+
+@pytest.fixture
+def variable_rate_video(tmp_path: Path) -> Path:
+    path = tmp_path / "variable.mkv"
+    with av.open(str(path), mode="w") as container:
+        stream = cast(VideoStream, container.add_stream("ffv1", rate=25))
+        stream.width, stream.height = 32, 16
+        stream.pix_fmt = "bgr0"
+        stream.time_base = Fraction(1, 1000)
+        stream.codec_context.time_base = Fraction(1, 1000)
+        for index, pts in enumerate([100, 140, 220, 260, 400]):
+            pixels = np.full((16, 32, 3), index * 40, dtype=np.uint8)
+            pixels[:8, :16] = (255, 0, 0)
+            frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+            frame.pts, frame.time_base = pts, Fraction(1, 1000)
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+    return path
+
+
+@pytest.mark.parametrize("pts", [220, -1, 221])
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+def test_process_video_frame_exact_frame(
+    variable_rate_video: Path,
+    pts: int,
+    rotation: int,
 ) -> None:
-    """Test _get_cached_capture creates new VideoCapture when not cached."""
-    video_path = create_video_file(
-        output_path=tmp_path / "test_video.mp4",
-        width=320,
-        height=240,
-        num_frames=5,
-        fps=1,
+    # Includes missing/unmatched PTS and a nonzero start time at variable frame rate.
+    buffer, media_type = video_frames_media_module._process_video_frame(
+        video_path=str(variable_rate_video),
+        frame_number=2,
+        frame_timestamp_pts=pts,
+        rotation_deg=rotation,
+        transform=FrameTransformOptions(GridViewThumbnailQualityType.RAW, None, None),
+    )
+    expected = np.full((16, 32, 3), 80, dtype=np.uint8)
+    expected[:8, :16] = (255, 0, 0)
+    assert media_type == "image/png"
+    np.testing.assert_array_equal(
+        np.asarray(Image.open(io.BytesIO(buffer))), np.rot90(expected, k=rotation // 90)
     )
 
-    cap = _get_cached_capture(str(video_path))
 
-    assert cap is not None
-    assert isinstance(cap, cv2.VideoCapture)
-    assert cap.isOpened()
-
-
-def test_get_cached_capture_reuses_cached(
-    tmp_path: Path,
-) -> None:
-    """Test _get_cached_capture reuses cached VideoCapture for same video."""
-    video_path = create_video_file(
-        output_path=tmp_path / "test_video.mp4",
-        width=320,
-        height=240,
-        num_frames=5,
-        fps=1,
-    )
-
-    # Get capture first time
-    cap1 = _get_cached_capture(str(video_path))
-    cap1_id = id(cap1)
-
-    # Get capture second time - should be same object
-    cap2 = _get_cached_capture(str(video_path))
-    cap2_id = id(cap2)
-
-    assert cap1_id == cap2_id, "VideoCapture should be reused from cache"
-
-
-def test_get_cached_capture_lru_eviction(
-    tmp_path: Path,
-) -> None:
-    """Test _get_cached_capture evicts least recently used entries when cache is full."""
-    # Create multiple video files
-    video_paths = []
-    for i in range(_CAP_CACHE_SIZE + 2):  # Create more than cache size
-        video_path = create_video_file(
-            output_path=tmp_path / f"test_video_{i}.mp4",
-            width=320,
-            height=240,
-            num_frames=5,
-            fps=1,
+def test_decode_video_frame_seeks_backwards(variable_rate_video: Path) -> None:
+    for index, pts in [(4, 400), (0, 100), (3, 260), (3, 260)]:
+        frame = video_frames_media_module._decode_video_frame(
+            video_path=str(variable_rate_video),
+            frame_number=index,
+            frame_timestamp_pts=pts,
         )
-        video_paths.append(str(video_path))
-
-    # Fill cache to capacity
-    for path in video_paths[:_CAP_CACHE_SIZE]:
-        _get_cached_capture(path)
-
-    # Access cache to verify size
-    cache = video_frames_media_module._thread_local.cap_cache
-    assert len(cache) == _CAP_CACHE_SIZE
-
-    # Add one more - should evict the oldest
-    _get_cached_capture(video_paths[_CAP_CACHE_SIZE])
-
-    # Cache should still be at max size
-    assert len(cache) == _CAP_CACHE_SIZE
-
-    # The first video should be evicted (oldest)
-    assert video_paths[0] not in cache
+        assert frame.pts == pts
+        assert frame.to_ndarray(format="rgb24")[-1, -1, 0] == index * 40
 
 
-def test_get_cached_capture_handles_stale_entry(
-    tmp_path: Path,
-) -> None:
-    """Test _get_cached_capture handles stale (closed) VideoCapture entries."""
-    video_path = create_video_file(
-        output_path=tmp_path / "test_video.mp4",
-        width=320,
-        height=240,
-        num_frames=5,
-        fps=1,
+def test_decode_video_frame_failed_seek(variable_rate_video: Path, mocker: MockerFixture) -> None:
+    container = video_frames_media_module._get_cached_container(str(variable_rate_video))
+    unseekable = mocker.Mock(streams=container.streams)
+    unseekable.seek.side_effect = av.error.InvalidDataError(1, "Cannot seek")
+    mocker.patch.object(
+        video_frames_media_module, "_get_cached_container", side_effect=[unseekable, container]
     )
+    frame = video_frames_media_module._decode_video_frame(
+        video_path=str(variable_rate_video),
+        frame_number=2,
+        frame_timestamp_pts=220,
+    )
+    assert frame.pts == 220
 
-    # Get and cache a capture
-    cap1 = _get_cached_capture(str(video_path))
-    assert cap1.isOpened()
 
-    # Manually close it to simulate stale entry
-    cap1.release()
+@pytest.mark.parametrize(
+    ("bounds", "expected"), [((None, 4), (8, 4)), ((8, None), (8, 4)), ((64, 64), (32, 16))]
+)
+def test_resize_frame(bounds: tuple[int | None, int | None], expected: tuple[int, int]) -> None:
+    result = video_frames_media_module._resize_frame(
+        image=Image.new("RGB", (32, 16)),
+        max_width=bounds[0],
+        max_height=bounds[1],
+    )
+    assert result.size == expected
 
-    # Get capture again - should create new one since old is closed
-    cap2 = _get_cached_capture(str(video_path))
-    assert cap2.isOpened()
-    assert id(cap1) != id(cap2), "Should create new VideoCapture for stale entry"
+
+def test_decode_video_frame_invalid_index(variable_rate_video: Path) -> None:
+    with pytest.raises(ValueError, match="No frame at index 20"):
+        video_frames_media_module._decode_video_frame(
+            video_path=str(variable_rate_video),
+            frame_number=20,
+            frame_timestamp_pts=-1,
+        )
+
+
+def test_get_cached_container_reuses_cached(variable_rate_video: Path) -> None:
+    first = video_frames_media_module._get_cached_container(str(variable_rate_video))
+    assert video_frames_media_module._get_cached_container(str(variable_rate_video)) is first
+
+
+@pytest.mark.parametrize("reset", [False, True])
+def test_get_cached_container_closes_files(
+    variable_rate_video: Path,
+    mocker: MockerFixture,
+    reset: bool,
+) -> None:
+    fs = fsspec.filesystem("memory")
+    mocker.patch.object(fsspec.core, "url_to_fs", return_value=(fs, "video"))
+    files = [io.BytesIO(variable_rate_video.read_bytes()) for _ in range(5)]
+    mocker.patch.object(fs, "open", side_effect=files)
+    first = video_frames_media_module._get_cached_container("first")
+    close = mocker.spy(video_frames_media_module._thread_local.container_cache["first"][1], "close")
+    if reset:
+        video_frames_media_module._get_cached_container(video_path="first", reset=True)
+    else:
+        for index in range(4):
+            video_frames_media_module._get_cached_container(str(index))
+    close.assert_called_once()
+    assert files[0].closed
+    with pytest.raises((AssertionError, ValueError), match=r"not open|closed"):
+        next(first.decode(video=0))
+
+
+@pytest.mark.parametrize("audio_only", [False, True])
+def test_get_cached_container_failed_open_closes_file(
+    mocker: MockerFixture,
+    audio_only: bool,
+) -> None:
+    fs = fsspec.filesystem("memory")
+    file = io.BytesIO(b"not a video")
+    if audio_only:
+        file = io.BytesIO()
+        with wave.open(file, mode="wb") as audio:
+            audio.setparams((1, 2, 8000, 0, "NONE", "not compressed"))
+            audio.writeframes(b"\x00\x00" * 800)
+        file.seek(0)
+    mocker.patch.object(fsspec.core, "url_to_fs", return_value=(fs, "broken"))
+    mocker.patch.object(fs, "open", return_value=file)
+    with pytest.raises((av.FFmpegError, ValueError)):
+        video_frames_media_module._get_cached_container("broken")
+    assert file.closed
+    assert "broken" not in video_frames_media_module._thread_local.container_cache
+
+
+@pytest.mark.parametrize("protocol", ["gs", "gcs", "s3", "file"])
+def test_get_cached_container_remote_cache(
+    variable_rate_video: Path,
+    mocker: MockerFixture,
+    protocol: str,
+) -> None:
+    fs = fsspec.filesystem("memory")
+    mocker.patch.object(fsspec.core, "url_to_fs", return_value=(fs, "video"))
+    open_file = mocker.patch.object(
+        fs, "open", return_value=io.BytesIO(variable_rate_video.read_bytes())
+    )
+    container = video_frames_media_module._get_cached_container(f"{protocol}://video")
+    assert next(container.decode(video=0)).pts == 100
+    if protocol == "file":
+        open_file.assert_called_once_with(path="video", mode="rb")
+    else:
+        open_file.assert_called_once_with(
+            path="video",
+            mode="rb",
+            block_size=256 * 2**10,
+            cache_type="blockcache",
+            cache_options={"maxblocks": 4},
+        )
 
 
 def test_get_media_executor_creates_singleton() -> None:

--- a/lightly_studio/tests/api/test_video_frames_media.py
+++ b/lightly_studio/tests/api/test_video_frames_media.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import wave
 from collections.abc import Iterator
 from fractions import Fraction
 from pathlib import Path
@@ -185,12 +184,9 @@ def variable_rate_video(tmp_path: Path) -> Path:
 @pytest.mark.parametrize("pts", [220, -1, 221])
 @pytest.mark.parametrize("rotation", [0, 90, 180, 270])
 def test_process_video_frame_exact_frame(
-    variable_rate_video: Path,
-    pts: int,
-    rotation: int,
+    variable_rate_video: Path, pts: int, rotation: int
 ) -> None:
-    # Includes missing/unmatched PTS and a nonzero start time at variable frame rate.
-    buffer, media_type = video_frames_media_module._process_video_frame(
+    buffer, _ = video_frames_media_module._process_video_frame(
         video_path=str(variable_rate_video),
         frame_number=2,
         frame_timestamp_pts=pts,
@@ -199,62 +195,9 @@ def test_process_video_frame_exact_frame(
     )
     expected = np.full((16, 32, 3), 80, dtype=np.uint8)
     expected[:8, :16] = (255, 0, 0)
-    assert media_type == "image/png"
     np.testing.assert_array_equal(
         np.asarray(Image.open(io.BytesIO(buffer))), np.rot90(expected, k=rotation // 90)
     )
-
-
-def test_decode_video_frame_seeks_backwards(variable_rate_video: Path) -> None:
-    for index, pts in [(4, 400), (0, 100), (3, 260), (3, 260)]:
-        frame = video_frames_media_module._decode_video_frame(
-            video_path=str(variable_rate_video),
-            frame_number=index,
-            frame_timestamp_pts=pts,
-        )
-        assert frame.pts == pts
-        assert frame.to_ndarray(format="rgb24")[-1, -1, 0] == index * 40
-
-
-def test_decode_video_frame_failed_seek(variable_rate_video: Path, mocker: MockerFixture) -> None:
-    container = video_frames_media_module._get_cached_container(str(variable_rate_video))
-    unseekable = mocker.Mock(streams=container.streams)
-    unseekable.seek.side_effect = av.error.InvalidDataError(1, "Cannot seek")
-    mocker.patch.object(
-        video_frames_media_module, "_get_cached_container", side_effect=[unseekable, container]
-    )
-    frame = video_frames_media_module._decode_video_frame(
-        video_path=str(variable_rate_video),
-        frame_number=2,
-        frame_timestamp_pts=220,
-    )
-    assert frame.pts == 220
-
-
-@pytest.mark.parametrize(
-    ("bounds", "expected"), [((None, 4), (8, 4)), ((8, None), (8, 4)), ((64, 64), (32, 16))]
-)
-def test_resize_frame(bounds: tuple[int | None, int | None], expected: tuple[int, int]) -> None:
-    result = video_frames_media_module._resize_frame(
-        image=Image.new("RGB", (32, 16)),
-        max_width=bounds[0],
-        max_height=bounds[1],
-    )
-    assert result.size == expected
-
-
-def test_decode_video_frame_invalid_index(variable_rate_video: Path) -> None:
-    with pytest.raises(ValueError, match="No frame at index 20"):
-        video_frames_media_module._decode_video_frame(
-            video_path=str(variable_rate_video),
-            frame_number=20,
-            frame_timestamp_pts=-1,
-        )
-
-
-def test_get_cached_container_reuses_cached(variable_rate_video: Path) -> None:
-    first = video_frames_media_module._get_cached_container(str(variable_rate_video))
-    assert video_frames_media_module._get_cached_container(str(variable_rate_video)) is first
 
 
 @pytest.mark.parametrize("reset", [False, True])
@@ -266,64 +209,34 @@ def test_get_cached_container_closes_files(
     fs = fsspec.filesystem("memory")
     mocker.patch.object(fsspec.core, "url_to_fs", return_value=(fs, "video"))
     files = [io.BytesIO(variable_rate_video.read_bytes()) for _ in range(5)]
-    mocker.patch.object(fs, "open", side_effect=files)
-    first = video_frames_media_module._get_cached_container("first")
-    close = mocker.spy(video_frames_media_module._thread_local.container_cache["first"][1], "close")
+    open_file = mocker.patch.object(fs, "open", side_effect=files)
+    first = video_frames_media_module._get_cached_container("gs://first")
+    assert video_frames_media_module._get_cached_container("gs://first") is first
+    open_file.assert_called_once_with(
+        path="video",
+        mode="rb",
+        block_size=256 * 2**10,
+        cache_type="blockcache",
+        cache_options={"maxblocks": 4},
+    )
     if reset:
-        video_frames_media_module._get_cached_container(video_path="first", reset=True)
+        video_frames_media_module._get_cached_container(video_path="gs://first", reset=True)
     else:
         for index in range(4):
             video_frames_media_module._get_cached_container(str(index))
-    close.assert_called_once()
     assert files[0].closed
     with pytest.raises((AssertionError, ValueError), match=r"not open|closed"):
         next(first.decode(video=0))
 
 
-@pytest.mark.parametrize("audio_only", [False, True])
-def test_get_cached_container_failed_open_closes_file(
-    mocker: MockerFixture,
-    audio_only: bool,
-) -> None:
+def test_get_cached_container_failed_open_closes_file(mocker: MockerFixture) -> None:
     fs = fsspec.filesystem("memory")
     file = io.BytesIO(b"not a video")
-    if audio_only:
-        file = io.BytesIO()
-        with wave.open(file, mode="wb") as audio:
-            audio.setparams((1, 2, 8000, 0, "NONE", "not compressed"))
-            audio.writeframes(b"\x00\x00" * 800)
-        file.seek(0)
     mocker.patch.object(fsspec.core, "url_to_fs", return_value=(fs, "broken"))
     mocker.patch.object(fs, "open", return_value=file)
-    with pytest.raises((av.FFmpegError, ValueError)):
+    with pytest.raises(av.FFmpegError):
         video_frames_media_module._get_cached_container("broken")
     assert file.closed
-    assert "broken" not in video_frames_media_module._thread_local.container_cache
-
-
-@pytest.mark.parametrize("protocol", ["gs", "gcs", "s3", "file"])
-def test_get_cached_container_remote_cache(
-    variable_rate_video: Path,
-    mocker: MockerFixture,
-    protocol: str,
-) -> None:
-    fs = fsspec.filesystem("memory")
-    mocker.patch.object(fsspec.core, "url_to_fs", return_value=(fs, "video"))
-    open_file = mocker.patch.object(
-        fs, "open", return_value=io.BytesIO(variable_rate_video.read_bytes())
-    )
-    container = video_frames_media_module._get_cached_container(f"{protocol}://video")
-    assert next(container.decode(video=0)).pts == 100
-    if protocol == "file":
-        open_file.assert_called_once_with(path="video", mode="rb")
-    else:
-        open_file.assert_called_once_with(
-            path="video",
-            mode="rb",
-            block_size=256 * 2**10,
-            cache_type="blockcache",
-            cache_options={"maxblocks": 4},
-        )
 
 
 def test_get_media_executor_creates_singleton() -> None:


### PR DESCRIPTION
## What has changed and why?

- Replace OpenCV preview decoding with PyAV so thumbnails load faster. (6x faster, 10s for the full grid view vs 1min before)
- Read small chunks from cloud storage and reuse open videos.
- Preserve exact frame selection, image orientation, and thumbnail quality.

## How has it been tested?

- Update tests and manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved video decoding performance in the GUI, with up to 6× faster decoding for parallel streams.
  - Grid view loading and scrolling are now more responsive when working with video content.

- **Reliability**
  - Improved frame extraction for videos with variable frame rates.
  - Enhanced handling of rotated video frames and invalid or unavailable video data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->