### PR TITLE
Publish the wheel to PyPI from Finish Release

### DIFF
--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -45,6 +45,7 @@ def render_pr_body(section_body: str, version: str) -> str:
         f"{_GUARDS}\n\n"
         f"{_CHECKLIST}\n\n"
         f"Merging tags this commit and opens a **draft** GitHub release. Nothing is public "
-        f"until the wheel is on PyPI and someone runs Finish Release; PyPI and the docs are "
-        f"still manual.\n"
+        f"until someone runs Finish Release with `target: pypi`, which builds the wheel, "
+        f"publishes it to PyPI and "
+        f"un-drafts the release; the docs are still manual.\n"
     )

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -220,4 +220,4 @@ jobs:
             --draft \
             --title "${TAG}" \
             --notes-file "${RUNNER_TEMP}/release-notes.md"
-          echo "::notice::Draft release ${TAG} ready. Run Finish Release once the wheel is on PyPI."
+          echo "::notice::Draft release ${TAG} ready. Run Finish Release to publish the wheel to PyPI and make the release public."

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -7,55 +7,195 @@ on:
         description: Tag of the draft release to publish, e.g. v1.2.3.
         type: string
         required: true
+      target:
+        description: >-
+          Index to publish to. "testpypi" rehearses the whole path - it builds
+          and uploads, and leaves the GitHub release alone.
+        type: choice
+        options: [pypi, testpypi]
+        default: pypi
 
-permissions:
-  contents: write
+# Nothing at workflow level: each job below asks for exactly what it needs.
+permissions: {}
+
+# A second dispatch for the same tag while the first waits for its environment
+# approval would try to publish it twice. Queued rather than cancelled, because
+# cancelling a run mid-upload is worse than making it wait.
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  PYTHONPATH: ${{ github.workspace }}/.github/scripts
+  # The frontend build needs more heap than the default, same as the test workflows.
+  NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
-  finish-release:
+  # Split from the publish deliberately. This job runs the tagged commit's own
+  # code - `uv sync`, `npm ci`, `npm run build` - so it must not be able to mint
+  # a PyPI credential: it has no `id-token: write`, and the only thing it hands
+  # onwards is the built distribution.
+  build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      TAG: ${{ inputs.tag }}
     steps:
-      - name: Require the version on PyPI
-        env:
-          TAG: ${{ inputs.tag }}
-        # The release is drafted so that a failed PyPI publish stays
-        # recoverable; publishing it before the wheel is installable is the
-        # state that drafting exists to avoid.
+      # The tagged commit, never main, which has usually moved past the bump. A
+      # tag that does not exist fails here, in seconds, before anything is built.
+      - name: Checkout the release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      # The tag is what a person typed; the version is what would be uploaded.
+      # A mismatch means the tag does not point where whoever dispatched this
+      # believes it does, and PyPI would happily accept the wrong version.
+      - name: Assert the tag matches the version it points at
         run: |
           set -euo pipefail
-          version="${TAG#v}"
-          status="$(curl -sS -o "${RUNNER_TEMP}/pypi.json" -w '%{http_code}' \
-            "https://pypi.org/pypi/lightly-studio/${version}/json")"
-          if [ "${status}" != "200" ]; then
-            echo "::error::lightly-studio ${version} is not on PyPI (HTTP ${status}). Publish the wheel first."
-            exit 1
-          fi
-          # A version record outlives its files: a half-finished upload or a yank still answers 200.
-          if ! python3 -c 'import json, sys; sys.exit(0 if any(f["packagetype"] == "bdist_wheel" and not f["yanked"] for f in json.load(open(sys.argv[1]))["urls"]) else 1)' \
-            "${RUNNER_TEMP}/pypi.json"; then
-            echo "::error::lightly-studio ${version} has no installable wheel on PyPI."
+          version="$(python3 -m prepare_release read-version \
+            --pyproject lightly_studio/pyproject.toml)"
+          if [ "v${version}" != "${TAG}" ]; then
+            echo "::error::${TAG} points at a commit whose version is ${version}."
             exit 1
           fi
 
