### PR TITLE
Fix flaky S3 file listing tests

### DIFF
--- a/lightly_studio/tests/dataset/test_fsspec_lister.py
+++ b/lightly_studio/tests/dataset/test_fsspec_lister.py
@@ -79,17 +79,18 @@ def mock_fsspec_s3fs(moto_server: ThreadedMotoServer) -> Generator[None, None, N
     # Store original functions
     original_get_filesystem = fsspec_lister._get_filesystem
     original_fsspec_open = fsspec.open
+    s3_filesystem = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": endpoint},
+        key="testing",
+        secret="testing",
+        token="testing",
+        skip_instance_cache=True,
+    )
 
     def mock_get_filesystem(path: str) -> Any:
         """Get filesystem that points to moto server."""
         if path.startswith("s3://"):
-            # Configure s3fs to use moto server
-            return s3fs.S3FileSystem(
-                client_kwargs={"endpoint_url": endpoint},
-                key="testing",
-                secret="testing",
-                token="testing",
-            )
+            return s3_filesystem
         return original_get_filesystem(path)
 
     def mock_fsspec_open(path: str, mode: str = "rb", **kwargs: Any) -> Any:


### PR DESCRIPTION
## What has changed and why?

Fixes [LIG-10652](https://linear.app/lightly/issue/LIG-10652/fix-flaky-ci-tests).

### Failure

- The Python 3.9 CI job sometimes failed in `test_get_file_list_from_s3__empty_dir`.
- The test raised `ValueError: Path does not exist: s3://test/images/empty_dir` even though the test fixture created the empty S3 folder.
- The failure occurred when pytest-xdist ran the recursive glob test and the empty-folder test on the same worker.

### Cause

- The mock returned the same cached `S3FileSystem` instance across tests in one worker.
- The recursive glob test stored the empty-folder marker as `test/images/empty_dir/` in the directory cache.
- The empty-folder test then checked `test/images/empty_dir`, without the final slash. With s3fs 2025.10.0, the cached paths did not match, so `exists()` returned `False` without making an S3 request.

### Solution

- Create one mocked S3 file system for each fixture invocation with `skip_instance_cache=True`.
- Reuse that instance within the test, so normal directory caching remains enabled.
- Prevent cache state from earlier tests from affecting later tests.
- No production code changes.

## How has it been tested?

- Reproduced before the fix by running the recursive glob test followed by the empty-folder test: 1 passed, 1 failed.
- Ran the same test pair after the fix: 2 passed.
- Ran `tests/dataset/test_fsspec_lister.py`: 24 passed.
- Ruff checks and formatting checks passed.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Alternative reviewer: @IgorSusmelj.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated S3 filesystem test fixtures to reuse a single filesystem instance across calls.
  - Disabled instance caching in the test configuration for more consistent test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->