### PR TITLE
Implement serve() and the protocol wire models

### DIFF
--- a/lightly_studio_embed/Makefile
+++ b/lightly_studio_embed/Makefile
@@ -12,12 +12,9 @@ build: clean
 	@echo "Building a distribution package..."
 	uv build --package lightly-studio-embed --out-dir dist
 
-# Exit code 5 is "no tests collected". The package has no code to test yet, and any real
-# failure still fails the target.
-# TODO(Iunir, 09/2026): Drop the exit code 5 tolerance once the package has tests.
 .PHONY: test
 test:
 	@echo "Running tests..."
-	uv run pytest || [ $$? -eq 5 ]
+	uv run pytest
 
 include ../make/python.mk

--- a/lightly_studio_embed/README.md
+++ b/lightly_studio_embed/README.md
@@ -37,7 +37,13 @@ serve(MyEmbedder(), host="0.0.0.0", port=8080, api_key="the-key-you-paste-into-l
 `serve` mounts `GET /v1/describe`, which reports the identity, capabilities and limits of the
 server, plus one endpoint per capability the class implements — here `/v1/embed/texts` and
 `/v1/embed/images/bytes`, and nothing else. An input the model cannot decode is left out of
-`kept_indices` rather than failing the batch.
+`kept_indices` rather than failing the batch, and a method you have not finished yet raises
+`CapabilityNotImplementedError`, which answers 501.
+
+The bytes endpoints take a `multipart/form-data` body with one part per item, in the field
+`files`. Every path and that field name are constants in `lightly_studio_embed.protocol`,
+alongside the wire models, so an implementation in another language has one definition to
+follow.
 
 Nothing is published to PyPI yet. Once it is released, installing it will be:
 

--- a/lightly_studio_embed/README.md
+++ b/lightly_studio_embed/README.md
@@ -6,8 +6,40 @@ over HTTP, so that your model's weights never leave your machine.
 The package deliberately depends on nothing but an HTTP server, so that it installs next to your
 own CUDA and torch pins.
 
-There is no public API yet, and nothing is published to PyPI: this only reserves the package. Once
-it is released, installing it will be:
+## Usage
+
+Implement the capability classes your model supports, then serve it:
+
+```python
+from lightly_studio_embed import EmbeddingResult, ImageBytesEmbedder, TextEmbedder, serve
+
+
+class MyEmbedder(TextEmbedder, ImageBytesEmbedder):
+    @property
+    def space_key(self) -> str:
+        return "acme/clip@v3"
+
+    @property
+    def dimension(self) -> int:
+        return 512
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        vectors = my_model.encode_text(texts)
+        return EmbeddingResult(embeddings=vectors.tolist(), kept_indices=list(range(len(texts))))
+
+    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
+        ...
+
+
+serve(MyEmbedder(), host="0.0.0.0", port=8080, api_key="the-key-you-paste-into-lightlystudio")
+```
+
+`serve` mounts `GET /v1/describe`, which reports the identity, capabilities and limits of the
+server, plus one endpoint per capability the class implements — here `/v1/embed/texts` and
+`/v1/embed/images/bytes`, and nothing else. An input the model cannot decode is left out of
+`kept_indices` rather than failing the batch.
+
+Nothing is published to PyPI yet. Once it is released, installing it will be:
 
 ```bash
 pip install lightly-studio-embed

--- a/lightly_studio_embed/README.md
+++ b/lightly_studio_embed/README.md
@@ -34,6 +34,9 @@ class MyEmbedder(TextEmbedder, ImageBytesEmbedder):
 serve(MyEmbedder(), host="0.0.0.0", port=8080, api_key="the-key-you-paste-into-lightlystudio")
 ```
 
+The server speaks plain HTTP, so put a TLS-terminating proxy in front of any bind other than
+loopback — otherwise the bearer token travels in the clear. `serve` warns when it binds one.
+
 `serve` mounts `GET /v1/describe`, which reports the identity, capabilities and limits of the
 server, plus one endpoint per capability the class implements — here `/v1/embed/texts` and
 `/v1/embed/images/bytes`, and nothing else. An input the model cannot decode is left out of

--- a/lightly_studio_embed/README.md
+++ b/lightly_studio_embed/README.md
@@ -34,8 +34,9 @@ class MyEmbedder(TextEmbedder, ImageBytesEmbedder):
 serve(MyEmbedder(), host="0.0.0.0", port=8080, api_key="the-key-you-paste-into-lightlystudio")
 ```
 
-The server speaks plain HTTP, so put a TLS-terminating proxy in front of any bind other than
-loopback — otherwise the bearer token travels in the clear. `serve` warns when it binds one.
+Pass `ssl_certfile` and `ssl_keyfile` for any bind other than loopback, or terminate TLS in a
+proxy in front of it — the bearer token travels in the request, so plain HTTP puts it in the
+clear. `serve` warns when neither is in place.
 
 `serve` mounts `GET /v1/describe`, which reports the identity, capabilities and limits of the
 server, plus one endpoint per capability the class implements — here `/v1/embed/texts` and

--- a/lightly_studio_embed/pyproject.toml
+++ b/lightly_studio_embed/pyproject.toml
@@ -23,12 +23,16 @@ classifiers = [
 dependencies = [
     "fastapi>=0.115.5",
     "pydantic>=2.0",
+    # Starlette parses the multipart bodies of the bytes endpoints through it.
+    "python-multipart>=0.0.18",
     "uvicorn>=0.32.1",
 ]
 
 [dependency-groups]
 # The same floors as the repository's other Python packages, so the tooling behaves alike.
 dev = [
+    # The FastAPI test client is an httpx transport.
+    "httpx>=0.27.2",
     "mypy>=1.19.1",
     "pytest>=8.3.3",
     "ruff>=0.7.4",

--- a/lightly_studio_embed/pyproject.toml
+++ b/lightly_studio_embed/pyproject.toml
@@ -23,8 +23,14 @@ classifiers = [
 dependencies = [
     "fastapi>=0.115.5",
     "pydantic>=2.0",
-    # Starlette parses the multipart bodies of the bytes endpoints through it.
-    "python-multipart>=0.0.18",
+    # Starlette parses the multipart bodies of the bytes endpoints through it. The floor is
+    # the first release fixing CVE-2026-53540, after a run of parser DoS advisories
+    # (CVE-2026-40347, CVE-2026-42561, CVE-2026-53537..53539). Python 3.9 is stuck on
+    # 0.0.20, the last release that supports it, so a 3.9 host keeps those weaknesses in its
+    # multipart parser.
+    # TODO(Iunir, 09/2026): Drop the 3.9 pin once `lightly-studio` drops Python 3.9.
+    "python-multipart>=0.0.31; python_version >= '3.10'",
+    "python-multipart>=0.0.20; python_version < '3.10'",
     "uvicorn>=0.32.1",
 ]
 

--- a/lightly_studio_embed/src/lightly_studio_embed/__init__.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/__init__.py
@@ -1,1 +1,36 @@
 """Serve your own embedding model to LightlyStudio over HTTP."""
+
+from lightly_studio_embed.embedder import (
+    BaseEmbedder,
+    EmbeddingResult,
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
+from lightly_studio_embed.protocol import (
+    PROTOCOL_VERSION,
+    DescribeResponse,
+    EmbeddingsResponse,
+    EmbedTextsRequest,
+    ServerLimits,
+    WireCapability,
+)
+from lightly_studio_embed.server import create_app, serve
+from lightly_studio_embed.validation import EmbedderContractError
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "BaseEmbedder",
+    "DescribeResponse",
+    "EmbedTextsRequest",
+    "EmbedderContractError",
+    "EmbeddingResult",
+    "EmbeddingsResponse",
+    "ImageBytesEmbedder",
+    "ServerLimits",
+    "TextEmbedder",
+    "VideoBytesEmbedder",
+    "WireCapability",
+    "create_app",
+    "serve",
+]

--- a/lightly_studio_embed/src/lightly_studio_embed/__init__.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/__init__.py
@@ -7,22 +7,25 @@ from lightly_studio_embed.embedder import (
     TextEmbedder,
     VideoBytesEmbedder,
 )
+from lightly_studio_embed.errors import CapabilityNotImplementedError, EmbedderContractError
 from lightly_studio_embed.protocol import (
     PROTOCOL_VERSION,
     DescribeResponse,
     EmbeddingsResponse,
     EmbedTextsRequest,
+    EmbedUrlsRequest,
     ServerLimits,
     WireCapability,
 )
 from lightly_studio_embed.server import create_app, serve
-from lightly_studio_embed.validation import EmbedderContractError
 
 __all__ = [
     "PROTOCOL_VERSION",
     "BaseEmbedder",
+    "CapabilityNotImplementedError",
     "DescribeResponse",
     "EmbedTextsRequest",
+    "EmbedUrlsRequest",
     "EmbedderContractError",
     "EmbeddingResult",
     "EmbeddingsResponse",

--- a/lightly_studio_embed/src/lightly_studio_embed/embedder.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/embedder.py
@@ -1,0 +1,128 @@
+"""Base classes a model is wrapped in to be served.
+
+``BaseEmbedder`` carries the identity of the embedding space. One subclass per
+input kind adds the method that embeds it, so a model implements only what it
+supports and ``serve`` mounts exactly the matching endpoints.
+
+The signatures mirror ``lightly_studio.embed.embedder``. The duplication is
+deliberate: this package installs next to a customer's own torch pins, so it
+cannot depend on ``lightly-studio``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EmbeddingResult:
+    """Embeddings for the inputs that could be read, plus which inputs they cover.
+
+    An embedder skips an input it cannot decode instead of failing the batch, so
+    ``embeddings`` can have fewer rows than the input list.
+    """
+
+    embeddings: Sequence[Sequence[float]]
+    """One row per entry of ``kept_indices``, each ``BaseEmbedder.dimension`` long.
+
+    Pass a numpy array as ``array.tolist()``; the package stays free of numpy.
+    """
+
+    kept_indices: Sequence[int]
+    """Indices into the input list of the inputs that were embedded, ascending."""
+
+
+class BaseEmbedder(ABC):
+    """Identity of the embedding space a model produces.
+
+    Subclass one or more of the capability classes below rather than this class
+    directly: an embedder with no capability serves no embeddings.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def space_key(self) -> str:
+        """Stable identifier of the embedding space.
+
+        Two embedders sharing a ``space_key`` are treated as producing comparable
+        vectors. Change it whenever they stop being comparable, e.g. for a model
+        version change. Can be any string, e.g. ``your-company/model@v3``.
+        """
+
+    @property
+    @abstractmethod
+    def dimension(self) -> int:
+        """Length of every embedding vector this embedder returns."""
+
+    @property
+    def ready(self) -> bool:
+        """Whether the model is loaded and can answer requests.
+
+        The default suits a model loaded by the time the object exists. Override it
+        when the model loads in the background: while it is ``False``,
+        ``/v1/describe`` reports ``ready: false`` and the embed endpoints answer 503
+        instead of running a half-loaded model.
+        """
+        return True
+
+
+class TextEmbedder(BaseEmbedder):
+    """Embeds text queries."""
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        """Embed a batch of text strings.
+
+        Args:
+            texts: The strings to embed.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+
+
+class ImageBytesEmbedder(BaseEmbedder):
+    """Embeds images passed as raw bytes.
+
+    Annotation crops arrive here too: LightlyStudio crops with a margin and posts
+    the result, so an image-capable embedder supports them with no extra work.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
+        """Embed a batch of images given as encoded bytes.
+
+        Sniff the format from the header rather than trusting the caller. JPEG, PNG
+        and WebP are the formats the protocol allows.
+
+        Args:
+            images: Encoded image bytes.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+
+
+class VideoBytesEmbedder(BaseEmbedder):
+    """Embeds videos passed as raw bytes."""
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embed_video_bytes(self, videos: list[bytes]) -> EmbeddingResult:
+        """Embed a batch of videos given as encoded bytes.
+
+        Args:
+            videos: Encoded video bytes.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """

--- a/lightly_studio_embed/src/lightly_studio_embed/embedder.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/embedder.py
@@ -7,6 +7,10 @@ supports and ``serve`` mounts exactly the matching endpoints.
 The signatures mirror ``lightly_studio.embed.embedder``. The duplication is
 deliberate: this package installs next to a customer's own torch pins, so it
 cannot depend on ``lightly-studio``.
+
+A method that is mounted but unfinished raises
+``lightly_studio_embed.CapabilityNotImplementedError``, which the server answers
+501. Every other error is a failure of the model and answers 500.
 """
 
 from __future__ import annotations

--- a/lightly_studio_embed/src/lightly_studio_embed/errors.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/errors.py
@@ -1,0 +1,20 @@
+"""The errors an embedder can raise or provoke, in one place."""
+
+from __future__ import annotations
+
+
+class EmbedderContractError(RuntimeError):
+    """Raised when an embedder returns a result the protocol does not allow.
+
+    The server answers 500 and names the problem, rather than shipping the result to
+    LightlyStudio.
+    """
+
+
+class CapabilityNotImplementedError(NotImplementedError):
+    """Raise it from a capability method that is mounted but not finished yet.
+
+    The server answers 501, which tells a client to re-read ``/v1/describe`` instead
+    of retrying. Any other error is a failure of the model, not a retracted
+    capability, and answers 500.
+    """

--- a/lightly_studio_embed/src/lightly_studio_embed/middleware.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/middleware.py
@@ -1,0 +1,97 @@
+"""ASGI middleware that guards a request before FastAPI parses its body.
+
+Neither check can be a dependency: FastAPI reads and parses the whole body before
+it solves dependencies, so as dependencies both would arrive after an untrusted
+peer had already decided how much the server buffers.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from fastapi import HTTPException, status
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from lightly_studio_embed import protocol
+
+
+class BearerAuth:
+    """Rejects a request whose bearer token is missing or wrong.
+
+    The header is compared as the raw bytes the client sent. Decoding it first would
+    make a single non-ASCII byte, in the header or in the key, raise inside
+    ``secrets.compare_digest`` and answer 500 where the protocol wants 401.
+    """
+
+    def __init__(self, app: ASGIApp, *, api_key: str | None) -> None:
+        """Guard ``app``, or let every request through when ``api_key`` is ``None``."""
+        self.app = app
+        self.expected = None if api_key is None else f"Bearer {api_key}".encode()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Answer 401 for a bad token, otherwise hand the request on."""
+        if self.expected is None or scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        if not secrets.compare_digest(_authorization_header(scope=scope), self.expected):
+            await _unauthorized()(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+
+class RequestSizeLimit:
+    """Rejects a body that grows past the advertised ceiling while it arrives.
+
+    ``Content-Length`` is not enough on its own: an HTTP/1.1 client may leave it out
+    and stream the body chunked, which is the shape the ceiling most needs to bound,
+    since starlette spools every multipart part over 1 MiB to disk.
+    """
+
+    def __init__(self, app: ASGIApp, *, max_request_bytes: int) -> None:
+        """Guard ``app``, rejecting a body over ``max_request_bytes``."""
+        self.app = app
+        self.max_request_bytes = max_request_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Hand the request on with its body counted as it is read."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        await self.app(scope, self._counted(receive=receive), send)
+
+    def _counted(self, *, receive: Receive) -> Receive:
+        """Wrap ``receive`` so the body is measured as the server hands it over."""
+        received = 0
+
+        async def receive_counted() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_request_bytes:
+                    # Raised through the route into FastAPI's own handler for it.
+                    raise HTTPException(
+                        status_code=protocol.STATUS_PAYLOAD_TOO_LARGE,
+                        detail="The request body is over the advertised max_request_bytes of "
+                        f"{self.max_request_bytes}.",
+                    )
+            return message
+
+        return receive_counted
+
+
+def _authorization_header(*, scope: Scope) -> bytes:
+    """Read the raw ``Authorization`` header. ASGI lowercases the names for us."""
+    for name, value in scope["headers"]:
+        if name == b"authorization":
+            return bytes(value)
+    return b""
+
+
+def _unauthorized() -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        content={"detail": "Missing or invalid bearer token."},
+        headers={"WWW-Authenticate": "Bearer"},
+    )

--- a/lightly_studio_embed/src/lightly_studio_embed/protocol.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/protocol.py
@@ -1,10 +1,10 @@
 """Wire models of the LightlyStudio embedding protocol, version 1.
 
 Holds the request and response bodies, the capability strings that name the
-endpoints, and the paths they are mounted under. This is the shared definition of
-the contract: the server in this package answers with these models and
-``lightly-studio`` validates the same ones on the client side, so the two halves
-cannot drift apart.
+endpoints, the paths they are mounted under, and the multipart field the bytes
+endpoints read. This is the shared definition of the contract: the server in this
+package answers with these models and ``lightly-studio`` validates the same ones on
+the client side, so the two halves cannot drift apart.
 
 A capability ``{subject}_{transport}`` is served by
 ``POST /v1/embed/{subjects}/{transport}``; ``text`` carries no transport segment
@@ -20,6 +20,19 @@ from pydantic import BaseModel, Field
 PROTOCOL_VERSION = "1.0"
 
 BASE_PATH = "/v1"
+
+DESCRIBE_PATH = f"{BASE_PATH}/describe"
+
+EMBED_TEXTS_PATH = f"{BASE_PATH}/embed/texts"
+
+EMBED_IMAGES_BYTES_PATH = f"{BASE_PATH}/embed/images/bytes"
+
+EMBED_VIDEOS_BYTES_PATH = f"{BASE_PATH}/embed/videos/bytes"
+
+# Specified for a server that implements the URL transports; `serve` mounts neither.
+EMBED_IMAGES_URLS_PATH = f"{BASE_PATH}/embed/images/urls"
+
+EMBED_VIDEOS_URLS_PATH = f"{BASE_PATH}/embed/videos/urls"
 
 # Multipart form field the bytes endpoints read, one part per item in input order.
 FILES_FIELD_NAME = "files"
@@ -89,6 +102,21 @@ class EmbedTextsRequest(BaseModel):
 
     texts: list[str]
     """The strings to embed, in the order the embeddings are returned for."""
+
+
+class EmbedUrlsRequest(BaseModel):
+    """Body of the URL transports, ``POST /v1/embed/{images,videos}/urls``.
+
+    Defined so that a server implementing them has one definition to validate
+    against, even though ``serve`` mounts no URL route yet.
+    """
+
+    urls: list[str]
+    """Presigned URLs the server fetches, in the order the embeddings are returned for.
+
+    A URL the server cannot fetch is a per-item failure: it is left out of
+    ``kept_indices`` rather than failing the batch.
+    """
 
 
 class EmbeddingsResponse(BaseModel):

--- a/lightly_studio_embed/src/lightly_studio_embed/protocol.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/protocol.py
@@ -37,6 +37,10 @@ EMBED_VIDEOS_URLS_PATH = f"{BASE_PATH}/embed/videos/urls"
 # Multipart form field the bytes endpoints read, one part per item in input order.
 FILES_FIELD_NAME = "files"
 
+# Spelled out, because starlette renamed its constant for this status and the old name warns
+# on new versions while the new one is missing on the versions `requires-python` still allows.
+STATUS_PAYLOAD_TOO_LARGE = 413
+
 DEFAULT_MAX_BATCH_SIZE = 64
 
 DEFAULT_MAX_REQUEST_BYTES = 32 * 1024 * 1024

--- a/lightly_studio_embed/src/lightly_studio_embed/protocol.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/protocol.py
@@ -1,0 +1,115 @@
+"""Wire models of the LightlyStudio embedding protocol, version 1.
+
+Holds the request and response bodies, the capability strings that name the
+endpoints, and the paths they are mounted under. This is the shared definition of
+the contract: the server in this package answers with these models and
+``lightly-studio`` validates the same ones on the client side, so the two halves
+cannot drift apart.
+
+A capability ``{subject}_{transport}`` is served by
+``POST /v1/embed/{subjects}/{transport}``; ``text`` carries no transport segment
+because text is already a payload.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+PROTOCOL_VERSION = "1.0"
+
+BASE_PATH = "/v1"
+
+# Multipart form field the bytes endpoints read, one part per item in input order.
+FILES_FIELD_NAME = "files"
+
+DEFAULT_MAX_BATCH_SIZE = 64
+
+DEFAULT_MAX_REQUEST_BYTES = 32 * 1024 * 1024
+
+
+class WireCapability(str, Enum):
+    """An input kind an embedding server can accept over HTTP.
+
+    A path is deliberately absent: an fsspec path is resolved with LightlyStudio's
+    credentials, so it never crosses the wire.
+    """
+
+    TEXT = "text"
+    """Text queries, as JSON."""
+
+    IMAGE_BYTES = "image_bytes"
+    """Images as raw file bytes (JPEG, PNG or WebP), as multipart parts."""
+
+    IMAGE_URL = "image_url"
+    """Images the server fetches from presigned URLs. Not served by ``serve`` yet."""
+
+    VIDEO_BYTES = "video_bytes"
+    """Videos as raw file bytes, as multipart parts."""
+
+    VIDEO_URL = "video_url"
+    """Videos the server fetches from presigned URLs. Not served by ``serve`` yet."""
+
+
+class ServerLimits(BaseModel):
+    """Ceilings the server enforces and advertises, so a client need not guess them."""
+
+    max_batch_size: int = Field(default=DEFAULT_MAX_BATCH_SIZE, gt=0)
+    """Largest number of items one request may carry."""
+
+    max_request_bytes: int = Field(default=DEFAULT_MAX_REQUEST_BYTES, gt=0)
+    """Largest request body the server accepts, in bytes."""
+
+
+class DescribeResponse(BaseModel):
+    """Body of ``GET /v1/describe``, the only endpoint every server implements."""
+
+    protocol_version: str = PROTOCOL_VERSION
+    """Version of this contract the server speaks."""
+
+    space_key: str
+    """Identifier of the embedding space the server produces."""
+
+    dimension: int
+    """Length of every embedding vector the server returns."""
+
+    ready: bool
+    """Whether the model is loaded. ``False`` means retry shortly, not broken."""
+
+    capabilities: list[WireCapability]
+    """The input kinds this server accepts. Exactly the endpoints it mounts."""
+
+    limits: ServerLimits
+    """The ceilings a client has to batch against."""
+
+
+class EmbedTextsRequest(BaseModel):
+    """Body of ``POST /v1/embed/texts``."""
+
+    texts: list[str]
+    """The strings to embed, in the order the embeddings are returned for."""
+
+
+class EmbeddingsResponse(BaseModel):
+    """Body of every embed endpoint.
+
+    ``space_key`` and ``dimension`` are echoed on each response, because that is the
+    only thing that catches a server whose weights changed without a new
+    ``space_key``.
+    """
+
+    space_key: str
+    """Identifier of the embedding space these vectors belong to."""
+
+    dimension: int
+    """Length of every vector in ``embeddings``."""
+
+    kept_indices: list[int]
+    """Indices of the request items that were embedded, ascending.
+
+    An item the server cannot decode is skipped here instead of failing the batch.
+    """
+
+    embeddings: list[list[float]]
+    """One row per entry in ``kept_indices``, in the same order."""

--- a/lightly_studio_embed/src/lightly_studio_embed/server.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/server.py
@@ -6,15 +6,12 @@ endpoints plus ``/v1/describe``, and runs uvicorn. Version 1 serves the ``texts`
 but not mounted, because LightlyStudio does not call them yet and capabilities are
 advertised, so adding them later is purely additive.
 
-The bearer token and the request size ceiling are enforced in ASGI middleware
-rather than in dependencies, because FastAPI reads and parses the whole body before
-it solves a dependency: as dependencies, both checks would arrive after an
-untrusted peer had already decided how much the server buffers.
+The bearer token and the request size ceiling are enforced in the ASGI middleware
+of ``lightly_studio_embed.middleware``, which runs ahead of routing.
 """
 
 from __future__ import annotations
 
-import secrets
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -26,7 +23,6 @@ from fastapi import params as fastapi_params
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from lightly_studio_embed import protocol, validation
 from lightly_studio_embed.embedder import (
@@ -37,6 +33,7 @@ from lightly_studio_embed.embedder import (
     VideoBytesEmbedder,
 )
 from lightly_studio_embed.errors import CapabilityNotImplementedError, EmbedderContractError
+from lightly_studio_embed.middleware import BearerAuth, RequestSizeLimit
 from lightly_studio_embed.protocol import (
     DescribeResponse,
     EmbeddingsResponse,
@@ -47,10 +44,6 @@ from lightly_studio_embed.protocol import (
 
 # How long a client should wait before retrying a model that is still loading.
 _RETRY_AFTER_SECONDS = "5"
-
-# Spelled out, because starlette renamed its constant for this status and the old name warns
-# on new versions while the new one is missing on the versions `requires-python` still allows.
-_STATUS_PAYLOAD_TOO_LARGE = 413
 
 # Binding to one of these keeps the port unreachable from other hosts.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
@@ -82,7 +75,9 @@ def serve(
         embedder: The model to serve. Its capability classes decide which endpoints
             exist: a text-only embedder exposes no image or video routes.
         host: Interface to bind. The default is loopback only; pass ``"0.0.0.0"`` to
-            accept requests from other hosts.
+            accept requests from other hosts. Terminate TLS in front of a bind like
+            that: the server speaks plain HTTP, so the bearer token would otherwise
+            travel in the clear.
         port: TCP port to bind.
         api_key: Token a client must send as ``Authorization: Bearer <api_key>``.
             ``None`` leaves the server unauthenticated, which is only safe behind a
@@ -93,14 +88,23 @@ def serve(
     Raises:
         ValueError: If ``api_key`` is given but blank.
     """
-    if api_key is None and host not in _LOOPBACK_HOSTS:
-        warnings.warn(
-            f"Serving on {host} without an api_key: everyone who can reach the port can use "
-            "the model. Pass api_key, or bind a loopback address.",
-            stacklevel=2,
-        )
+    if host not in _LOOPBACK_HOSTS:
+        warnings.warn(_public_bind_warning(host=host, api_key=api_key), stacklevel=2)
     app = create_app(embedder=embedder, api_key=api_key, limits=limits)
     uvicorn.run(app, host=host, port=port)
+
+
+def _public_bind_warning(*, host: str, api_key: str | None) -> str:
+    """Name what a bind reachable from other hosts exposes, so it is not a surprise."""
+    if api_key is None:
+        return (
+            f"Serving on {host} without an api_key: everyone who can reach the port can use "
+            "the model. Pass api_key, or bind a loopback address."
+        )
+    return (
+        f"Serving on {host} over plain HTTP: the bearer token travels in the clear. Put a "
+        "TLS-terminating proxy in front, or bind a loopback address."
+    )
 
 
 def create_app(
@@ -133,74 +137,13 @@ def create_app(
     app.add_exception_handler(EmbedderContractError, _handle_contract_error)
     app.add_exception_handler(RequestValidationError, _handle_invalid_request)
     # Added innermost first, so the token is checked before a body is even counted.
-    app.add_middleware(_RequestSizeLimit, max_request_bytes=resolved_limits.max_request_bytes)
-    app.add_middleware(_BearerAuth, api_key=api_key)
+    app.add_middleware(RequestSizeLimit, max_request_bytes=resolved_limits.max_request_bytes)
+    app.add_middleware(BearerAuth, api_key=api_key)
     router = APIRouter()
     _mount_describe(router=router, embedder=embedder, limits=resolved_limits)
     _mount_embed_routes(router=router, embedder=embedder, limits=resolved_limits)
     app.include_router(router)
     return app
-
-
-class _BearerAuth:
-    """Rejects a request whose bearer token is missing or wrong.
-
-    The header is compared as the raw bytes the client sent. Decoding it first would
-    make a single non-ASCII byte, in the header or in ``api_key``, raise inside
-    ``secrets.compare_digest`` and answer 500 where the protocol wants 401.
-    """
-
-    def __init__(self, app: ASGIApp, *, api_key: str | None) -> None:
-        self.app = app
-        self.expected = None if api_key is None else f"Bearer {api_key}".encode()
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if self.expected is None or scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-        if not secrets.compare_digest(_authorization_header(scope=scope), self.expected):
-            await _unauthorized()(scope, receive, send)
-            return
-        await self.app(scope, receive, send)
-
-
-class _RequestSizeLimit:
-    """Rejects a body that grows past the advertised ceiling while it arrives.
-
-    ``Content-Length`` is not enough on its own: an HTTP/1.1 client may leave it out
-    and stream the body chunked, which is the shape the ceiling most needs to bound,
-    since starlette spools every multipart part over 1 MiB to disk.
-    """
-
-    def __init__(self, app: ASGIApp, *, max_request_bytes: int) -> None:
-        self.app = app
-        self.max_request_bytes = max_request_bytes
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-        await self.app(scope, self._counted(receive=receive), send)
-
-    def _counted(self, *, receive: Receive) -> Receive:
-        """Wrap ``receive`` so the body is measured as the server hands it over."""
-        received = 0
-
-        async def receive_counted() -> Message:
-            nonlocal received
-            message = await receive()
-            if message["type"] == "http.request":
-                received += len(message.get("body", b""))
-                if received > self.max_request_bytes:
-                    # Raised through the route into FastAPI's own handler for it.
-                    raise HTTPException(
-                        status_code=_STATUS_PAYLOAD_TOO_LARGE,
-                        detail="The request body is over the advertised max_request_bytes of "
-                        f"{self.max_request_bytes}.",
-                    )
-            return message
-
-        return receive_counted
 
 
 def _mount_describe(*, router: APIRouter, embedder: BaseEmbedder, limits: ServerLimits) -> None:
@@ -301,18 +244,10 @@ def _respond(*, result: EmbeddingResult, mount: _Mount, item_count: int) -> Embe
 def _check_batch_size(*, item_count: int, limits: ServerLimits) -> None:
     if item_count > limits.max_batch_size:
         raise HTTPException(
-            status_code=_STATUS_PAYLOAD_TOO_LARGE,
+            status_code=protocol.STATUS_PAYLOAD_TOO_LARGE,
             detail=f"The request carries {item_count} items, over the advertised "
             f"max_batch_size of {limits.max_batch_size}.",
         )
-
-
-def _authorization_header(*, scope: Scope) -> bytes:
-    """Read the raw ``Authorization`` header. ASGI lowercases the names for us."""
-    for name, value in scope["headers"]:
-        if name == b"authorization":
-            return bytes(value)
-    return b""
 
 
 def _readiness(*, embedder: BaseEmbedder) -> Callable[[], None]:
@@ -325,14 +260,6 @@ def _readiness(*, embedder: BaseEmbedder) -> Callable[[], None]:
             )
 
     return verify
-
-
-def _unauthorized() -> JSONResponse:
-    return JSONResponse(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        content={"detail": "Missing or invalid bearer token."},
-        headers={"WWW-Authenticate": "Bearer"},
-    )
 
 
 def _handle_contract_error(_request: Request, exc: Exception) -> Response:

--- a/lightly_studio_embed/src/lightly_studio_embed/server.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Annotated, Callable
 
 import uvicorn
@@ -61,13 +62,17 @@ class _Mount:
     guards: Sequence[fastapi_params.Depends]
 
 
-def serve(
+# PLR0913: `serve` is the one function a customer calls, and every argument is a knob they set
+# on their own. Folding them into a config object would only move the list somewhere else.
+def serve(  # noqa: PLR0913
     embedder: BaseEmbedder,
     *,
     host: str = "127.0.0.1",
     port: int = 8080,
     api_key: str | None = None,
     limits: ServerLimits | None = None,
+    ssl_certfile: str | Path | None = None,
+    ssl_keyfile: str | Path | None = None,
 ) -> None:
     """Serve an embedder over HTTP until the process is stopped.
 
@@ -75,36 +80,49 @@ def serve(
         embedder: The model to serve. Its capability classes decide which endpoints
             exist: a text-only embedder exposes no image or video routes.
         host: Interface to bind. The default is loopback only; pass ``"0.0.0.0"`` to
-            accept requests from other hosts. Terminate TLS in front of a bind like
-            that: the server speaks plain HTTP, so the bearer token would otherwise
-            travel in the clear.
+            accept requests from other hosts.
         port: TCP port to bind.
         api_key: Token a client must send as ``Authorization: Bearer <api_key>``.
             ``None`` leaves the server unauthenticated, which is only safe behind a
             loopback bind or a trusted network boundary.
         limits: Ceilings to advertise and enforce. Defaults to 64 items and 32 MiB
             per request.
+        ssl_certfile: PEM certificate chain to serve HTTPS with. Give it, or
+            terminate TLS in a proxy in front, for any bind other than loopback: the
+            bearer token travels in the request otherwise, in the clear. ``serve``
+            warns when neither is in place.
+        ssl_keyfile: Private key for ``ssl_certfile``, unless the certificate file
+            already carries it.
 
     Raises:
-        ValueError: If ``api_key`` is given but blank.
+        ValueError: If ``api_key`` is given but blank, or if ``ssl_keyfile`` is given
+            without ``ssl_certfile``.
     """
+    if ssl_keyfile is not None and ssl_certfile is None:
+        raise ValueError("ssl_keyfile was given without ssl_certfile, so TLS cannot start.")
     if host not in _LOOPBACK_HOSTS:
-        warnings.warn(_public_bind_warning(host=host, api_key=api_key), stacklevel=2)
+        exposure = _public_bind_warning(
+            host=host, api_key=api_key, has_tls=ssl_certfile is not None
+        )
+        if exposure is not None:
+            warnings.warn(exposure, stacklevel=2)
     app = create_app(embedder=embedder, api_key=api_key, limits=limits)
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=host, port=port, ssl_certfile=ssl_certfile, ssl_keyfile=ssl_keyfile)
 
 
-def _public_bind_warning(*, host: str, api_key: str | None) -> str:
-    """Name what a bind reachable from other hosts exposes, so it is not a surprise."""
+def _public_bind_warning(*, host: str, api_key: str | None, has_tls: bool) -> str | None:
+    """Name what a bind reachable from other hosts exposes, or ``None`` if it is covered."""
     if api_key is None:
         return (
             f"Serving on {host} without an api_key: everyone who can reach the port can use "
             "the model. Pass api_key, or bind a loopback address."
         )
-    return (
-        f"Serving on {host} over plain HTTP: the bearer token travels in the clear. Put a "
-        "TLS-terminating proxy in front, or bind a loopback address."
-    )
+    if not has_tls:
+        return (
+            f"Serving on {host} over plain HTTP: the bearer token travels in the clear. Pass "
+            "ssl_certfile, terminate TLS in a proxy in front, or bind a loopback address."
+        )
+    return None
 
 
 def create_app(

--- a/lightly_studio_embed/src/lightly_studio_embed/server.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/server.py
@@ -5,29 +5,28 @@ endpoints plus ``/v1/describe``, and runs uvicorn. Version 1 serves the ``texts`
 ``images/bytes`` and ``videos/bytes`` transports; the URL transports are specified
 but not mounted, because LightlyStudio does not call them yet and capabilities are
 advertised, so adding them later is purely additive.
+
+The bearer token and the request size ceiling are enforced in ASGI middleware
+rather than in dependencies, because FastAPI reads and parses the whole body before
+it solves a dependency: as dependencies, both checks would arrive after an
+untrusted peer had already decided how much the server buffers.
 """
 
 from __future__ import annotations
 
 import secrets
+import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Annotated, Callable
 
 import uvicorn
-from fastapi import (
-    APIRouter,
-    Depends,
-    FastAPI,
-    File,
-    HTTPException,
-    Request,
-    Response,
-    UploadFile,
-    status,
-)
+from fastapi import APIRouter, Depends, FastAPI, File, HTTPException, Request, UploadFile, status
 from fastapi import params as fastapi_params
-from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from lightly_studio_embed import protocol, validation
 from lightly_studio_embed.embedder import (
@@ -37,6 +36,7 @@ from lightly_studio_embed.embedder import (
     TextEmbedder,
     VideoBytesEmbedder,
 )
+from lightly_studio_embed.errors import CapabilityNotImplementedError, EmbedderContractError
 from lightly_studio_embed.protocol import (
     DescribeResponse,
     EmbeddingsResponse,
@@ -44,7 +44,6 @@ from lightly_studio_embed.protocol import (
     ServerLimits,
     WireCapability,
 )
-from lightly_studio_embed.validation import EmbedderContractError
 
 # How long a client should wait before retrying a model that is still loading.
 _RETRY_AFTER_SECONDS = "5"
@@ -52,6 +51,9 @@ _RETRY_AFTER_SECONDS = "5"
 # Spelled out, because starlette renamed its constant for this status and the old name warns
 # on new versions while the new one is missing on the versions `requires-python` still allows.
 _STATUS_PAYLOAD_TOO_LARGE = 413
+
+# Binding to one of these keeps the port unreachable from other hosts.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 _MultipartFiles = Annotated[list[UploadFile], File(alias=protocol.FILES_FIELD_NAME)]
 
@@ -87,7 +89,16 @@ def serve(
             loopback bind or a trusted network boundary.
         limits: Ceilings to advertise and enforce. Defaults to 64 items and 32 MiB
             per request.
+
+    Raises:
+        ValueError: If ``api_key`` is given but blank.
     """
+    if api_key is None and host not in _LOOPBACK_HOSTS:
+        warnings.warn(
+            f"Serving on {host} without an api_key: everyone who can reach the port can use "
+            "the model. Pass api_key, or bind a loopback address.",
+            stacklevel=2,
+        )
     app = create_app(embedder=embedder, api_key=api_key, limits=limits)
     uvicorn.run(app, host=host, port=port)
 
@@ -110,21 +121,90 @@ def create_app(
 
     Returns:
         An application serving ``/v1/describe`` and the embedder's capabilities.
+
+    Raises:
+        ValueError: If ``api_key`` is given but blank, which would otherwise leave a
+            server that looks authenticated while accepting an empty token.
     """
+    if api_key is not None and not api_key.strip():
+        raise ValueError("api_key is blank. Pass a token, or None to serve unauthenticated.")
+    resolved_limits = limits if limits is not None else ServerLimits()
     app = FastAPI(title="LightlyStudio embedding server")
     app.add_exception_handler(EmbedderContractError, _handle_contract_error)
-    resolved_limits = limits if limits is not None else ServerLimits()
-    router = APIRouter(
-        prefix=protocol.BASE_PATH, dependencies=[Depends(_authorization(api_key=api_key))]
-    )
+    app.add_exception_handler(RequestValidationError, _handle_invalid_request)
+    # Added innermost first, so the token is checked before a body is even counted.
+    app.add_middleware(_RequestSizeLimit, max_request_bytes=resolved_limits.max_request_bytes)
+    app.add_middleware(_BearerAuth, api_key=api_key)
+    router = APIRouter()
     _mount_describe(router=router, embedder=embedder, limits=resolved_limits)
     _mount_embed_routes(router=router, embedder=embedder, limits=resolved_limits)
     app.include_router(router)
     return app
 
 
+class _BearerAuth:
+    """Rejects a request whose bearer token is missing or wrong.
+
+    The header is compared as the raw bytes the client sent. Decoding it first would
+    make a single non-ASCII byte, in the header or in ``api_key``, raise inside
+    ``secrets.compare_digest`` and answer 500 where the protocol wants 401.
+    """
+
+    def __init__(self, app: ASGIApp, *, api_key: str | None) -> None:
+        self.app = app
+        self.expected = None if api_key is None else f"Bearer {api_key}".encode()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.expected is None or scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        if not secrets.compare_digest(_authorization_header(scope=scope), self.expected):
+            await _unauthorized()(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+
+class _RequestSizeLimit:
+    """Rejects a body that grows past the advertised ceiling while it arrives.
+
+    ``Content-Length`` is not enough on its own: an HTTP/1.1 client may leave it out
+    and stream the body chunked, which is the shape the ceiling most needs to bound,
+    since starlette spools every multipart part over 1 MiB to disk.
+    """
+
+    def __init__(self, app: ASGIApp, *, max_request_bytes: int) -> None:
+        self.app = app
+        self.max_request_bytes = max_request_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        await self.app(scope, self._counted(receive=receive), send)
+
+    def _counted(self, *, receive: Receive) -> Receive:
+        """Wrap ``receive`` so the body is measured as the server hands it over."""
+        received = 0
+
+        async def receive_counted() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_request_bytes:
+                    # Raised through the route into FastAPI's own handler for it.
+                    raise HTTPException(
+                        status_code=_STATUS_PAYLOAD_TOO_LARGE,
+                        detail="The request body is over the advertised max_request_bytes of "
+                        f"{self.max_request_bytes}.",
+                    )
+            return message
+
+        return receive_counted
+
+
 def _mount_describe(*, router: APIRouter, embedder: BaseEmbedder, limits: ServerLimits) -> None:
-    @router.get("/describe")
+    @router.get(protocol.DESCRIBE_PATH)
     def describe() -> DescribeResponse:
         return DescribeResponse(
             protocol_version=protocol.PROTOCOL_VERSION,
@@ -141,18 +221,26 @@ def _mount_embed_routes(*, router: APIRouter, embedder: BaseEmbedder, limits: Se
         router=router,
         embedder=embedder,
         limits=limits,
-        guards=[Depends(_readiness(embedder=embedder)), Depends(_request_size(limits=limits))],
+        guards=[Depends(_readiness(embedder=embedder))],
     )
     if isinstance(embedder, TextEmbedder):
         _mount_texts(mount=mount, embed=embedder.embed_text)
     if isinstance(embedder, ImageBytesEmbedder):
-        _mount_bytes(mount=mount, path="/embed/images/bytes", embed=embedder.embed_image_bytes)
+        _mount_bytes(
+            mount=mount,
+            path=protocol.EMBED_IMAGES_BYTES_PATH,
+            embed=embedder.embed_image_bytes,
+        )
     if isinstance(embedder, VideoBytesEmbedder):
-        _mount_bytes(mount=mount, path="/embed/videos/bytes", embed=embedder.embed_video_bytes)
+        _mount_bytes(
+            mount=mount,
+            path=protocol.EMBED_VIDEOS_BYTES_PATH,
+            embed=embedder.embed_video_bytes,
+        )
 
 
 def _mount_texts(*, mount: _Mount, embed: Callable[[list[str]], EmbeddingResult]) -> None:
-    @mount.router.post("/embed/texts", dependencies=mount.guards)
+    @mount.router.post(protocol.EMBED_TEXTS_PATH, dependencies=mount.guards)
     def embed_texts(request: EmbedTextsRequest) -> EmbeddingsResponse:
         _check_batch_size(item_count=len(request.texts), limits=mount.limits)
         result = _embed(lambda: embed(request.texts))
@@ -169,9 +257,16 @@ def _mount_bytes(
     @mount.router.post(path, dependencies=mount.guards)
     def embed_bytes(files: _MultipartFiles) -> EmbeddingsResponse:
         _check_batch_size(item_count=len(files), limits=mount.limits)
-        items = [file.file.read() for file in files]
+        items = [_read_part(file=file) for file in files]
         result = _embed(lambda: embed(items))
         return _respond(result=result, mount=mount, item_count=len(items))
+
+
+def _read_part(*, file: UploadFile) -> bytes:
+    """Read one multipart part, releasing the copy starlette spooled for it."""
+    data = file.file.read()
+    file.file.close()
+    return data
 
 
 def _capabilities(*, embedder: BaseEmbedder) -> list[WireCapability]:
@@ -184,10 +279,10 @@ def _capabilities(*, embedder: BaseEmbedder) -> list[WireCapability]:
 
 
 def _embed(call: Callable[[], EmbeddingResult]) -> EmbeddingResult:
-    """Run an embedder call, mapping a method left unimplemented to 501."""
+    """Run an embedder call, mapping a capability left unfinished to 501."""
     try:
         return call()
-    except NotImplementedError as error:
+    except CapabilityNotImplementedError as error:
         raise HTTPException(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail="The server mounts this capability but does not implement it.",
@@ -212,19 +307,12 @@ def _check_batch_size(*, item_count: int, limits: ServerLimits) -> None:
         )
 
 
-def _authorization(*, api_key: str | None) -> Callable[[Request], None]:
-    def verify(request: Request) -> None:
-        if api_key is None:
-            return
-        header = request.headers.get("authorization", "")
-        if not secrets.compare_digest(header, f"Bearer {api_key}"):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Missing or invalid bearer token.",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-    return verify
+def _authorization_header(*, scope: Scope) -> bytes:
+    """Read the raw ``Authorization`` header. ASGI lowercases the names for us."""
+    for name, value in scope["headers"]:
+        if name == b"authorization":
+            return bytes(value)
+    return b""
 
 
 def _readiness(*, embedder: BaseEmbedder) -> Callable[[], None]:
@@ -239,21 +327,28 @@ def _readiness(*, embedder: BaseEmbedder) -> Callable[[], None]:
     return verify
 
 
-def _request_size(*, limits: ServerLimits) -> Callable[[Request], None]:
-    def verify(request: Request) -> None:
-        content_length = request.headers.get("content-length", "")
-        if content_length.isdigit() and int(content_length) > limits.max_request_bytes:
-            raise HTTPException(
-                status_code=_STATUS_PAYLOAD_TOO_LARGE,
-                detail=f"The request body is over the advertised max_request_bytes of "
-                f"{limits.max_request_bytes}.",
-            )
-
-    return verify
+def _unauthorized() -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        content={"detail": "Missing or invalid bearer token."},
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 def _handle_contract_error(_request: Request, exc: Exception) -> Response:
     """Answer 500 naming what the embedder returned, rather than shipping it."""
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": str(exc)}
+    )
+
+
+def _handle_invalid_request(_request: Request, exc: Exception) -> Response:
+    """Answer 400, because the protocol reserves 422 for input it cannot use.
+
+    FastAPI answers 422 for both by default, and the two carry opposite advice for a
+    client: a malformed request is its own bug, unusable input is the batch's.
+    """
+    errors = exc.errors() if isinstance(exc, RequestValidationError) else []
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST, content={"detail": jsonable_encoder(errors)}
     )

--- a/lightly_studio_embed/src/lightly_studio_embed/server.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/server.py
@@ -1,0 +1,259 @@
+"""Turns an embedder into the HTTP endpoints the protocol defines.
+
+``serve`` inspects which capability classes the embedder implements, mounts those
+endpoints plus ``/v1/describe``, and runs uvicorn. Version 1 serves the ``texts``,
+``images/bytes`` and ``videos/bytes`` transports; the URL transports are specified
+but not mounted, because LightlyStudio does not call them yet and capabilities are
+advertised, so adding them later is purely additive.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Annotated, Callable
+
+import uvicorn
+from fastapi import (
+    APIRouter,
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi import params as fastapi_params
+from fastapi.responses import JSONResponse
+
+from lightly_studio_embed import protocol, validation
+from lightly_studio_embed.embedder import (
+    BaseEmbedder,
+    EmbeddingResult,
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
+from lightly_studio_embed.protocol import (
+    DescribeResponse,
+    EmbeddingsResponse,
+    EmbedTextsRequest,
+    ServerLimits,
+    WireCapability,
+)
+from lightly_studio_embed.validation import EmbedderContractError
+
+# How long a client should wait before retrying a model that is still loading.
+_RETRY_AFTER_SECONDS = "5"
+
+# Spelled out, because starlette renamed its constant for this status and the old name warns
+# on new versions while the new one is missing on the versions `requires-python` still allows.
+_STATUS_PAYLOAD_TOO_LARGE = 413
+
+_MultipartFiles = Annotated[list[UploadFile], File(alias=protocol.FILES_FIELD_NAME)]
+
+
+@dataclass(frozen=True)
+class _Mount:
+    """What every embed route is built from, so each mounts with two arguments."""
+
+    router: APIRouter
+    embedder: BaseEmbedder
+    limits: ServerLimits
+    guards: Sequence[fastapi_params.Depends]
+
+
+def serve(
+    embedder: BaseEmbedder,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    api_key: str | None = None,
+    limits: ServerLimits | None = None,
+) -> None:
+    """Serve an embedder over HTTP until the process is stopped.
+
+    Args:
+        embedder: The model to serve. Its capability classes decide which endpoints
+            exist: a text-only embedder exposes no image or video routes.
+        host: Interface to bind. The default is loopback only; pass ``"0.0.0.0"`` to
+            accept requests from other hosts.
+        port: TCP port to bind.
+        api_key: Token a client must send as ``Authorization: Bearer <api_key>``.
+            ``None`` leaves the server unauthenticated, which is only safe behind a
+            loopback bind or a trusted network boundary.
+        limits: Ceilings to advertise and enforce. Defaults to 64 items and 32 MiB
+            per request.
+    """
+    app = create_app(embedder=embedder, api_key=api_key, limits=limits)
+    uvicorn.run(app, host=host, port=port)
+
+
+def create_app(
+    *,
+    embedder: BaseEmbedder,
+    api_key: str | None = None,
+    limits: ServerLimits | None = None,
+) -> FastAPI:
+    """Build the application ``serve`` runs.
+
+    Use it to mount the protocol inside an application of your own, or to exercise
+    an embedder over a test client without binding a port.
+
+    Args:
+        embedder: The model to serve.
+        api_key: Token a client must send as ``Authorization: Bearer <api_key>``.
+        limits: Ceilings to advertise and enforce.
+
+    Returns:
+        An application serving ``/v1/describe`` and the embedder's capabilities.
+    """
+    app = FastAPI(title="LightlyStudio embedding server")
+    app.add_exception_handler(EmbedderContractError, _handle_contract_error)
+    resolved_limits = limits if limits is not None else ServerLimits()
+    router = APIRouter(
+        prefix=protocol.BASE_PATH, dependencies=[Depends(_authorization(api_key=api_key))]
+    )
+    _mount_describe(router=router, embedder=embedder, limits=resolved_limits)
+    _mount_embed_routes(router=router, embedder=embedder, limits=resolved_limits)
+    app.include_router(router)
+    return app
+
+
+def _mount_describe(*, router: APIRouter, embedder: BaseEmbedder, limits: ServerLimits) -> None:
+    @router.get("/describe")
+    def describe() -> DescribeResponse:
+        return DescribeResponse(
+            protocol_version=protocol.PROTOCOL_VERSION,
+            space_key=embedder.space_key,
+            dimension=embedder.dimension,
+            ready=embedder.ready,
+            capabilities=_capabilities(embedder=embedder),
+            limits=limits,
+        )
+
+
+def _mount_embed_routes(*, router: APIRouter, embedder: BaseEmbedder, limits: ServerLimits) -> None:
+    mount = _Mount(
+        router=router,
+        embedder=embedder,
+        limits=limits,
+        guards=[Depends(_readiness(embedder=embedder)), Depends(_request_size(limits=limits))],
+    )
+    if isinstance(embedder, TextEmbedder):
+        _mount_texts(mount=mount, embed=embedder.embed_text)
+    if isinstance(embedder, ImageBytesEmbedder):
+        _mount_bytes(mount=mount, path="/embed/images/bytes", embed=embedder.embed_image_bytes)
+    if isinstance(embedder, VideoBytesEmbedder):
+        _mount_bytes(mount=mount, path="/embed/videos/bytes", embed=embedder.embed_video_bytes)
+
+
+def _mount_texts(*, mount: _Mount, embed: Callable[[list[str]], EmbeddingResult]) -> None:
+    @mount.router.post("/embed/texts", dependencies=mount.guards)
+    def embed_texts(request: EmbedTextsRequest) -> EmbeddingsResponse:
+        _check_batch_size(item_count=len(request.texts), limits=mount.limits)
+        result = _embed(lambda: embed(request.texts))
+        return _respond(result=result, mount=mount, item_count=len(request.texts))
+
+
+def _mount_bytes(
+    *, mount: _Mount, path: str, embed: Callable[[list[bytes]], EmbeddingResult]
+) -> None:
+    """Mount one of the two bytes endpoints; they differ only in the path."""
+
+    # A synchronous handler, so that FastAPI runs the forward pass in a worker
+    # thread rather than on the event loop.
+    @mount.router.post(path, dependencies=mount.guards)
+    def embed_bytes(files: _MultipartFiles) -> EmbeddingsResponse:
+        _check_batch_size(item_count=len(files), limits=mount.limits)
+        items = [file.file.read() for file in files]
+        result = _embed(lambda: embed(items))
+        return _respond(result=result, mount=mount, item_count=len(items))
+
+
+def _capabilities(*, embedder: BaseEmbedder) -> list[WireCapability]:
+    served = [
+        (TextEmbedder, WireCapability.TEXT),
+        (ImageBytesEmbedder, WireCapability.IMAGE_BYTES),
+        (VideoBytesEmbedder, WireCapability.VIDEO_BYTES),
+    ]
+    return [capability for base, capability in served if isinstance(embedder, base)]
+
+
+def _embed(call: Callable[[], EmbeddingResult]) -> EmbeddingResult:
+    """Run an embedder call, mapping a method left unimplemented to 501."""
+    try:
+        return call()
+    except NotImplementedError as error:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="The server mounts this capability but does not implement it.",
+        ) from error
+
+
+def _respond(*, result: EmbeddingResult, mount: _Mount, item_count: int) -> EmbeddingsResponse:
+    return validation.build_embeddings_response(
+        result=result,
+        space_key=mount.embedder.space_key,
+        dimension=mount.embedder.dimension,
+        item_count=item_count,
+    )
+
+
+def _check_batch_size(*, item_count: int, limits: ServerLimits) -> None:
+    if item_count > limits.max_batch_size:
+        raise HTTPException(
+            status_code=_STATUS_PAYLOAD_TOO_LARGE,
+            detail=f"The request carries {item_count} items, over the advertised "
+            f"max_batch_size of {limits.max_batch_size}.",
+        )
+
+
+def _authorization(*, api_key: str | None) -> Callable[[Request], None]:
+    def verify(request: Request) -> None:
+        if api_key is None:
+            return
+        header = request.headers.get("authorization", "")
+        if not secrets.compare_digest(header, f"Bearer {api_key}"):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing or invalid bearer token.",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    return verify
+
+
+def _readiness(*, embedder: BaseEmbedder) -> Callable[[], None]:
+    def verify() -> None:
+        if not embedder.ready:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="The model is still loading.",
+                headers={"Retry-After": _RETRY_AFTER_SECONDS},
+            )
+
+    return verify
+
+
+def _request_size(*, limits: ServerLimits) -> Callable[[Request], None]:
+    def verify(request: Request) -> None:
+        content_length = request.headers.get("content-length", "")
+        if content_length.isdigit() and int(content_length) > limits.max_request_bytes:
+            raise HTTPException(
+                status_code=_STATUS_PAYLOAD_TOO_LARGE,
+                detail=f"The request body is over the advertised max_request_bytes of "
+                f"{limits.max_request_bytes}.",
+            )
+
+    return verify
+
+
+def _handle_contract_error(_request: Request, exc: Exception) -> Response:
+    """Answer 500 naming what the embedder returned, rather than shipping it."""
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": str(exc)}
+    )

--- a/lightly_studio_embed/src/lightly_studio_embed/validation.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/validation.py
@@ -1,0 +1,74 @@
+"""Checks an embedder's result against the contract before it leaves the server.
+
+A wrong dimension or a NaN is far cheaper to find here, in the customer's own
+process, than as a similarity search that misbehaves inside LightlyStudio.
+"""
+
+from __future__ import annotations
+
+import math
+
+from lightly_studio_embed.embedder import EmbeddingResult
+from lightly_studio_embed.protocol import EmbeddingsResponse
+
+
+class EmbedderContractError(RuntimeError):
+    """Raised when an embedder returns a result the protocol does not allow."""
+
+
+def build_embeddings_response(
+    *, result: EmbeddingResult, space_key: str, dimension: int, item_count: int
+) -> EmbeddingsResponse:
+    """Validate an embedder's result and convert it into a wire response.
+
+    Args:
+        result: What the embedder returned.
+        space_key: The embedder's embedding space, echoed on the response.
+        dimension: The vector length the embedder declares.
+        item_count: How many items the request carried.
+
+    Returns:
+        The response body for any embed endpoint.
+
+    Raises:
+        EmbedderContractError: If the result does not match the declared dimension,
+            the number of kept indices, or the items of the request.
+    """
+    kept_indices = list(result.kept_indices)
+    embeddings = [[float(value) for value in row] for row in result.embeddings]
+    _validate_kept_indices(kept_indices=kept_indices, item_count=item_count)
+    _validate_embeddings(embeddings=embeddings, kept_count=len(kept_indices), dimension=dimension)
+    return EmbeddingsResponse(
+        space_key=space_key,
+        dimension=dimension,
+        kept_indices=kept_indices,
+        embeddings=embeddings,
+    )
+
+
+def _validate_kept_indices(*, kept_indices: list[int], item_count: int) -> None:
+    if any(index < 0 or index >= item_count for index in kept_indices):
+        raise EmbedderContractError(
+            f"kept_indices must point into the {item_count} items of the request, "
+            f"got {kept_indices}."
+        )
+    if any(current >= following for current, following in zip(kept_indices, kept_indices[1:])):
+        raise EmbedderContractError(
+            f"kept_indices must be ascending and unique, got {kept_indices}."
+        )
+
+
+def _validate_embeddings(*, embeddings: list[list[float]], kept_count: int, dimension: int) -> None:
+    if len(embeddings) != kept_count:
+        raise EmbedderContractError(
+            f"Got {len(embeddings)} embeddings for {kept_count} kept indices; "
+            f"the two must have the same length."
+        )
+    for index, row in enumerate(embeddings):
+        if len(row) != dimension:
+            raise EmbedderContractError(
+                f"Embedding {index} has {len(row)} values, but the embedder declares "
+                f"dimension {dimension}."
+            )
+        if not all(math.isfinite(value) for value in row):
+            raise EmbedderContractError(f"Embedding {index} holds a value that is not finite.")

--- a/lightly_studio_embed/src/lightly_studio_embed/validation.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/validation.py
@@ -50,13 +50,20 @@ def _as_numbers(*, result: EmbeddingResult) -> tuple[list[int], list[list[float]
     embeddings up against the wrong request items.
     """
     try:
-        kept_indices = [operator.index(index) for index in result.kept_indices]
+        kept_indices = [_as_index(index) for index in result.kept_indices]
         embeddings = [[float(value) for value in row] for row in result.embeddings]
     except (OverflowError, TypeError, ValueError) as error:
         raise EmbedderContractError(
             f"kept_indices must hold integers and every embedding must hold numbers: {error}"
         ) from error
     return kept_indices, embeddings
+
+
+def _as_index(index: int) -> int:
+    """Read one kept index, rejecting a bool so a mask cannot pass for a list of indices."""
+    if isinstance(index, bool):
+        raise TypeError(f"{index!r} is a bool, not an index")
+    return operator.index(index)
 
 
 def _validate_kept_indices(*, kept_indices: list[int], item_count: int) -> None:

--- a/lightly_studio_embed/src/lightly_studio_embed/validation.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/validation.py
@@ -7,6 +7,7 @@ process, than as a similarity search that misbehaves inside LightlyStudio.
 from __future__ import annotations
 
 import math
+import operator
 
 from lightly_studio_embed.embedder import EmbeddingResult
 from lightly_studio_embed.errors import EmbedderContractError
@@ -43,11 +44,15 @@ def build_embeddings_response(
 
 
 def _as_numbers(*, result: EmbeddingResult) -> tuple[list[int], list[list[float]]]:
-    """Convert the result to plain numbers, so a non-numeric row fails as a contract error."""
+    """Convert the result to plain numbers, so a non-numeric row fails as a contract error.
+
+    ``operator.index`` rather than ``int``, which would truncate a float index and line the
+    embeddings up against the wrong request items.
+    """
     try:
-        kept_indices = [int(index) for index in result.kept_indices]
+        kept_indices = [operator.index(index) for index in result.kept_indices]
         embeddings = [[float(value) for value in row] for row in result.embeddings]
-    except (TypeError, ValueError) as error:
+    except (OverflowError, TypeError, ValueError) as error:
         raise EmbedderContractError(
             f"kept_indices must hold integers and every embedding must hold numbers: {error}"
         ) from error

--- a/lightly_studio_embed/src/lightly_studio_embed/validation.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/validation.py
@@ -9,11 +9,8 @@ from __future__ import annotations
 import math
 
 from lightly_studio_embed.embedder import EmbeddingResult
+from lightly_studio_embed.errors import EmbedderContractError
 from lightly_studio_embed.protocol import EmbeddingsResponse
-
-
-class EmbedderContractError(RuntimeError):
-    """Raised when an embedder returns a result the protocol does not allow."""
 
 
 def build_embeddings_response(
@@ -34,8 +31,7 @@ def build_embeddings_response(
         EmbedderContractError: If the result does not match the declared dimension,
             the number of kept indices, or the items of the request.
     """
-    kept_indices = list(result.kept_indices)
-    embeddings = [[float(value) for value in row] for row in result.embeddings]
+    kept_indices, embeddings = _as_numbers(result=result)
     _validate_kept_indices(kept_indices=kept_indices, item_count=item_count)
     _validate_embeddings(embeddings=embeddings, kept_count=len(kept_indices), dimension=dimension)
     return EmbeddingsResponse(
@@ -44,6 +40,18 @@ def build_embeddings_response(
         kept_indices=kept_indices,
         embeddings=embeddings,
     )
+
+
+def _as_numbers(*, result: EmbeddingResult) -> tuple[list[int], list[list[float]]]:
+    """Convert the result to plain numbers, so a non-numeric row fails as a contract error."""
+    try:
+        kept_indices = [int(index) for index in result.kept_indices]
+        embeddings = [[float(value) for value in row] for row in result.embeddings]
+    except (TypeError, ValueError) as error:
+        raise EmbedderContractError(
+            f"kept_indices must hold integers and every embedding must hold numbers: {error}"
+        ) from error
+    return kept_indices, embeddings
 
 
 def _validate_kept_indices(*, kept_indices: list[int], item_count: int) -> None:

--- a/lightly_studio_embed/tests/test_server.py
+++ b/lightly_studio_embed/tests/test_server.py
@@ -97,6 +97,16 @@ def _chunked_multipart() -> Iterator[bytes]:
     yield f"\r\n--{_BOUNDARY}--\r\n".encode()
 
 
+def _unreadable_body() -> Iterator[bytes]:
+    """A body that raises the moment anything reads it.
+
+    Starlette answers 400 when a body fails to parse, so a request that comes back 401 is
+    one whose body was never touched.
+    """
+    raise AssertionError("The request body was read before the bearer token was checked.")
+    yield b""  # Unreachable, and only here to make this a generator.
+
+
 def _do_not_run(*_args: object, **_kwargs: object) -> None:
     """Stand in for ``uvicorn.run``, so ``serve`` returns instead of binding a port."""
 
@@ -312,14 +322,13 @@ def test_create_app__chunked_body_over_max_request_bytes() -> None:
     assert "max_request_bytes" in response.json()["detail"]
 
 
-def test_create_app__unauthenticated_body_over_max_request_bytes() -> None:
-    """The token is checked before the body arrives, so the 401 comes first."""
-    app = create_app(embedder=FakeBytesEmbedder(), api_key="secret")
-    client = TestClient(app)
+def test_create_app__unauthenticated_request_body_is_never_read() -> None:
+    """The token is checked first: reading this body would answer 400 instead of 401."""
+    client = TestClient(create_app(embedder=FakeBytesEmbedder(), api_key="secret"))
 
     response = client.post(
         "/v1/embed/images/bytes",
-        content=_chunked_multipart(),
+        content=_unreadable_body(),
         headers={"Content-Type": f"multipart/form-data; boundary={_BOUNDARY}"},
     )
 

--- a/lightly_studio_embed/tests/test_server.py
+++ b/lightly_studio_embed/tests/test_server.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
+import pytest
+import uvicorn
 from fastapi.testclient import TestClient
 
+from lightly_studio_embed import server
 from lightly_studio_embed.embedder import (
     EmbeddingResult,
     ImageBytesEmbedder,
     TextEmbedder,
     VideoBytesEmbedder,
 )
+from lightly_studio_embed.errors import CapabilityNotImplementedError
 from lightly_studio_embed.protocol import ServerLimits
 from lightly_studio_embed.server import create_app
 
 SPACE_KEY = "acme/model@v1"
 DIMENSION = 2
+_BOUNDARY = "b0undary"
 
 
 class FakeTextEmbedder(TextEmbedder):
@@ -63,15 +70,35 @@ class FakeBytesEmbedder(ImageBytesEmbedder, VideoBytesEmbedder):
         return _rows(count=len(videos))
 
 
-class UnimplementedTextEmbedder(FakeTextEmbedder):
+class UnfinishedTextEmbedder(FakeTextEmbedder):
     """A mounted capability whose method was never finished."""
 
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:  # noqa: ARG002
+        raise CapabilityNotImplementedError
+
+
+class BrokenTextEmbedder(FakeTextEmbedder):
+    """A model that fails, the way torch does for an op its backend lacks."""
+
     def embed_text(self, texts: list[str]) -> EmbeddingResult:
-        raise NotImplementedError
+        raise NotImplementedError("could not run 'aten::foo' on the 'MPS' backend")
 
 
 def _rows(*, count: int) -> EmbeddingResult:
     return EmbeddingResult(embeddings=[[0.5, -0.5]] * count, kept_indices=list(range(count)))
+
+
+def _chunked_multipart() -> Iterator[bytes]:
+    """One 4 MB part, streamed so that the request carries no ``Content-Length``."""
+    yield (
+        f'--{_BOUNDARY}\r\nContent-Disposition: form-data; name="files"; filename="a.jpg"\r\n\r\n'
+    ).encode()
+    yield b"x" * 4_000_000
+    yield f"\r\n--{_BOUNDARY}--\r\n".encode()
+
+
+def _do_not_run(*_args: object, **_kwargs: object) -> None:
+    """Stand in for ``uvicorn.run``, so ``serve`` returns instead of binding a port."""
 
 
 def test_create_app__describe() -> None:
@@ -224,11 +251,19 @@ def test_create_app__embed_while_not_ready() -> None:
 
 
 def test_create_app__capability_not_implemented() -> None:
-    client = TestClient(create_app(embedder=UnimplementedTextEmbedder()))
+    client = TestClient(create_app(embedder=UnfinishedTextEmbedder()))
 
     response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
 
     assert response.status_code == 501
+
+
+def test_create_app__model_raises_not_implemented_error() -> None:
+    client = TestClient(create_app(embedder=BrokenTextEmbedder()), raise_server_exceptions=False)
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 500
 
 
 def test_create_app__embedder_returns_wrong_dimension() -> None:
@@ -239,3 +274,78 @@ def test_create_app__embedder_returns_wrong_dimension() -> None:
 
     assert response.status_code == 500
     assert "dimension 2" in response.json()["detail"]
+
+
+def test_create_app__non_ascii_bearer_token() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(), api_key="secret"))
+
+    response = client.get("/v1/describe", headers={b"authorization": b"Bearer \xe9"})
+
+    assert response.status_code == 401
+
+
+def test_create_app__non_ascii_api_key() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(), api_key="sécret"))
+
+    response = client.get("/v1/describe", headers={b"authorization": "Bearer sécret".encode()})
+
+    assert response.status_code == 200
+
+
+def test_create_app__blank_api_key() -> None:
+    with pytest.raises(ValueError, match="api_key is blank"):
+        create_app(embedder=FakeTextEmbedder(), api_key=" ")
+
+
+def test_create_app__chunked_body_over_max_request_bytes() -> None:
+    app = create_app(embedder=FakeBytesEmbedder(), limits=ServerLimits(max_request_bytes=8))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/embed/images/bytes",
+        content=_chunked_multipart(),
+        headers={"Content-Type": f"multipart/form-data; boundary={_BOUNDARY}"},
+    )
+
+    assert response.request.headers["transfer-encoding"] == "chunked"
+    assert response.status_code == 413
+    assert "max_request_bytes" in response.json()["detail"]
+
+
+def test_create_app__unauthenticated_body_over_max_request_bytes() -> None:
+    """The token is checked before the body arrives, so the 401 comes first."""
+    app = create_app(embedder=FakeBytesEmbedder(), api_key="secret")
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/embed/images/bytes",
+        content=_chunked_multipart(),
+        headers={"Content-Type": f"multipart/form-data; boundary={_BOUNDARY}"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_create_app__malformed_request() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    response = client.post("/v1/embed/texts", json={"texts": "a red car"})
+
+    assert response.status_code == 400
+
+
+def test_serve__warns_on_a_public_bind_without_a_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(uvicorn, "run", _do_not_run)
+
+    with pytest.warns(UserWarning, match="without an api_key"):
+        server.serve(FakeTextEmbedder(), host="0.0.0.0")
+
+
+def test_serve__silent_on_a_loopback_bind(
+    monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
+) -> None:
+    monkeypatch.setattr(uvicorn, "run", _do_not_run)
+
+    server.serve(FakeTextEmbedder())
+
+    assert len(recwarn) == 0

--- a/lightly_studio_embed/tests/test_server.py
+++ b/lightly_studio_embed/tests/test_server.py
@@ -350,6 +350,48 @@ def test_serve__warns_on_a_public_bind_without_a_key(monkeypatch: pytest.MonkeyP
         server.serve(FakeTextEmbedder(), host="0.0.0.0")
 
 
+def test_serve__warns_on_a_public_bind_without_tls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(uvicorn, "run", _do_not_run)
+
+    with pytest.warns(UserWarning, match="travels in the clear"):
+        server.serve(FakeTextEmbedder(), host="0.0.0.0", api_key="secret")
+
+
+def test_serve__forwards_the_tls_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def record(*_args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(uvicorn, "run", record)
+
+    server.serve(
+        FakeTextEmbedder(),
+        host="0.0.0.0",
+        api_key="secret",
+        ssl_certfile="cert.pem",
+        ssl_keyfile="key.pem",
+    )
+
+    assert captured["ssl_certfile"] == "cert.pem"
+    assert captured["ssl_keyfile"] == "key.pem"
+
+
+def test_serve__silent_on_a_public_bind_with_tls(
+    monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
+) -> None:
+    monkeypatch.setattr(uvicorn, "run", _do_not_run)
+
+    server.serve(FakeTextEmbedder(), host="0.0.0.0", api_key="secret", ssl_certfile="cert.pem")
+
+    assert len(recwarn) == 0
+
+
+def test_serve__keyfile_without_certfile() -> None:
+    with pytest.raises(ValueError, match="without ssl_certfile"):
+        server.serve(FakeTextEmbedder(), ssl_keyfile="key.pem")
+
+
 def test_serve__silent_on_a_loopback_bind(
     monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
 ) -> None:

--- a/lightly_studio_embed/tests/test_server.py
+++ b/lightly_studio_embed/tests/test_server.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from lightly_studio_embed.embedder import (
+    EmbeddingResult,
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
+from lightly_studio_embed.protocol import ServerLimits
+from lightly_studio_embed.server import create_app
+
+SPACE_KEY = "acme/model@v1"
+DIMENSION = 2
+
+
+class FakeTextEmbedder(TextEmbedder):
+    """Returns one fixed row per text, or a canned result when one is given."""
+
+    def __init__(self, *, result: EmbeddingResult | None = None, ready: bool = True) -> None:
+        self.result = result
+        self.is_ready = ready
+        self.received: list[str] = []
+
+    @property
+    def space_key(self) -> str:
+        return SPACE_KEY
+
+    @property
+    def dimension(self) -> int:
+        return DIMENSION
+
+    @property
+    def ready(self) -> bool:
+        return self.is_ready
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        self.received = texts
+        return self.result if self.result is not None else _rows(count=len(texts))
+
+
+class FakeBytesEmbedder(ImageBytesEmbedder, VideoBytesEmbedder):
+    """Embeds images and videos, recording the bytes it was handed."""
+
+    def __init__(self) -> None:
+        self.received: list[bytes] = []
+
+    @property
+    def space_key(self) -> str:
+        return SPACE_KEY
+
+    @property
+    def dimension(self) -> int:
+        return DIMENSION
+
+    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
+        self.received = images
+        return _rows(count=len(images))
+
+    def embed_video_bytes(self, videos: list[bytes]) -> EmbeddingResult:
+        self.received = videos
+        return _rows(count=len(videos))
+
+
+class UnimplementedTextEmbedder(FakeTextEmbedder):
+    """A mounted capability whose method was never finished."""
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        raise NotImplementedError
+
+
+def _rows(*, count: int) -> EmbeddingResult:
+    return EmbeddingResult(embeddings=[[0.5, -0.5]] * count, kept_indices=list(range(count)))
+
+
+def test_create_app__describe() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    response = client.get("/v1/describe")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "protocol_version": "1.0",
+        "space_key": SPACE_KEY,
+        "dimension": DIMENSION,
+        "ready": True,
+        "capabilities": ["text"],
+        "limits": {"max_batch_size": 64, "max_request_bytes": 33554432},
+    }
+
+
+def test_create_app__describe_bytes_capabilities() -> None:
+    client = TestClient(create_app(embedder=FakeBytesEmbedder()))
+
+    response = client.get("/v1/describe")
+
+    assert response.json()["capabilities"] == ["image_bytes", "video_bytes"]
+
+
+def test_create_app__describe_not_ready() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(ready=False)))
+
+    response = client.get("/v1/describe")
+
+    assert response.json()["ready"] is False
+
+
+def test_create_app__text_only_mounts_no_other_route() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    assert client.post("/v1/embed/images/bytes", files={"files": b"\xff\xd8"}).status_code == 404
+    assert client.post("/v1/embed/videos/bytes", files={"files": b"\x00\x00"}).status_code == 404
+
+
+def test_create_app__embed_texts() -> None:
+    embedder = FakeTextEmbedder()
+    client = TestClient(create_app(embedder=embedder))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car", "a blue car"]})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "space_key": SPACE_KEY,
+        "dimension": DIMENSION,
+        "kept_indices": [0, 1],
+        "embeddings": [[0.5, -0.5], [0.5, -0.5]],
+    }
+    assert embedder.received == ["a red car", "a blue car"]
+
+
+def test_create_app__embed_texts_with_skipped_item() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5]], kept_indices=[1])
+    client = TestClient(create_app(embedder=FakeTextEmbedder(result=result)))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["", "a red car"]})
+
+    assert response.status_code == 200
+    assert response.json()["kept_indices"] == [1]
+
+
+def test_create_app__embed_images_bytes() -> None:
+    embedder = FakeBytesEmbedder()
+    client = TestClient(create_app(embedder=embedder))
+
+    response = client.post(
+        "/v1/embed/images/bytes",
+        files=[
+            ("files", ("a.jpg", b"\xff\xd8a", "image/jpeg")),
+            ("files", ("b.png", b"\x89P", "image/png")),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert response.json()["kept_indices"] == [0, 1]
+    assert embedder.received == [b"\xff\xd8a", b"\x89P"]
+
+
+def test_create_app__embed_videos_bytes() -> None:
+    embedder = FakeBytesEmbedder()
+    client = TestClient(create_app(embedder=embedder))
+
+    response = client.post("/v1/embed/videos/bytes", files=[("files", ("a.mp4", b"\x00moov"))])
+
+    assert response.status_code == 200
+    assert embedder.received == [b"\x00moov"]
+
+
+def test_create_app__batch_over_max_batch_size() -> None:
+    app = create_app(embedder=FakeTextEmbedder(), limits=ServerLimits(max_batch_size=1))
+    client = TestClient(app)
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car", "a blue car"]})
+
+    assert response.status_code == 413
+    assert "max_batch_size" in response.json()["detail"]
+
+
+def test_create_app__body_over_max_request_bytes() -> None:
+    app = create_app(embedder=FakeTextEmbedder(), limits=ServerLimits(max_request_bytes=8))
+    client = TestClient(app)
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 413
+    assert "max_request_bytes" in response.json()["detail"]
+
+
+def test_create_app__missing_bearer_token() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(), api_key="secret"))
+
+    assert client.get("/v1/describe").status_code == 401
+
+
+def test_create_app__wrong_bearer_token() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(), api_key="secret"))
+
+    response = client.get("/v1/describe", headers={"Authorization": "Bearer wrong"})
+
+    assert response.status_code == 401
+
+
+def test_create_app__correct_bearer_token() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(), api_key="secret"))
+
+    response = client.get("/v1/describe", headers={"Authorization": "Bearer secret"})
+
+    assert response.status_code == 200
+
+
+def test_create_app__no_api_key_leaves_the_server_open() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    assert client.get("/v1/describe").status_code == 200
+
+
+def test_create_app__embed_while_not_ready() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(ready=False)))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "5"
+
+
+def test_create_app__capability_not_implemented() -> None:
+    client = TestClient(create_app(embedder=UnimplementedTextEmbedder()))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 501
+
+
+def test_create_app__embedder_returns_wrong_dimension() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5, 0.5]], kept_indices=[0])
+    client = TestClient(create_app(embedder=FakeTextEmbedder(result=result)))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 500
+    assert "dimension 2" in response.json()["detail"]

--- a/lightly_studio_embed/tests/test_validation.py
+++ b/lightly_studio_embed/tests/test_validation.py
@@ -65,6 +65,25 @@ def test_build_embeddings_response__value_not_finite() -> None:
         )
 
 
+def test_build_embeddings_response__kept_index_not_integral() -> None:
+    """A float index is rejected rather than truncated onto the wrong request item."""
+    result = EmbeddingResult(embeddings=[[0.5, -0.5]], kept_indices=[0.9])  # type: ignore[list-item]
+
+    with pytest.raises(EmbedderContractError, match="must hold integers"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=2
+        )
+
+
+def test_build_embeddings_response__value_too_large_for_a_float() -> None:
+    result = EmbeddingResult(embeddings=[[10**400, 1.0]], kept_indices=[0])
+
+    with pytest.raises(EmbedderContractError, match="must hold numbers"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=1
+        )
+
+
 def test_build_embeddings_response__value_not_a_number() -> None:
     result = EmbeddingResult(embeddings=[["not a number", 1.0]], kept_indices=[0])  # type: ignore[list-item]
 

--- a/lightly_studio_embed/tests/test_validation.py
+++ b/lightly_studio_embed/tests/test_validation.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from lightly_studio_embed.embedder import EmbeddingResult
+from lightly_studio_embed.validation import EmbedderContractError, build_embeddings_response
+
+
+def test_build_embeddings_response() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5], [1.0, 0.0]], kept_indices=[0, 2])
+
+    response = build_embeddings_response(
+        result=result, space_key="acme/model@v1", dimension=2, item_count=3
+    )
+
+    assert response.space_key == "acme/model@v1"
+    assert response.dimension == 2
+    assert response.kept_indices == [0, 2]
+    assert response.embeddings == [[0.5, -0.5], [1.0, 0.0]]
+
+
+def test_build_embeddings_response__kept_indices_out_of_range() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5]], kept_indices=[3])
+
+    with pytest.raises(EmbedderContractError, match="must point into the 2 items"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=2
+        )
+
+
+def test_build_embeddings_response__kept_indices_not_ascending() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5], [1.0, 0.0]], kept_indices=[1, 1])
+
+    with pytest.raises(EmbedderContractError, match="ascending and unique"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=2
+        )
+
+
+def test_build_embeddings_response__row_count_mismatch() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5]], kept_indices=[0, 1])
+
+    with pytest.raises(EmbedderContractError, match="1 embeddings for 2 kept indices"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=2
+        )
+
+
+def test_build_embeddings_response__wrong_dimension() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, -0.5, 0.5]], kept_indices=[0])
+
+    with pytest.raises(EmbedderContractError, match="has 3 values"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=1
+        )
+
+
+def test_build_embeddings_response__value_not_finite() -> None:
+    result = EmbeddingResult(embeddings=[[0.5, float("nan")]], kept_indices=[0])
+
+    with pytest.raises(EmbedderContractError, match="not finite"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=1
+        )

--- a/lightly_studio_embed/tests/test_validation.py
+++ b/lightly_studio_embed/tests/test_validation.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from lightly_studio_embed.embedder import EmbeddingResult
-from lightly_studio_embed.validation import EmbedderContractError, build_embeddings_response
+from lightly_studio_embed.errors import EmbedderContractError
+from lightly_studio_embed.validation import build_embeddings_response
 
 
 def test_build_embeddings_response() -> None:
@@ -59,6 +60,15 @@ def test_build_embeddings_response__value_not_finite() -> None:
     result = EmbeddingResult(embeddings=[[0.5, float("nan")]], kept_indices=[0])
 
     with pytest.raises(EmbedderContractError, match="not finite"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=1
+        )
+
+
+def test_build_embeddings_response__value_not_a_number() -> None:
+    result = EmbeddingResult(embeddings=[["not a number", 1.0]], kept_indices=[0])  # type: ignore[list-item]
+
+    with pytest.raises(EmbedderContractError, match="must hold numbers"):
         build_embeddings_response(
             result=result, space_key="acme/model@v1", dimension=2, item_count=1
         )

--- a/lightly_studio_embed/tests/test_validation.py
+++ b/lightly_studio_embed/tests/test_validation.py
@@ -75,6 +75,16 @@ def test_build_embeddings_response__kept_index_not_integral() -> None:
         )
 
 
+def test_build_embeddings_response__kept_indices_are_a_boolean_mask() -> None:
+    """A mask must not pass for indices, which is what bools would convert into."""
+    result = EmbeddingResult(embeddings=[[0.5, -0.5]], kept_indices=[False, True])
+
+    with pytest.raises(EmbedderContractError, match="is a bool, not an index"):
+        build_embeddings_response(
+            result=result, space_key="acme/model@v1", dimension=2, item_count=2
+        )
+
+
 def test_build_embeddings_response__value_too_large_for_a_float() -> None:
     result = EmbeddingResult(embeddings=[[10**400, 1.0]], kept_indices=[0])
 

--- a/uv.lock
+++ b/uv.lock
@@ -3324,12 +3324,15 @@ dependencies = [
     { name = "fastapi", version = "0.128.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "fastapi", version = "0.135.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic" },
+    { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "python-multipart", version = "0.0.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "uvicorn", version = "0.42.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3340,11 +3343,13 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.5" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "uvicorn", specifier = ">=0.32.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "ruff", specifier = ">=0.7.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -3182,7 +3182,7 @@ dependencies = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "python-multipart", version = "0.0.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "requests" },
     { name = "scikit-learn", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3325,7 +3325,7 @@ dependencies = [
     { name = "fastapi", version = "0.135.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic" },
     { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "python-multipart", version = "0.0.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "uvicorn", version = "0.42.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -3343,7 +3343,8 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.5" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "python-multipart", specifier = ">=0.0.18" },
+    { name = "python-multipart", marker = "python_full_version < '3.10'", specifier = ">=0.0.20" },
+    { name = "python-multipart", marker = "python_full_version >= '3.10'", specifier = ">=0.0.31" },
     { name = "uvicorn", specifier = ">=0.32.1" },
 ]
 
@@ -6104,7 +6105,7 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -6113,9 +6114,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version == '3.10.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes LIG-10691.

## What has changed and why?

The substance of `lightly-studio-embed`: the wire models, the embedder base classes and `serve()`.

- **`protocol.py`** — request/response bodies, wire capability strings, every route path. The shared definition: `lightly-studio` will import it, so client and server validate one contract.
- **`embedder.py`** — `BaseEmbedder` (`space_key`, `dimension`, `ready`) plus one class per capability. The signatures mirror `lightly_studio/embed/embedder.py`; the duplication is deliberate, as this package cannot depend on `lightly-studio`.
- **`server.py`** — `serve()` mounts `/v1/describe` plus exactly the endpoints the embedder implements, so a text-only model exposes no image routes. Optional TLS, `max_batch_size` (413), 501 for a capability left unfinished, 503 while `ready` is false.
- **`middleware.py`** — the bearer token and the body ceiling are enforced at the ASGI layer, ahead of routing, because FastAPI parses a body before it solves dependencies: as dependencies, both checks would arrive after an untrusted peer had already decided how much the server buffers. The token is compared as raw bytes, and the body is counted as it streams, so a chunked request without `Content-Length` is bounded too.
- **`validation.py`** — row count, width against the declared `dimension`, finite values and integral indices are checked before a response leaves, so a broken embedder fails in the customer's own process rather than inside LightlyStudio.
- **The URL transports stay unmounted.** They keep their capability strings, paths and request model, but `RemoteEmbedder` (LIG-10641) will not call them, so mounting them would be dead code. Additive later, since capabilities are advertised.
- `python-multipart` joins the dependencies (starlette parses the bytes endpoints with it), `httpx` the dev group (the FastAPI test client).

## Notes for the reviewer

- The `python-multipart` floor is the first release past the parser DoS advisories. Python 3.9 cannot reach it — 0.0.20 is the last release supporting 3.9 — so it is pinned there and the comment calls out the exposure. Dropping 3.9 for this package is the open question; `requires-python` currently matches `lightly-studio`.
- Crops get no endpoint: LightlyStudio crops with a margin and posts to `images/bytes`.
- `lightly-studio` still does not depend on this package. The client is LIG-10641.
- Alternative reviewer: @lukas-lightly.

## How has it been tested?

40 tests over a `TestClient` cover the acceptance criteria: route mounting per capability, `ready`, auth ordering, both 413s, 501, a per-item skip, the dimension rejection and the index checks. `make static-checks` and `make test` pass on 3.9 and 3.14.

Also smoke-tested against real `serve()` processes: `/v1/describe`, `/v1/embed/texts` and a multipart `/v1/embed/images/bytes` all answer, 401 without the key, 404 for the video route the model does not implement; a chunked 13 MB body is cut off with 413 after the first 64 KB; and HTTPS answers with a self-signed certificate while plain HTTP to the same port is refused.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
