### PR TITLE
Add: Dataset split preview and validation helpers

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetSplit/splitPreview.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/splitPreview.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { getSplitCounts, getSplitError } from './splitPreview';
+
+const splits = [
+    { tag_name: 'train', relative_size: 8 },
+    { tag_name: 'val', relative_size: 1 },
+    { tag_name: 'test', relative_size: 1 }
+];
+const defaultParams = { splits, sampleCount: 11, existingTagNames: [] };
+
+describe('getSplitCounts', () => {
+    it.each([
+        { sampleCount: 11, weights: [8, 1, 1], expected: [9, 1, 1] },
+        { sampleCount: 5, weights: [1, 1], expected: [3, 2] },
+        { sampleCount: 5, weights: [1, 2, 3], expected: [1, 2, 2] },
+        { sampleCount: 3, weights: [100, 1, 1], expected: [3, 0, 0] },
+        {
+            sampleCount: 5,
+            weights: [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+            expected: [3, 2]
+        }
+    ])(
+        'allocates $sampleCount samples with weights $weights',
+        ({ sampleCount, weights, expected }) => {
+            const rows = weights.map((relative_size, index) => ({
+                tag_name: `${index}`,
+                relative_size
+            }));
+            const counts = getSplitCounts(sampleCount, rows);
+            expect(counts).toEqual(expected);
+            expect(counts.reduce((total, count) => total + count, 0)).toBe(sampleCount);
+        }
+    );
+});
+
+describe('getSplitError', () => {
+    it('accepts trimmed, case-sensitive names and zero-count rows', () => {
+        expect(
+            getSplitError({
+                splits: [
+                    { tag_name: ' train ', relative_size: 100 },
+                    { tag_name: 'Train', relative_size: 1 }
+                ],
+                sampleCount: 2,
+                existingTagNames: ['TRAIN']
+            })
+        ).toBeUndefined();
+    });
+
+    it.each([0, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1])(
+        'rejects weight %s',
+        (relative_size) => {
+            expect(
+                getSplitError({
+                    ...defaultParams,
+                    splits: [{ ...splits[0], relative_size }, ...splits.slice(1)]
+                })
+            ).toContain('Weights must be positive whole numbers');
+        }
+    );
+
+    it.each([
+        { names: [' ', 'val'], existingTagNames: [], error: 'Enter a name' },
+        { names: ['train', ' train '], existingTagNames: [], error: 'different name' },
+        { names: [' train ', 'val'], existingTagNames: ['train'], error: 'already exists' },
+        { names: ['train'], existingTagNames: [], error: 'At least two' },
+        { names: [], existingTagNames: [], error: 'At least two' }
+    ])('rejects invalid names or row counts: $names', ({ names, existingTagNames, error }) => {
+        expect(
+            getSplitError({
+                ...defaultParams,
+                splits: names.map((tag_name) => ({ tag_name, relative_size: 1 })),
+                existingTagNames
+            })
+        ).toContain(error);
+    });
+
+    it.each([0, 2])('rejects insufficient scope size %s', (sampleCount) => {
+        expect(getSplitError({ ...defaultParams, sampleCount })).toContain('matching samples');
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetSplit/splitPreview.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/splitPreview.ts
@@ -1,0 +1,54 @@
+interface Split {
+    tag_name: string;
+    relative_size: number;
+}
+
+interface SplitValidationParams {
+    splits: Split[];
+    sampleCount: number;
+    existingTagNames: string[];
+}
+
+/** Return the first name, weight, or sample-count error, or undefined when valid. */
+export function getSplitError({
+    splits,
+    sampleCount,
+    existingTagNames
+}: SplitValidationParams): string | undefined {
+    if (splits.length < 2) return 'At least two splits are required.';
+    const names = splits.map((split) => split.tag_name.trim());
+    if (names.some((name) => !name)) return 'Enter a name for every split.';
+    if (new Set(names).size !== names.length) return 'Use a different name for each split.';
+    if (names.some((name) => existingTagNames.includes(name)))
+        return 'A tag with this name already exists.';
+    if (
+        splits.some(
+            ({ relative_size }) => !Number.isSafeInteger(relative_size) || relative_size <= 0
+        )
+    )
+        return 'Weights must be positive whole numbers within the supported range.';
+    if (!Number.isSafeInteger(sampleCount) || sampleCount < splits.length)
+        return 'There must be at least as many matching samples as splits.';
+    return undefined;
+}
+
+/**
+ * Return sample counts in split order, matching the backend's weighted allocation.
+ * Round shares down, then give leftover samples to the largest remainders; ties favor earlier rows.
+ * Call only after getSplitError has validated the form.
+ */
+export function getSplitCounts(sampleCount: number, splits: Split[]): number[] {
+    // Integer arithmetic keeps large weighted shares exact, matching the backend.
+    const weights = splits.map((split) => BigInt(split.relative_size));
+    const totalWeight = weights.reduce((total, weight) => total + weight, 0n);
+    const shares = weights.map((weight) => BigInt(sampleCount) * weight);
+    const counts = shares.map((share) => Number(share / totalWeight));
+    const remaining = sampleCount - counts.reduce((total, count) => total + count, 0);
+    const ranked = shares.map((share, index) => ({ index, remainder: share % totalWeight }));
+    // Equal remainders favor earlier rows, as in the backend allocation.
+    ranked.sort((a, b) =>
+        a.remainder === b.remainder ? a.index - b.index : a.remainder > b.remainder ? -1 : 1
+    );
+    for (const { index } of ranked.slice(0, remaining)) counts[index] += 1;
+    return counts;
+}


### PR DESCRIPTION
## What has changed and why?

Simple helper function required for the dataset split feature in the frontend. We want to calculate the splits based on user input (e.g. how many images go to train/validation/test set). The helper functions provide basic error handling so the user can't override an existing tag etc.

- Calculate sample counts for each split.
- Check split names, weights, and available samples.

## How has it been tested?

- New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for dataset splits, including split names, duplicate tags, weights, sample counts, and available scope.
  - Added weighted sample allocation across splits while preserving the total sample count.
  - Added clear handling for invalid configurations and edge cases such as zero-result splits.

- **Tests**
  - Added coverage for weighted allocation, validation rules, duplicate names, insufficient data, and boundary-value inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->