### PR TITLE
Stop bootstrapping nvm in CI

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -131,6 +131,13 @@ jobs:
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
 
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: lightly_studio_view/.nvmrc
+          cache: npm
+          cache-dependency-path: lightly_studio_view/package-lock.json
+
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio
         run: make install-optional-deps
@@ -189,6 +196,13 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: lightly_studio_view/.nvmrc
+          cache: npm
+          cache-dependency-path: lightly_studio_view/package-lock.json
+
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio
         env:
@@ -234,6 +248,13 @@ jobs:
           python-version: "3.9"
           enable-cache: true
           save-cache: ${{ env.UV_SAVE_CACHE }}
+
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: lightly_studio_view/.nvmrc
+          cache: npm
+          cache-dependency-path: lightly_studio_view/package-lock.json
 
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio

--- a/lightly_studio_view/Makefile
+++ b/lightly_studio_view/Makefile
@@ -5,6 +5,11 @@ ifeq ($(OS),Windows_NT)
 	@echo "Checking Node.js installation..."
 	@powershell -Command "if (-not (Get-Command node -ErrorAction SilentlyContinue)) { Write-Host 'Error: Node.js is not installed. Please install Node.js >=22.11.0 from https://nodejs.org/'; exit 1 }"
 	npm ci
+else ifeq ($(CI),true)
+# CI installs Node with actions/setup-node from the same .nvmrc, so there is nothing
+# left for nvm to do. Skipping it also keeps a remote installer out of the build,
+# which matters once a workflow builds the wheel in a job that can publish it.
+	npm ci
 else
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 	bash -c 'export NVM_DIR="$${HOME}/.nvm"; \


### PR DESCRIPTION
## What has changed and why?

`lightly_studio_view`'s `install` target bootstraps nvm by piping a remote script into a shell (`curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/.../install.sh | bash`). `build` depends on `install`, and `lightly_studio`'s `make build` chains into it, so every CI job that builds the app downloads and executes that script. A `raw.githubusercontent.com` URL at a tag is a mutable ref: whoever controls that repository controls what runs on the runner.

Two commits:

1. **Skip the nvm bootstrap under CI.** An `else ifeq ($(CI),true)` branch runs `npm ci` directly; GitHub Actions sets `CI=true`. Local development is untouched — developers without Node still get the bootstrap. Windows already did exactly this, so the new branch matches the existing one.
2. **Install Node explicitly in the jobs that build the frontend.** `check-typescript`, `test-backend` and `test-frontend` in `unit_test.yml` had **no** `actions/setup-node` at all: their Node came from the nvm bootstrap as a side effect of `make install`. Removing it left them on the runner default (22.23.2) and `npm ci` refused the package's `>=24` engine constraint. They now pin Node from `lightly_studio_view/.nvmrc`, which is what `end2end_test.yml` already does.

The motivation is the next PR in this stack, which builds the release wheel in the job that holds `id-token: write` and publishes to PyPI. A script fetched at build time would run in the same job that then mints a PyPI credential. Split out so that PR stays a workflow change only.

## How has it been tested?

`make -n` in `lightly_studio_view`, which prints the recipe without running it:

- `make -n install` → the nvm bootstrap, unchanged.
- `CI=true make -n install` → `npm ci`, no curl.
- `CI=true make -n build` → `npm ci` then `npm run build`, no curl.

CI on this PR is the real check, and the first run earned its keep: `end2end_test.yml` passed (it already pinned Node correctly) while `Static Checks Typescript` and `Frontend Tests` failed with `EBADENGINE … Required: {"node":">=24"} Actual: node v22.23.2`, which is what the second commit fixes. Every job reaching this target was then audited rather than assumed:

| Job | Builds the frontend? | Node |
| -- | -- | -- |
| `unit_test` / `check-typescript`, `test-backend`, `test-frontend` | yes, via `make build` / `make test` | added here, from the view's `.nvmrc` |
| `unit_test` / `check-python`, `check-docs`, `check-release-tooling` | no | not needed |
| `end2end_test` | yes | already the view's `.nvmrc` |
| `fast_track_guardrails` | yes, `make build-lightly_studio_view` | `fast_track/.nvmrc`, currently also 24.13.1 |

`test-backend` is the one that would have bitten later: it was skipped on the first run, but `make test` and `make test-postgres` both depend on `build`, so it would have failed on the next backend change. The dependency set is unchanged everywhere — it is the same `npm ci` either way.

Two things called out for the reviewer:

- `fast_track_guardrails.yml` builds the view but pins Node from `fast_track/.nvmrc`. Both files say 24.13.1 today, so it works; it is a latent coupling, not a break, and worth a follow-up if the two ever need to diverge.
- CI no longer has nvm, so the `nvm use` lines in the other view targets (`static-checks`, `test`, …) will print `nvm: command not found` and carry on — they are `;`-separated and `setup-node` supplies the same version. Log noise, not a behaviour change. A follow-up collapses those seven copies of the conditional into one definition and removes it.

Also confirmed `lightly_studio`'s `install-uv` target (which fetches the uv installer) is not referenced by any workflow; CI uses `astral-sh/setup-uv`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Reviewer: @horatiualmasan, who added the Windows/nvm conditional this extends (#365). Alternative: @michal-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build and test setup by consistently using the project’s specified Node.js version.
  * Streamlined dependency installation in continuous integration environments for faster, more reliable validation.
  * Enabled dependency caching during automated checks to reduce setup time.

* **Tests**
  * Updated frontend, backend, and TypeScript checks to use the standardized Node.js environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->