-      - name: Publish the draft release
+      - name: Set Up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # No enable-cache, unlike the test workflows. A cache written by another
+      # workflow is an input to the artifact that gets published, so this job
+      # builds from the lockfile alone.
+      - name: Set Up Uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.6"
+
+      # The wheel bundles the built frontend, so the build needs Node. Taken
+      # from .nvmrc, the same version the Makefile's nvm path picks locally.
+      - name: Set Up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: lightly_studio_view/.nvmrc
+
+      - name: Install Dependencies
+        working-directory: lightly_studio
+        run: make install-optional-deps
+
+      # `make build` builds the frontend, copies it in, and runs `uv build`. In
+      # a uv workspace the lock is at the root but the distributions still land
+      # in lightly_studio/dist.
+      - name: Build the Distributions
+        working-directory: lightly_studio
+        run: make build
+
+      # Short retention: PyPI is where these live permanently, and a re-run
+      # rebuilds them from the tag anyway.
+      - name: Upload the Distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: lightly_studio/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  # The only job that can publish. It runs no code from the release commit: it
+  # downloads the distributions, signs them, uploads them, and un-drafts the
+  # GitHub release.
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The environment is what PyPI's trusted publisher checks the OIDC claim
+    # against, so only this job of this file can publish. `pypi` carries the
+    # approval gate and is restricted to main; `testpypi` has neither, so a
+    # rehearsal runs unattended.
+    environment: ${{ inputs.target }}
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      TAG: ${{ inputs.tag }}
+      PUBLISH_URL: >-
+        ${{ inputs.target == 'pypi' && 'https://upload.pypi.org/legacy/'
+        || 'https://test.pypi.org/legacy/' }}
+      CHECK_URL: >-
+        ${{ inputs.target == 'pypi' && 'https://pypi.org/simple/'
+        || 'https://test.pypi.org/simple/' }}
+    steps:
+      # Before the upload, and skipped for a rehearsal, which never touches the
+      # release. This is also what makes a re-run safe: a run that published the
+      # distributions but failed to un-draft leaves a draft, so a re-run passes
+      # here, skips the upload on --check-url, and finishes; once the release is
+      # live, a re-run stops here instead of appending "Released by" twice.
+      - name: Require a draft release
+        if: inputs.target == 'pypi'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
           REPO: ${{ github.repository }}
-          ACTOR: ${{ github.actor }}
-        # A release's author is whichever identity's token created it, so a
-        # workflow-created release always reads as github-actions[bot]. This
-        # workflow is dispatch-triggered, so the actor is the person who
-        # decided to release; the notes name them instead. Appending it here
-        # rather than when drafting keeps it out of a draft nobody published,
-        # and the draft check above keeps a re-run from adding it twice.
         run: |
           set -euo pipefail
           if [ "$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq .isDraft)" != "true" ]; then
             echo "::error::${TAG} is not a draft release."
             exit 1
           fi
