### PR TITLE
Add: Dataset split dialog and preview

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
@@ -10,7 +10,10 @@
         existingTagNames: string[];
         pending?: boolean;
         error?: string;
-        onSubmit: (values: { splits: Parameters<typeof getSplitCounts>[1]; seed?: number }) => void;
+        onSubmit: (values: {
+            splits: Parameters<typeof getSplitCounts>[1];
+            seed?: number;
+        }) => void | Promise<void>;
         onClose: () => void;
     }
 
@@ -37,13 +40,20 @@
     const validationError = $derived(splitError || seedError);
     const counts = $derived(splitError ? [] : getSplitCounts(sampleCount, splits));
 
-    function submit(event: SubmitEvent) {
+    let submitting = false;
+
+    async function submit(event: SubmitEvent) {
         event.preventDefault();
-        if (pending || validationError) return;
-        onSubmit({
-            splits: splits.map((split) => ({ ...split, tag_name: split.tag_name.trim() })),
-            ...(seed.trim() ? { seed: Number(seed) } : {})
-        });
+        if (submitting || pending || validationError) return;
+        submitting = true;
+        try {
+            await onSubmit({
+                splits: splits.map((split) => ({ ...split, tag_name: split.tag_name.trim() })),
+                ...(seed.trim() ? { seed: Number(seed) } : {})
+            });
+        } finally {
+            submitting = false;
+        }
     }
 </script>
 

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button';
+    import * as Dialog from '$lib/components/ui/dialog';
+    import { Input } from '$lib/components/ui/input';
+    import { getSplitCounts, getSplitError } from '../splitPreview';
+    import DatasetSplitRow from './DatasetSplitRow/DatasetSplitRow.svelte';
+
+    interface Props {
+        sampleCount: number;
+        existingTagNames: string[];
+        pending?: boolean;
+        error?: string;
+        onSubmit: (values: { splits: Parameters<typeof getSplitCounts>[1]; seed?: number }) => void;
+        onClose: () => void;
+    }
+
+    let {
+        sampleCount,
+        existingTagNames,
+        pending = false,
+        error,
+        onSubmit,
+        onClose
+    }: Props = $props();
+    let splits = $state([
+        { tag_name: 'train', relative_size: 8 },
+        { tag_name: 'val', relative_size: 1 },
+        { tag_name: 'test', relative_size: 1 }
+    ]);
+    let seed = $state('');
+    const splitError = $derived(getSplitError({ splits, sampleCount, existingTagNames }));
+    const seedError = $derived(
+        seed.trim() && !Number.isSafeInteger(Number(seed))
+            ? 'Seed must be a whole number within the supported range.'
+            : undefined
+    );
+    const validationError = $derived(splitError || seedError);
+    const counts = $derived(splitError ? [] : getSplitCounts(sampleCount, splits));
+
+    function submit(event: SubmitEvent) {
+        event.preventDefault();
+        if (pending || validationError) return;
+        onSubmit({
+            splits: splits.map((split) => ({ ...split, tag_name: split.tag_name.trim() })),
+            ...(seed.trim() ? { seed: Number(seed) } : {})
+        });
+    }
+</script>
+
+<Dialog.Root open onOpenChange={(open) => !open && onClose()}>
+    <Dialog.Content>
+        <Dialog.Header>
+            <Dialog.Title>Split dataset</Dialog.Title>
+            <Dialog.Description>
+                Split {sampleCount} matching samples into three tags using relative weights.
+            </Dialog.Description>
+        </Dialog.Header>
+        <form onsubmit={submit} novalidate class="space-y-4">
+            <fieldset disabled={pending} class="space-y-3">
+                {#each splits as split, index (split)}
+                    <DatasetSplitRow bind:split={splits[index]} {index} count={counts[index]} />
+                {/each}
+                <label class="block space-y-1 text-sm">
+                    Seed (optional)
+                    <Input bind:value={seed} placeholder="Random" />
+                </label>
+            </fieldset>
+            {#if validationError || error}
+                <p role="alert" class="text-sm text-destructive">{validationError || error}</p>
+            {/if}
+            <Dialog.Footer>
+                <Button type="button" variant="ghost" onclick={onClose}>Cancel</Button>
+                <Button type="submit" disabled={pending || !!validationError}>
+                    {pending ? 'Splitting…' : 'Split dataset'}
+                </Button>
+            </Dialog.Footer>
+        </form>
+    </Dialog.Content>
+</Dialog.Root>

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.test.ts
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import DatasetSplitDialog from './DatasetSplitDialog.svelte';
+
+const defaultProps = {
+    sampleCount: 11,
+    existingTagNames: [],
+    onSubmit: vi.fn(),
+    onClose: vi.fn()
+};
+
+describe('DatasetSplitDialog', () => {
+    it('updates counts and submits trimmed names with an optional seed', async () => {
+        const onSubmit = vi.fn();
+        render(DatasetSplitDialog, { ...defaultProps, onSubmit });
+        expect(screen.getByLabelText('Split 1 sample count')).toHaveTextContent('9 samples');
+        await fireEvent.input(screen.getByLabelText('Tag 1'), { target: { value: ' training ' } });
+        await fireEvent.input(screen.getByLabelText('Weight 1'), { target: { value: '1' } });
+        expect(screen.getByLabelText('Split 1 sample count')).toHaveTextContent('4 samples');
+        expect(screen.getByLabelText('Split 2 sample count')).toHaveTextContent('4 samples');
+        expect(screen.getByLabelText('Split 3 sample count')).toHaveTextContent('3 samples');
+        const button = screen.getByRole('button', { name: 'Split dataset' });
+        await fireEvent.click(button);
+        const splits = ['training', 'val', 'test'].map((tag_name) => ({
+            tag_name,
+            relative_size: 1
+        }));
+        expect(onSubmit).toHaveBeenLastCalledWith({ splits });
+        await fireEvent.input(screen.getByLabelText('Seed (optional)'), {
+            target: { value: '-7' }
+        });
+        await fireEvent.click(button);
+        expect(onSubmit).toHaveBeenLastCalledWith({ splits, seed: -7 });
+    });
+
+    it.each([
+        ['Tag 1', 'val', 'different name'],
+        ['Tag 1', 'existing', 'already exists'],
+        ['Weight 1', '', 'positive whole numbers'],
+        ['Seed (optional)', '1.5', 'Seed must be a whole number'],
+        ['Seed (optional)', 'invalid', 'Seed must be a whole number']
+    ])('blocks invalid input in %s: %s', async (label, value, message) => {
+        const onSubmit = vi.fn();
+        render(DatasetSplitDialog, { ...defaultProps, existingTagNames: ['existing'], onSubmit });
+        await fireEvent.input(screen.getByLabelText(label), { target: { value } });
+        expect(screen.getByRole('alert')).toHaveTextContent(message);
+        expect(screen.getByRole('button', { name: 'Split dataset' })).toBeDisabled();
+        await fireEvent.submit(
+            screen.getByRole('button', { name: 'Split dataset' }).closest('form')!
+        );
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('blocks pending submissions and preserves values after an error', async () => {
+        const onSubmit = vi.fn();
+        const onClose = vi.fn();
+        const { rerender } = render(DatasetSplitDialog, { ...defaultProps, onSubmit, onClose });
+        await fireEvent.input(screen.getByLabelText('Tag 1'), { target: { value: 'training' } });
+        await rerender({ pending: true });
+        const button = screen.getByRole('button', { name: 'Splitting…' });
+        expect(button).toBeDisabled();
+        await fireEvent.submit(button.closest('form')!);
+        expect(onSubmit).not.toHaveBeenCalled();
+        await rerender({ pending: false, error: 'Unable to split dataset.' });
+        expect(screen.getByRole('alert')).toHaveTextContent('Unable to split dataset.');
+        expect(screen.getByLabelText('Tag 1')).toHaveValue('training');
+        await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitRow/DatasetSplitRow.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitRow/DatasetSplitRow.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+    import { Input } from '$lib/components/ui/input';
+    import { getSplitCounts } from '../../splitPreview';
+
+    interface Props {
+        split: Parameters<typeof getSplitCounts>[1][number];
+        index: number;
+        count?: number;
+    }
+
+    let { split = $bindable(), index, count }: Props = $props();
+</script>
+
+<div class="grid grid-cols-3 items-end gap-3 text-sm">
+    <label class="space-y-1">
+        Tag {index + 1}
+        <Input bind:value={split.tag_name} />
+    </label>
+    <label class="space-y-1">
+        Weight {index + 1}
+        <Input type="number" min={1} step={1} bind:value={split.relative_size} />
+    </label>
+    <p aria-label={`Split ${index + 1} sample count`}>{count ?? '—'} samples</p>
+</div>


### PR DESCRIPTION
## What has changed and why?

- Add three editable splits with live sample counts.
- Validate names, weights, and an optional random seed.
- Prevent repeated submissions and preserve edits after errors.

builds up on #2245 

## How has it been tested?

- new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dataset split dialog for dividing datasets into train, validation, and test tags using configurable weights.
  * Added editable split rows with optional sample-count previews.
  * Added optional random seed support.
  * Added validation for duplicate or reserved tags, invalid weights, and non-integer seeds.
  * Added submission safeguards to prevent duplicate submissions while processing and preserve entered values after errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->