### PR TITLE
Fix: Calculate only the metadata field being viewed in backend

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -61,6 +61,9 @@ class MetadataHistogramsRequest(BaseModel):
     bin_count: int = Field(
         _DEFAULT_BIN_COUNT, ge=1, le=200, description="Number of equal-width bins per histogram"
     )
+    fields: list[str] | None = Field(
+        None, description="Numeric fields to histogram; all numeric fields are computed when absent"
+    )
 
 
 @metadata_router.post("/metadata/histograms", response_model=dict[str, HistogramView])
@@ -69,7 +72,7 @@ def get_metadata_histograms(
     collection_id: Annotated[UUID, Path(title="collection Id")],
     request: MetadataHistogramsRequest | None = None,
 ) -> dict[str, HistogramView]:
-    """Compute value-distribution histograms for all numeric metadata keys.
+    """Compute value-distribution histograms for selected numeric metadata keys.
 
     Bin edges always span the full (unfiltered) value range of each key so the
     chart axis stays stable; the counts reflect the given filters. Each key's
@@ -79,7 +82,7 @@ def get_metadata_histograms(
     Args:
         session: The database session.
         collection_id: The ID of the collection.
-        request: Optional request body carrying the active sample filters.
+        request: Optional request body carrying the active sample filters and bin count.
 
     Returns:
         Mapping of metadata key to its histogram.
@@ -89,6 +92,7 @@ def get_metadata_histograms(
         collection_id=collection_id,
         filters=request.filters if request else None,
         bin_count=request.bin_count if request else _DEFAULT_BIN_COUNT,
+        fields=request.fields if request else None,
     )
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -72,8 +72,9 @@ def get_metadata_histograms(
     collection_id: UUID,
     filters: ImageFilter | None = None,
     bin_count: int = _HISTOGRAM_BIN_COUNT,
+    fields: list[str] | None = None,
 ) -> dict[str, HistogramView]:
-    """Compute value-distribution histograms for all numeric metadata keys.
+    """Compute value-distribution histograms for selected numeric metadata keys.
 
     Bin edges always span the full (unfiltered) value range of each key, so
     the chart's x-axis stays stable while the counts change with the active
@@ -86,6 +87,7 @@ def get_metadata_histograms(
         collection_id: The collection's UUID.
         filters: Optional sample filters restricting which values are counted.
         bin_count: Number of equal-width bins per histogram.
+        fields: Optional numeric metadata keys to include; unknown and nonnumeric keys are ignored.
 
     Returns:
         Mapping of metadata key to its histogram.
@@ -94,7 +96,7 @@ def get_metadata_histograms(
 
     histograms: dict[str, HistogramView] = {}
     for key, metadata_type in merged.items():
-        if metadata_type not in NUMERIC_TYPE_NAMES:
+        if metadata_type not in NUMERIC_TYPE_NAMES or (fields is not None and key not in fields):
             continue
         stats = _get_metadata_min_max_count(
             session=session, collection_id=collection_id, metadata_key=key

--- a/lightly_studio/tests/metadata/test_get_metadata_histograms.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_histograms.py
@@ -68,6 +68,14 @@ def test_get_metadata_histograms__unfiltered_matches_totals(db_session: Session)
     assert score.bin_edges[-1] == pytest.approx(9.0)
     assert sum(score.counts) == 10
 
+    selected = get_metadata_info.get_metadata_histograms(
+        session=db_session,
+        collection_id=collection.collection_id,
+        fields=["score", "location", "score"],
+    )
+    assert set(selected) == {"score"}
+    assert selected["score"] == score
+
 
 def test_get_metadata_histograms__filter_reduces_counts_keeps_edges(
     db_session: Session,


### PR DESCRIPTION
## What has changed and why?

Follow up PR based on this PR here: #2226 

- The backend calculated distributions for every metadata field for each selected tag, even though the GUI showed only one.
- Add field selection so it calculates only the field the user is viewing.
- Testing on various datasets (100k samples) showed up to 4.9× faster backend processing.

There will be a separate frontend PR to wire this into the GUI.

## How has it been tested?

- Updated tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Metadata histogram requests can now target specific numeric metadata fields instead of processing all available fields.
  - Unknown, nonnumeric, and duplicate field entries are handled automatically, with results limited to valid selections.

- **Tests**
  - Added coverage confirming filtered histograms match unfiltered results and return only the requested valid field data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->