+
+      - name: Download the Distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - name: Set Up Uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.6"
+
+      # `uv publish` uploads PEP 740 attestations but does not create them, so
+      # without this step there is no provenance at all. Signing has to happen
+      # here rather than in the build job: the index checks the signing
+      # certificate against the trusted publisher, so the identity has to be
+      # this job's. Pinned to an exact version, since it runs in the job that
+      # holds the token.
+      - name: Sign the Distributions
+        run: uvx pypi-attestations@0.0.30 sign dist/*.whl dist/*.tar.gz
+
+      # `always` rather than the default `automatic`: a misconfigured publisher
+      # should fail loudly here instead of quietly falling back to looking for a
+      # token that does not exist. --check-url lets a re-run skip files already
+      # uploaded, which is what makes the job idempotent. The distributions are
+      # listed explicitly so the default `dist/*` glob does not hand uv the
+      # .publish.attestation files as if they were distributions.
+      - name: Publish to the Index
+        run: |
+          uv publish \
+            --trusted-publishing always \
+            --publish-url "${PUBLISH_URL}" \
+            --check-url "${CHECK_URL}" \
+            dist/*.whl dist/*.tar.gz
+
+      # Only for a real release: a TestPyPI rehearsal must not mark a GitHub
+      # release live.
+      #
+      # A release's author is whichever identity's token created it, so a
+      # workflow-created release always reads as github-actions[bot]. This
+      # workflow is dispatch-triggered, so the actor is the person who decided
+      # to release; the notes name them instead. Appending it here rather than
+      # when drafting keeps it out of a draft nobody published.
+      - name: Publish the draft release
+        if: inputs.target == 'pypi'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
           gh release view "${TAG}" --repo "${REPO}" --json body --jq .body \
             > "${RUNNER_TEMP}/release-notes.md"
           printf '\nReleased by @%s\n' "${ACTOR}" >> "${RUNNER_TEMP}/release-notes.md"

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -26,16 +26,44 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PYTHONPATH: ${{ github.workspace }}/.github/scripts
   # The frontend build needs more heap than the default, same as the test workflows.
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
+  # Ahead of the build rather than beside the upload: the publish job sits
+  # behind an approval gate, so a tag that was never drafted or is already
+  # released should be rejected before it costs half an hour of build and a
+  # reviewer's approval. Its own job because GitHub shows draft releases only to
+  # identities with push access, so this needs `contents: write` and the build
+  # job below must not have it. Nothing here runs repository code - no checkout.
+  precheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      # Skipped for a rehearsal, which never touches the release. This is also
+      # what keeps a re-dispatch from appending "Released by" twice: once the
+      # release is live, the next dispatch stops here.
+      - name: Require a draft release
+        if: inputs.target == 'pypi'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq .isDraft)" != "true" ]; then
+            echo "::error::${TAG} is not a draft release."
+            exit 1
+          fi
+
   # Split from the publish deliberately. This job runs the tagged commit's own
   # code - `uv sync`, `npm ci`, `npm run build` - so it must not be able to mint
   # a PyPI credential: it has no `id-token: write`, and the only thing it hands
   # onwards is the built distribution.
   build:
+    needs: precheck
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -43,18 +71,22 @@ jobs:
     env:
       TAG: ${{ inputs.tag }}
     steps:
-      # The tagged commit, never main, which has usually moved past the bump. A
-      # tag that does not exist fails here, in seconds, before anything is built.
+      # `refs/tags/` rather than the bare tag: actions/checkout resolves an
+      # unqualified ref as a branch first, so a branch sharing the tag's name
+      # would build the branch while the publish un-drafts the tag's release.
+      # Both carry the same `[project].version`, so the assert below cannot see it.
       - name: Checkout the release commit
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag }}
+          ref: refs/tags/${{ inputs.tag }}
           persist-credentials: false
 
       # The tag is what a person typed; the version is what would be uploaded.
       # A mismatch means the tag does not point where whoever dispatched this
       # believes it does, and PyPI would happily accept the wrong version.
       - name: Assert the tag matches the version it points at
+        env:
+          PYTHONPATH: ${{ github.workspace }}/.github/scripts
         run: |
           set -euo pipefail
           version="$(python3 -m prepare_release read-version \
@@ -84,9 +116,16 @@ jobs:
         with:
           node-version-file: lightly_studio_view/.nvmrc
 
+      # `--locked` rather than the Makefile's `install-optional-deps`, which is
+      # a plain `uv sync`: that re-resolves and rewrites uv.lock when it is
+      # stale against the tagged pyproject.toml, and `make build` then runs
+      # export-schema and export-version under the resulting environment - so a
+      # stale lock would change the schema and generated client inside the
+      # published wheel with no signal. Locally re-resolving is what you want,
+      # which is why the target itself is left alone.
       - name: Install Dependencies
         working-directory: lightly_studio
-        run: make install-optional-deps
+        run: uv sync --locked --all-groups --all-extras
 
       # `make build` builds the frontend, copies it in, and runs `uv build`. In
       # a uv workspace the lock is at the root but the distributions still land
@@ -95,19 +134,19 @@ jobs:
         working-directory: lightly_studio
         run: make build
 
-      # Short retention: PyPI is where these live permanently, and a re-run
-      # rebuilds them from the tag anyway.
+      # Long enough to outlast the pypi environment's approval gate, which can
+      # sit for days: an artifact that expired while a reviewer was away would
+      # fail the release after the approval had already been spent.
       - name: Upload the Distributions
         uses: actions/upload-artifact@v7
         with:
           name: dist
           path: lightly_studio/dist
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   # The only job that can publish. It runs no code from the release commit: it
-  # downloads the distributions, signs them, uploads them, and un-drafts the
-  # GitHub release.
+  # downloads the distributions, uploads them, and un-drafts the GitHub release.
   publish:
     needs: build
     runs-on: ubuntu-latest
@@ -122,63 +161,27 @@ jobs:
       id-token: write
     env:
       TAG: ${{ inputs.tag }}
-      PUBLISH_URL: >-
-        ${{ inputs.target == 'pypi' && 'https://upload.pypi.org/legacy/'
-        || 'https://test.pypi.org/legacy/' }}
-      CHECK_URL: >-
-        ${{ inputs.target == 'pypi' && 'https://pypi.org/simple/'
-        || 'https://test.pypi.org/simple/' }}
     steps:
-      # Before the upload, and skipped for a rehearsal, which never touches the
-      # release. This is also what makes a re-run safe: a run that published the
-      # distributions but failed to un-draft leaves a draft, so a re-run passes
-      # here, skips the upload on --check-url, and finishes; once the release is
-      # live, a re-run stops here instead of appending "Released by" twice.
-      - name: Require a draft release
-        if: inputs.target == 'pypi'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          if [ "$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq .isDraft)" != "true" ]; then
-            echo "::error::${TAG} is not a draft release."
-            exit 1
-          fi
-
       - name: Download the Distributions
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
 
-      - name: Set Up Uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          version: "0.12.6"
-
-      # `uv publish` uploads PEP 740 attestations but does not create them, so
-      # without this step there is no provenance at all. Signing has to happen
-      # here rather than in the build job: the index checks the signing
-      # certificate against the trusted publisher, so the identity has to be
-      # this job's. Pinned to an exact version, since it runs in the job that
-      # holds the token.
-      - name: Sign the Distributions
-        run: uvx pypi-attestations@0.0.30 sign dist/*.whl dist/*.tar.gz
-
-      # `always` rather than the default `automatic`: a misconfigured publisher
-      # should fail loudly here instead of quietly falling back to looking for a
-      # token that does not exist. --check-url lets a re-run skip files already
-      # uploaded, which is what makes the job idempotent. The distributions are
-      # listed explicitly so the default `dist/*` glob does not hand uv the
-      # .publish.attestation files as if they were distributions.
+      # The PyPA action rather than `uv publish`, which uploads PEP 740
+      # attestations but does not create them - this action mints the
+      # trusted-publishing token and signs the distributions with the same
+      # identity the index checks the certificate against. It is given no
+      # password, so a misconfigured publisher fails here rather than quietly
+      # looking for a token that does not exist. `skip-existing` lets a run that
+      # uploaded but failed to un-draft be re-dispatched.
       - name: Publish to the Index
-        run: |
-          uv publish \
-            --trusted-publishing always \
-            --publish-url "${PUBLISH_URL}" \
-            --check-url "${CHECK_URL}" \
-            dist/*.whl dist/*.tar.gz
+        uses: pypa/gh-action-pypi-publish@v1.14.2
+        with:
+          repository-url: >-
+            ${{ inputs.target == 'pypi' && 'https://upload.pypi.org/legacy/'
+            || 'https://test.pypi.org/legacy/' }}
+          skip-existing: true
 
       # Only for a real release: a TestPyPI rehearsal must not mark a GitHub
       # release live.
@@ -187,7 +190,8 @@ jobs:
       # workflow-created release always reads as github-actions[bot]. This
       # workflow is dispatch-triggered, so the actor is the person who decided
       # to release; the notes name them instead. Appending it here rather than
-      # when drafting keeps it out of a draft nobody published.
+      # when drafting keeps it out of a draft nobody published, and the
+      # `precheck` guard keeps a re-dispatch from appending it twice.
       - name: Publish the draft release
         if: inputs.target == 'pypi'
         env:

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -15,12 +15,10 @@ on:
         options: [pypi, testpypi]
         default: pypi
 
-# Nothing at workflow level: each job below asks for exactly what it needs.
 permissions: {}
 
-# A second dispatch for the same tag while the first waits for its environment
-# approval would try to publish it twice. Queued rather than cancelled, because
-# cancelling a run mid-upload is worse than making it wait.
+# Queued rather than cancelled: cancelling a run mid-upload is worse than
+# making a second dispatch for the same tag wait.
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag }}
   cancel-in-progress: false
@@ -30,21 +28,18 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
-  # Ahead of the build rather than beside the upload: the publish job sits
-  # behind an approval gate, so a tag that was never drafted or is already
-  # released should be rejected before it costs half an hour of build and a
-  # reviewer's approval. Its own job because GitHub shows draft releases only to
-  # identities with push access, so this needs `contents: write` and the build
-  # job below must not have it. Nothing here runs repository code - no checkout.
+  # Its own job ahead of the build, so a tag that was never drafted or is
+  # already released costs neither the build nor a reviewer's approval. It
+  # cannot live in `build`: GitHub shows draft releases only to identities with
+  # push access. No checkout, so it runs no repository code.
   precheck:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write
     steps:
-      # Skipped for a rehearsal, which never touches the release. This is also
-      # what keeps a re-dispatch from appending "Released by" twice: once the
-      # release is live, the next dispatch stops here.
+      # Also the idempotency guard: once the release is live, the next dispatch
+      # stops here instead of appending "Released by" twice.
       - name: Require a draft release
         if: inputs.target == 'pypi'
         env:
@@ -58,10 +53,8 @@ jobs:
             exit 1
           fi
 
-  # Split from the publish deliberately. This job runs the tagged commit's own
-  # code - `uv sync`, `npm ci`, `npm run build` - so it must not be able to mint
-  # a PyPI credential: it has no `id-token: write`, and the only thing it hands
-  # onwards is the built distribution.
+  # Runs the tagged commit's own code, so it must not be able to mint a PyPI
+  # credential: no `id-token: write`, and all it hands onwards is the artifact.
   build:
     needs: precheck
     runs-on: ubuntu-latest
@@ -71,19 +64,15 @@ jobs:
     env:
       TAG: ${{ inputs.tag }}
     steps:
-      # `refs/tags/` rather than the bare tag: actions/checkout resolves an
-      # unqualified ref as a branch first, so a branch sharing the tag's name
-      # would build the branch while the publish un-drafts the tag's release.
-      # Both carry the same `[project].version`, so the assert below cannot see it.
+      # `refs/tags/` because actions/checkout resolves an unqualified ref as a
+      # branch first, and a branch sharing the tag's name would be built in the
+      # tag's place - undetectably, since both carry the same version.
       - name: Checkout the release commit
         uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ inputs.tag }}
           persist-credentials: false
 
-      # The tag is what a person typed; the version is what would be uploaded.
-      # A mismatch means the tag does not point where whoever dispatched this
-      # believes it does, and PyPI would happily accept the wrong version.
       - name: Assert the tag matches the version it points at
         env:
           PYTHONPATH: ${{ github.workspace }}/.github/scripts
@@ -101,42 +90,33 @@ jobs:
         with:
           python-version: "3.12"
 
-      # No enable-cache, unlike the test workflows. A cache written by another
-      # workflow is an input to the artifact that gets published, so this job
-      # builds from the lockfile alone.
+      # No enable-cache, unlike the test workflows: a cache written by another
+      # workflow would be an input to what gets published.
       - name: Set Up Uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
 
-      # The wheel bundles the built frontend, so the build needs Node. Taken
-      # from .nvmrc, the same version the Makefile's nvm path picks locally.
+      # The wheel bundles the built frontend, so the build needs Node.
       - name: Set Up Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: lightly_studio_view/.nvmrc
 
-      # `--locked` rather than the Makefile's `install-optional-deps`, which is
-      # a plain `uv sync`: that re-resolves and rewrites uv.lock when it is
-      # stale against the tagged pyproject.toml, and `make build` then runs
-      # export-schema and export-version under the resulting environment - so a
-      # stale lock would change the schema and generated client inside the
-      # published wheel with no signal. Locally re-resolving is what you want,
-      # which is why the target itself is left alone.
+      # `--locked` rather than the Makefile's plain `uv sync`, which re-resolves
+      # a lock that is stale against the tagged pyproject.toml. `make build`
+      # then runs export-schema under that environment, so a stale lock would
+      # change the schema inside the published wheel with no signal.
       - name: Install Dependencies
         working-directory: lightly_studio
         run: uv sync --locked --all-groups --all-extras
 
-      # `make build` builds the frontend, copies it in, and runs `uv build`. In
-      # a uv workspace the lock is at the root but the distributions still land
-      # in lightly_studio/dist.
       - name: Build the Distributions
         working-directory: lightly_studio
         run: make build
 
-      # Long enough to outlast the pypi environment's approval gate, which can
-      # sit for days: an artifact that expired while a reviewer was away would
-      # fail the release after the approval had already been spent.
+      # A week, to outlast the pypi environment's approval gate: an artifact
+      # expiring mid-approval would fail the release after it was granted.
       - name: Upload the Distributions
         uses: actions/upload-artifact@v7
         with:
@@ -145,16 +125,13 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  # The only job that can publish. It runs no code from the release commit: it
-  # downloads the distributions, uploads them, and un-drafts the GitHub release.
   publish:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # The environment is what PyPI's trusted publisher checks the OIDC claim
-    # against, so only this job of this file can publish. `pypi` carries the
-    # approval gate and is restricted to main; `testpypi` has neither, so a
-    # rehearsal runs unattended.
+    # What PyPI's trusted publisher checks the OIDC claim against, so only this
+    # job of this file can publish. `pypi` carries the approval gate and is
+    # restricted to main; `testpypi` has neither, so a rehearsal is unattended.
     environment: ${{ inputs.target }}
     permissions:
       contents: write
@@ -168,13 +145,10 @@ jobs:
           name: dist
           path: dist
 
-      # The PyPA action rather than `uv publish`, which uploads PEP 740
-      # attestations but does not create them - this action mints the
-      # trusted-publishing token and signs the distributions with the same
-      # identity the index checks the certificate against. It is given no
-      # password, so a misconfigured publisher fails here rather than quietly
-      # looking for a token that does not exist. `skip-existing` lets a run that
-      # uploaded but failed to un-draft be re-dispatched.
+      # Not `uv publish`, which uploads PEP 740 attestations but does not create
+      # them. Given no password, so a misconfigured publisher fails here rather
+      # than falling back to looking for a token. `skip-existing` lets a run
+      # that uploaded but failed to un-draft be re-dispatched.
       - name: Publish to the Index
         uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
@@ -183,15 +157,10 @@ jobs:
             || 'https://test.pypi.org/legacy/' }}
           skip-existing: true
 
-      # Only for a real release: a TestPyPI rehearsal must not mark a GitHub
-      # release live.
-      #
       # A release's author is whichever identity's token created it, so a
       # workflow-created release always reads as github-actions[bot]. This
-      # workflow is dispatch-triggered, so the actor is the person who decided
-      # to release; the notes name them instead. Appending it here rather than
-      # when drafting keeps it out of a draft nobody published, and the
-      # `precheck` guard keeps a re-dispatch from appending it twice.
+      # workflow is dispatch-triggered, so the notes name the person who decided
+      # to release instead.
       - name: Publish the draft release
         if: inputs.target == 'pypi'
         env:


### PR DESCRIPTION
## What has changed and why?

`Finish Release` only un-drafts a GitHub release today, and refuses to until it finds the wheel already on PyPI — because the upload happens in the private repo, from a long-lived `PYPI_PUBLISH_TOKEN`. This moves the build and upload here and authenticates with Trusted Publishing (OIDC), so no stored credential is involved.

- **Publish and un-draft in one workflow**, publish first, so the ordering is structural and the `Require the version on PyPI` step is deleted rather than kept. A failed publish leaves a deletable draft; the reverse order would leave a published release advertising a version nobody can install.
- **Build and publish are separate jobs.** The build runs the tagged commit's own code — `uv sync`, `npm ci`, `npm run build` — so it holds no `id-token` and hands the distributions on as an artifact. Only the environment-protected `publish` job can mint a credential, and it runs no code from the release commit.
- **`environment: ${{ inputs.target }}`** is what carries the security: the index verifies the OIDC claim against repository + workflow filename + environment, so publish rights belong to this file under that environment rather than to the repository. `pypi` has required reviewers and is restricted to `main`; `testpypi` has neither, so a rehearsal runs unattended.
- **A `target` input** (`pypi` / `testpypi`) drives the environment and the `repository-url`, so a rehearsal runs this same file. The publisher config pins the workflow *filename*, so a second workflow would need its own publisher entry.
- **The upload is `pypa/gh-action-pypi-publish`.** It mints the trusted-publishing token and generates the PEP 740 attestations in one step — `uv publish` uploads attestations but does not create them, so provenance needs something else to produce them. It is given no password, so a misconfigured publisher fails loudly rather than falling back to looking for a token.
- **A version assert**, so a tag pointing at the wrong commit fails in the build job rather than putting the wrong version on the index.
- **A `precheck` job** requires a draft release before anything is built. It also doubles as the idempotency guard: a run that uploaded but failed to un-draft leaves a draft, so a re-dispatch passes the check, skips the upload via `skip-existing`, and finishes. Once the release is live a re-dispatch stops in `precheck` instead of appending `Released by @…` twice.
- **`refs/tags/${{ inputs.tag }}`** on the checkout. `actions/checkout` resolves an unqualified ref as a branch first, so a branch sharing a tag's name would build the branch while the publish un-drafts the tag's release — and the version assert cannot catch it, since both carry the same `[project].version`.
- **`uv sync --locked`** rather than the `install-optional-deps` target, which is a plain `uv sync`. That re-resolves and rewrites `uv.lock` when it is stale against the tagged `pyproject.toml`, and `make build` then runs `export-schema` and `export-version` under the resulting environment — so a stale lock would change the schema and the generated client inside the published wheel with no signal. The target itself is untouched, since re-resolving is what you want locally.

Other hardening, since `publish` is the only job that can publish: `permissions: {}` at workflow level with per-job grants, no `enable-cache` (a cache written by another workflow is an input to what gets published), and a `concurrency` group per tag so a second dispatch cannot publish the same tag while the first waits for approval. Artifact retention is a week rather than a day, so a build cannot expire while the `pypi` approval waits on a reviewer and fail the release after the approval was already spent.

Actions are referenced by tag, matching the rest of the repo. Pinning them by commit is the stronger choice here — `tj-actions/changed-files` had its tags repointed in March 2025 to code that dumped secrets from ~23k repositories — but this repo has no `.github/dependabot.yml` at all, so pins would never be bumped and would trade a mutable-tag risk for silently missing security patches. The hardening follow-up adds Dependabot and pins everything, and should land before the trusted publishers exist, since until then this workflow cannot publish anything anyway.

## Since the first review

Four correctness fixes and one simplification, all in `695da0aa`:

- The draft check moved out of `publish` into the new `precheck` job, ahead of the build. Beside the upload it only failed after half an hour of building *and* after a reviewer had spent an approval. It cannot live in the `build` job: GitHub shows draft releases only to identities with push access, so it needs `contents: write`, and `build` runs the tagged commit's code and must keep `contents: read`. `precheck` has no checkout, so it runs no repository code.
- `ref:` is now qualified with `refs/tags/`, closing the branch-shadows-tag hole described above.
- `uv sync --locked`, closing the stale-lock hole described above.
- `retention-days: 1` → `7`, so the artifact outlives the approval gate.
- The `pypi-attestations` signing step and `uv publish` are replaced by `pypa/gh-action-pypi-publish@v1.14.2`, which is the trade-off this description previously put to the reviewer. It removes the second `setup-uv`, the pinned signing tool resolving its own dependency tree inside the credentialed job, the `--check-url` ternary, and the explicit `dist/*.whl dist/*.tar.gz` list that kept uv from treating the attestation files as distributions — with no attestation files written into `dist`, the action's default `packages-dir` is unambiguous.

## Differences from the private `release_pypi.yml`

| | private | here |
| -- | -- | -- |
| PyPI auth | `uv publish --token ${{ secrets.PYPI_PUBLISH_TOKEN }}` | OIDC, no secret |
| Build and publish | one job | separate jobs, credential only in the second |
| Attestations | none | generated by the PyPA action under Trusted Publishing |
| Runner | `docker-cpu` (self-hosted) | `ubuntu-latest` |
| Checkout | cross-repo, `fetch-depth: 0` | same repo, shallow, `persist-credentials: false`, tag-qualified ref |
| GCP auth for `lightly-edge-sdk` | yes | dropped — not a dependency of this repo |
| PostHog | `make build PUBLIC_POSTHOG_KEY=<secret>` | plain `make build` |
| TestPyPI | a commented-out line to edit by hand | the `target` input |
| Un-draft the release | a separate workflow | the same workflow |
| Slack notification | a job here | not ported; moving to the GitHub app |
| Version assert | `grep -oP` on `pyproject.toml` | `prepare_release read-version` |

Two of those deserve a note. `PUBLIC_POSTHOG_KEY` no longer exists: #2106 hardcoded the write-only project keys in `posthog_project.py` precisely to remove "the build time variable a release could forget", and no Makefile reads it, so the private workflow has been passing a no-op. And `lightly-edge-sdk` appears nowhere in this repo's `pyproject.toml` or `uv.lock`, which is what makes the build possible without private access at all.

`NODE_OPTIONS: --max-old-space-size=4096` is carried over — the private workflow sets it, and so do both test workflows here, because the frontend build needs more heap than the default.

## How has it been tested?

A full TestPyPI rehearsal, [run 34494311237](https://github.com/lightly-ai/lightly-studio/actions/runs/34494311237), dispatched from this branch with `target: testpypi`. All three jobs green — `precheck` 3s, `build` 4m31s, `publish` 20s — and it put `lightly-studio` 1.1.0 on [TestPyPI](https://test.pypi.org/project/lightly-studio/1.1.0/) with attestations on both files.

That exercised the tag-qualified checkout resolving `refs/tags/v1.1.0`, the version assert, `uv sync --locked` against the tagged lockfile, the frontend build on `ubuntu-latest` (which had only ever run on the self-hosted `docker-cpu` runner), the artifact hand-off between the two jobs, the OIDC exchange against TestPyPI's trusted publisher, Sigstore signing with two Rekor transparency-log entries (`2784477028`, `2784477081`), and TestPyPI accepting the attestations — both files carry an `/integrity/…/provenance` URL. `precheck`'s draft guard and the un-draft step both skipped as intended for a rehearsal, leaving the GitHub release for `v1.1.0` untouched.

Everything behind the `pypi` environment is untested by construction and cannot be exercised before merge: the draft guard actually firing, the `main`-only branch policy, the `@lightly-ai/engineering` approval, and the un-draft. Merging changes nothing observable, since the workflow is dispatch-only.

- `make static-checks` and `make test` in `.github/scripts`: 55 passed, and the rendered release-PR body was checked by hand.
- `uv lock --check` is clean on this commit, so `--locked` will not fail the build for an unrelated reason.
- Checked `pypa/gh-action-pypi-publish@v1.14.2`'s own `action.yml`: `repository-url` and `skip-existing` are the current input names, and `attestations` defaults to `true` for PyPI and TestPyPI under Trusted Publishing.
- `zizmor --persona=auditor`, with a token so the impostor-commit, ref-confusion and known-vulnerable-actions audits run: no findings. That predates `695da0aa`, which changed the publish step and added a job, so it is worth re-running before merge.

Before the first real run: dispatch from `main` for `target: pypi`, since the environment is restricted to that branch and the branch is the run's ref, not the checked-out tag. And a `pypi` run pauses for an approval from `lightly-ai/engineering` before publishing — that is the gate, not a hang.

Note for a future rehearsal: 1.1.0 is now taken on TestPyPI, so re-dispatching against the same tag would be a `skip-existing` no-op. The next rehearsal needs a version that is not there yet.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Reviewer: @ikondrat, who reviewed #2174 and #2229 on these workflows. Alternative: @michal-lightly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release publishing now supports selecting PyPI or TestPyPI.
  - Builds and publishing are handled as separate steps, with signed distributions, secure authentication, and duplicate-publication checks.
  - Release tags and versions are validated before publishing; PyPI publishing also updates the GitHub release.
- **Documentation**
  - Updated release messaging clarifies that Finish Release with the PyPI target publishes the package and removes draft status, while documentation updates remain manual.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


