### PR TITLE
Share the embedder base classes with lightly-studio (embed server stack 1/4)

### DIFF
--- a/lightly_studio/pyproject.toml
+++ b/lightly_studio/pyproject.toml
@@ -61,7 +61,14 @@ dependencies = [
     # Pinned below 7.0, which dropped Python 3.9. 6.9 covers every Python this package supports,
     # so one major runs everywhere rather than two that have to stay behaviourally identical.
     "posthog>=6.9,<7.0",
+    # The embedder base classes and the value types they pass live here, so a customer's own
+    # server and LightlyStudio's in-process embedders derive from one definition. Resolved
+    # from the workspace, so the two cannot drift apart between releases.
+    "lightly-studio-embed",
 ]
+
+[tool.uv.sources]
+lightly-studio-embed = { workspace = true }
 
 [project.scripts]
 lightly-studio = "lightly_studio.cli:main"

--- a/lightly_studio/src/lightly_studio/embed/embedder.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder.py
@@ -1,19 +1,51 @@
 """Capability-split embedder interfaces.
 
-Defines the ``Embedder`` base class and one abstract subclass per input a model
-can embed: images and crops by path, videos, PIL images, text, and images by
-bytes. A concrete model implements only the capabilities it supports, and
-callers pick an embedder by the capability they need.
+Defines one abstract subclass per input a model can embed: images and crops by
+path, videos, PIL images, text, and images by bytes. A concrete model implements
+only the capabilities it supports, and callers pick an embedder by the capability
+they need.
+
+``Embedder`` and the capabilities a remote model can serve over HTTP
+(``TextEmbedder``, ``ImageBytesEmbedder``, ``VideoBytesEmbedder``) come from
+``lightly-studio-embed`` and are re-exported here, so an embedder written against
+that package is the same type as one written against this one. The capabilities
+below it are local only: they take an fsspec path or a PIL image, neither of which
+crosses the wire.
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from enum import Enum
 
+from lightly_studio_embed.embedder import (
+    BaseEmbedder,
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
 from PIL.Image import Image
 
-from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec, ImageCrop
+from lightly_studio.embed.types import EmbeddingResult, ImageCrop
+
+# The base class is named for its role in the customer-facing package; inside
+# LightlyStudio it has always been `Embedder`, and that name is public API.
+Embedder = BaseEmbedder
+
+# TODO(Michal, 09/2026): `ImageBytesEmbedder` is currently unused in-process. The
+# interactive path creates a temp file and uses `ImagePathEmbedder`.
+
+__all__ = [
+    "Capability",
+    "Embedder",
+    "ImageBytesEmbedder",
+    "ImageCropPathEmbedder",
+    "ImagePILEmbedder",
+    "ImagePathEmbedder",
+    "TextEmbedder",
+    "VideoBytesEmbedder",
+    "VideoPathEmbedder",
+]
 
 
 class Capability(str, Enum):
@@ -45,27 +77,6 @@ class Capability(str, Enum):
 
     VIDEO_BYTES = "video_bytes"
     """Ingest: video as raw file bytes. No local implementation yet."""
-
-
-class Embedder(ABC):
-    """Base class for every embedder.
-
-    <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Subclasses add one abstract method per input they support. A concrete model
-    implements the subclasses for the capabilities it provides.
-    """
-
-    __slots__ = ()
-
-    @abstractmethod
-    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
-        """Describe the embedding space this embedder produces.
-
-        Returns:
-            Metadata identifying the embedding space, stored so the same space
-            can be recognized across LightlyStudio runs.
-        """
 
 
 class ImagePathEmbedder(Embedder):
@@ -146,48 +157,3 @@ class ImagePILEmbedder(Embedder):
         Returns:
             The embeddings and the indices of the inputs they cover.
         """
-
-
-class TextEmbedder(Embedder):
-    """Embeds text queries.
-
-    <span class="doc-badge doc-badge--beta">Beta</span>
-    """
-
-    __slots__ = ()
-
-    @abstractmethod
-    def embed_text(self, texts: list[str]) -> EmbeddingResult:
-        """Embed a batch of text strings.
-
-        Args:
-            texts: The strings to embed.
-
-        Returns:
-            The embeddings and the indices of the inputs they cover.
-        """
-
-
-class ImageBytesEmbedder(Embedder):
-    """Embeds images passed as raw bytes.
-
-    <span class="doc-badge doc-badge--beta">Beta</span>
-
-    For callers that have no path to read, such as an upload. JPEG, PNG and
-    WebP only.
-    """
-
-    __slots__ = ()
-
-    @abstractmethod
-    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
-        """Embed a batch of images given as encoded bytes.
-
-        Args:
-            images: Encoded image bytes (JPEG, PNG or WebP).
-
-        Returns:
-            The embeddings and the indices of the inputs they cover.
-        """
-        # TODO(Michal, 09/2026): Currently unused. The interactive path creates a temp
-        # file and uses ImagePathEmbedder.

--- a/lightly_studio/src/lightly_studio/embed/types.py
+++ b/lightly_studio/src/lightly_studio/embed/types.py
@@ -4,57 +4,21 @@ Holds the model-agnostic types passed to and returned by embedders:
 ``EmbeddingSpaceSpec``, ``EmbeddingResult`` and ``ImageCrop``. They live in their
 own module so any caller can depend on them without importing the ``Embedder``
 classes.
+
+``EmbeddingSpaceSpec`` and ``EmbeddingResult`` are imported from
+``lightly-studio-embed`` and re-exported here: a customer serving their own model
+implements the same two types, so one definition keeps the two sides comparable.
+``ImageCrop`` stays local, as an fsspec path is resolved with LightlyStudio's
+credentials and so never crosses the wire.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-import numpy as np
-from numpy.typing import NDArray
+from lightly_studio_embed.types import EmbeddingResult, EmbeddingSpaceSpec
 
-
-@dataclass(frozen=True)
-class EmbeddingSpaceSpec:
-    """Identity and shape of the embedding space an embedder produces.
-
-    <span class="doc-badge doc-badge--beta">Beta</span>
-
-    Stored in the database so the same embedding space can be recognized across
-    LightlyStudio runs.
-    """
-
-    space_key: str
-    """Stable identifier for the embedding space.
-
-    Two embedders that share a ``space_key`` are treated as producing the same
-    embedding space, so their vectors are comparable. Change it whenever the
-    produced vectors become incomparable, e.g. for a model version change. Can be
-    any string, e.g. ``your-company/model-family@version``.
-    """
-
-    dimension: int
-    """Length of each embedding vector this embedder produces."""
-
-
-@dataclass(frozen=True)
-class EmbeddingResult:
-    """Embeddings for the inputs that could be read, plus which inputs they cover.
-
-    <span class="doc-badge doc-badge--beta">Beta</span>
-
-    An embedder skips broken inputs (files it cannot read or decode) instead of
-    failing the whole batch, so ``embeddings`` can have fewer rows than the input
-    list. ``kept_indices`` gives the position of each row in the input list, in
-    input order. Use it to line up the embeddings with any per-input data you keep
-    on the side, such as sample IDs.
-    """
-
-    embeddings: NDArray[np.float32]
-    """Float32 array of shape ``(len(kept_indices), embedding_dimension)``."""
-
-    kept_indices: list[int]
-    """Indices into the input list of the inputs that were embedded, in input order."""
+__all__ = ["EmbeddingResult", "EmbeddingSpaceSpec", "ImageCrop"]
 
 
 @dataclass(frozen=True)

--- a/lightly_studio_embed/Makefile
+++ b/lightly_studio_embed/Makefile
@@ -12,12 +12,9 @@ build: clean
 	@echo "Building a distribution package..."
 	uv build --package lightly-studio-embed --out-dir dist
 
-# Exit code 5 is "no tests collected". The package has no code to test yet, and any real
-# failure still fails the target.
-# TODO(Iunir, 09/2026): Drop the exit code 5 tolerance once the package has tests.
 .PHONY: test
 test:
 	@echo "Running tests..."
-	uv run pytest || [ $$? -eq 5 ]
+	uv run pytest
 
 include ../make/python.mk

--- a/lightly_studio_embed/README.md
+++ b/lightly_studio_embed/README.md
@@ -3,11 +3,13 @@
 Serve your own embedding model to [LightlyStudio](https://github.com/lightly-ai/lightly-studio)
 over HTTP, so that your model's weights never leave your machine.
 
-The package deliberately depends on nothing but an HTTP server, so that it installs next to your
-own CUDA and torch pins.
+The package depends on an HTTP server and numpy, and deliberately nothing else — no torch, no
+CUDA, no LightlyStudio — so that it installs next to your own pins. Numpy is there because
+`EmbeddingResult` is shared with `lightly-studio`, whose ingest paths index the array.
 
-There is no public API yet, and nothing is published to PyPI: this only reserves the package. Once
-it is released, installing it will be:
+The wire models of the protocol and the embedder base classes live in
+`lightly_studio_embed.protocol` and `lightly_studio_embed.embedder`. There is no server yet, and
+nothing is published to PyPI. Once it is released, installing it will be:
 
 ```bash
 pip install lightly-studio-embed

--- a/lightly_studio_embed/pyproject.toml
+++ b/lightly_studio_embed/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
 # torch pins, so anything heavier would fight them.
 dependencies = [
     "fastapi>=0.115.5",
+    # `EmbeddingResult.embeddings` is a numpy array, because `lightly-studio` imports that
+    # class from here and its ingest paths index and slice it. The floor is the last release
+    # supporting Python 3.9, so one floor covers everything `requires-python` allows.
+    "numpy>=1.26.4",
     "pydantic>=2.0",
     "uvicorn>=0.32.1",
 ]

--- a/lightly_studio_embed/src/lightly_studio_embed/__init__.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/__init__.py
@@ -1,1 +1,37 @@
 """Serve your own embedding model to LightlyStudio over HTTP."""
+
+from lightly_studio_embed.embedder import (
+    BaseEmbedder,
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
+from lightly_studio_embed.errors import CapabilityNotImplementedError, EmbedderContractError
+from lightly_studio_embed.protocol import (
+    PROTOCOL_VERSION,
+    DescribeResponse,
+    EmbeddingsResponse,
+    EmbedTextsRequest,
+    EmbedUrlsRequest,
+    ServerLimits,
+    WireCapability,
+)
+from lightly_studio_embed.types import EmbeddingResult, EmbeddingSpaceSpec
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "BaseEmbedder",
+    "CapabilityNotImplementedError",
+    "DescribeResponse",
+    "EmbedTextsRequest",
+    "EmbedUrlsRequest",
+    "EmbedderContractError",
+    "EmbeddingResult",
+    "EmbeddingSpaceSpec",
+    "EmbeddingsResponse",
+    "ImageBytesEmbedder",
+    "ServerLimits",
+    "TextEmbedder",
+    "VideoBytesEmbedder",
+    "WireCapability",
+]

--- a/lightly_studio_embed/src/lightly_studio_embed/embedder.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/embedder.py
@@ -1,0 +1,118 @@
+"""Base classes a model is wrapped in to be served.
+
+``BaseEmbedder`` carries the identity of the embedding space. One subclass per
+input kind adds the method that embeds it, so a model implements only what it
+supports and ``serve`` mounts exactly the matching endpoints.
+
+These are the same classes LightlyStudio's own embedders derive from:
+``lightly_studio.embed.embedder`` imports them from here and adds the capabilities
+that only make sense in-process, such as reading an fsspec path.
+
+A method that is mounted but unfinished raises
+``lightly_studio_embed.CapabilityNotImplementedError``, which the server answers
+501. Every other error is a failure of the model and answers 500.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from lightly_studio_embed.types import EmbeddingResult, EmbeddingSpaceSpec
+
+
+class BaseEmbedder(ABC):
+    """Identity of the embedding space a model produces.
+
+    <span class="doc-badge doc-badge--beta">Beta</span>
+
+    Subclass one or more of the capability classes below rather than this class
+    directly: an embedder with no capability serves no embeddings.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        """Describe the embedding space this embedder produces.
+
+        Returns:
+            Metadata identifying the embedding space, stored so the same space
+            can be recognized across LightlyStudio runs.
+        """
+
+    @property
+    def ready(self) -> bool:
+        """Whether the model is loaded and can answer requests.
+
+        The default suits a model loaded by the time the object exists. Override it
+        when the model loads in the background: while it is ``False``,
+        ``/v1/describe`` reports ``ready: false`` and the embed endpoints answer 503
+        instead of running a half-loaded model.
+        """
+        return True
+
+
+class TextEmbedder(BaseEmbedder):
+    """Embeds text queries.
+
+    <span class="doc-badge doc-badge--beta">Beta</span>
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        """Embed a batch of text strings.
+
+        Args:
+            texts: The strings to embed.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+
+
+class ImageBytesEmbedder(BaseEmbedder):
+    """Embeds images passed as raw bytes.
+
+    <span class="doc-badge doc-badge--beta">Beta</span>
+
+    Annotation crops arrive here too: LightlyStudio crops with a margin and posts
+    the result, so an image-capable embedder supports them with no extra work.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
+        """Embed a batch of images given as encoded bytes.
+
+        Sniff the format from the header rather than trusting the caller. JPEG, PNG
+        and WebP are the formats the protocol allows.
+
+        Args:
+            images: Encoded image bytes.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """
+
+
+class VideoBytesEmbedder(BaseEmbedder):
+    """Embeds videos passed as raw bytes.
+
+    <span class="doc-badge doc-badge--beta">Beta</span>
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def embed_video_bytes(self, videos: list[bytes]) -> EmbeddingResult:
+        """Embed a batch of videos given as encoded bytes.
+
+        Args:
+            videos: Encoded video bytes.
+
+        Returns:
+            The embeddings and the indices of the inputs they cover.
+        """

--- a/lightly_studio_embed/src/lightly_studio_embed/errors.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/errors.py
@@ -1,0 +1,20 @@
+"""The errors an embedder can raise or provoke, in one place."""
+
+from __future__ import annotations
+
+
+class EmbedderContractError(RuntimeError):
+    """Raised when an embedder returns a result the protocol does not allow.
+
+    The server answers 500 and names the problem, rather than shipping the result to
+    LightlyStudio.
+    """
+
+
+class CapabilityNotImplementedError(NotImplementedError):
+    """Raise it from a capability method that is mounted but not finished yet.
+
+    The server answers 501, which tells a client to re-read ``/v1/describe`` instead
+    of retrying. Any other error is a failure of the model, not a retracted
+    capability, and answers 500.
+    """

--- a/lightly_studio_embed/src/lightly_studio_embed/protocol.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/protocol.py
@@ -1,0 +1,147 @@
+"""Wire models of the LightlyStudio embedding protocol, version 1.
+
+Holds the request and response bodies, the capability strings that name the
+endpoints, the paths they are mounted under, and the multipart field the bytes
+endpoints read. This is the shared definition of the contract: the server in this
+package answers with these models and ``lightly-studio`` validates the same ones on
+the client side, so the two halves cannot drift apart.
+
+A capability ``{subject}_{transport}`` is served by
+``POST /v1/embed/{subjects}/{transport}``; ``text`` carries no transport segment
+because text is already a payload.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+PROTOCOL_VERSION = "1.0"
+
+BASE_PATH = "/v1"
+
+DESCRIBE_PATH = f"{BASE_PATH}/describe"
+
+EMBED_TEXTS_PATH = f"{BASE_PATH}/embed/texts"
+
+EMBED_IMAGES_BYTES_PATH = f"{BASE_PATH}/embed/images/bytes"
+
+EMBED_VIDEOS_BYTES_PATH = f"{BASE_PATH}/embed/videos/bytes"
+
+# Specified for a server that implements the URL transports; `serve` mounts neither.
+EMBED_IMAGES_URLS_PATH = f"{BASE_PATH}/embed/images/urls"
+
+EMBED_VIDEOS_URLS_PATH = f"{BASE_PATH}/embed/videos/urls"
+
+# Multipart form field the bytes endpoints read, one part per item in input order.
+FILES_FIELD_NAME = "files"
+
+# Spelled out, because starlette renamed its constant for this status and the old name warns
+# on new versions while the new one is missing on the versions `requires-python` still allows.
+STATUS_PAYLOAD_TOO_LARGE = 413
+
+DEFAULT_MAX_BATCH_SIZE = 64
+
+DEFAULT_MAX_REQUEST_BYTES = 32 * 1024 * 1024
+
+
+class WireCapability(str, Enum):
+    """An input kind an embedding server can accept over HTTP.
+
+    A path is deliberately absent: an fsspec path is resolved with LightlyStudio's
+    credentials, so it never crosses the wire.
+    """
+
+    TEXT = "text"
+    """Text queries, as JSON."""
+
+    IMAGE_BYTES = "image_bytes"
+    """Images as raw file bytes (JPEG, PNG or WebP), as multipart parts."""
+
+    IMAGE_URL = "image_url"
+    """Images the server fetches from presigned URLs. Not served by ``serve`` yet."""
+
+    VIDEO_BYTES = "video_bytes"
+    """Videos as raw file bytes, as multipart parts."""
+
+    VIDEO_URL = "video_url"
+    """Videos the server fetches from presigned URLs. Not served by ``serve`` yet."""
+
+
+class ServerLimits(BaseModel):
+    """Ceilings the server enforces and advertises, so a client need not guess them."""
+
+    max_batch_size: int = Field(default=DEFAULT_MAX_BATCH_SIZE, gt=0)
+    """Largest number of items one request may carry."""
+
+    max_request_bytes: int = Field(default=DEFAULT_MAX_REQUEST_BYTES, gt=0)
+    """Largest request body the server accepts, in bytes."""
+
+
+class DescribeResponse(BaseModel):
+    """Body of ``GET /v1/describe``, the only endpoint every server implements."""
+
+    protocol_version: str = PROTOCOL_VERSION
+    """Version of this contract the server speaks."""
+
+    space_key: str
+    """Identifier of the embedding space the server produces."""
+
+    dimension: int
+    """Length of every embedding vector the server returns."""
+
+    ready: bool
+    """Whether the model is loaded. ``False`` means retry shortly, not broken."""
+
+    capabilities: list[WireCapability]
+    """The input kinds this server accepts. Exactly the endpoints it mounts."""
+
+    limits: ServerLimits
+    """The ceilings a client has to batch against."""
+
+
+class EmbedTextsRequest(BaseModel):
+    """Body of ``POST /v1/embed/texts``."""
+
+    texts: list[str]
+    """The strings to embed, in the order the embeddings are returned for."""
+
+
+class EmbedUrlsRequest(BaseModel):
+    """Body of the URL transports, ``POST /v1/embed/{images,videos}/urls``.
+
+    Defined so that a server implementing them has one definition to validate
+    against, even though ``serve`` mounts no URL route yet.
+    """
+
+    urls: list[str]
+    """Presigned URLs the server fetches, in the order the embeddings are returned for.
+
+    A URL the server cannot fetch is a per-item failure: it is left out of
+    ``kept_indices`` rather than failing the batch.
+    """
+
+
+class EmbeddingsResponse(BaseModel):
+    """Body of every embed endpoint.
+
+    ``space_key`` and ``dimension`` are echoed on each response, because that is the
+    only thing that catches a server whose weights changed without a new
+    ``space_key``.
+    """
+
+    space_key: str
+    """Identifier of the embedding space these vectors belong to."""
+
+    dimension: int
+    """Length of every vector in ``embeddings``."""
+
+    kept_indices: list[int]
+    """Indices of the request items that were embedded, ascending.
+
+    An item the server cannot decode is skipped here instead of failing the batch.
+    """
+
+    embeddings: list[list[float]]
+    """One row per entry in ``kept_indices``, in the same order."""

--- a/lightly_studio_embed/src/lightly_studio_embed/types.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/types.py
@@ -1,0 +1,61 @@
+"""Value types every embedder passes and returns, LightlyStudio's own included.
+
+``EmbeddingSpaceSpec`` names the embedding space a model produces and
+``EmbeddingResult`` carries the vectors it produced. They live in their own module
+so a caller can depend on them without importing the embedder classes.
+
+``lightly-studio`` imports both from here rather than declaring its own, so the
+two packages cannot drift apart. That is also why this package depends on numpy:
+LightlyStudio's ingest paths index and slice ``embeddings`` as an array, and a
+plain nested sequence cannot carry that.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class EmbeddingSpaceSpec:
+    """Identity and shape of the embedding space an embedder produces.
+
+    <span class="doc-badge doc-badge--beta">Beta</span>
+
+    Stored in the database so the same embedding space can be recognized across
+    LightlyStudio runs.
+    """
+
+    space_key: str
+    """Stable identifier for the embedding space.
+
+    Two embedders that share a ``space_key`` are treated as producing the same
+    embedding space, so their vectors are comparable. Change it whenever the
+    produced vectors become incomparable, e.g. for a model version change. Can be
+    any string, e.g. ``your-company/model-family@version``.
+    """
+
+    dimension: int
+    """Length of each embedding vector this embedder produces."""
+
+
+@dataclass(frozen=True)
+class EmbeddingResult:
+    """Embeddings for the inputs that could be read, plus which inputs they cover.
+
+    <span class="doc-badge doc-badge--beta">Beta</span>
+
+    An embedder skips broken inputs (files it cannot read or decode) instead of
+    failing the whole batch, so ``embeddings`` can have fewer rows than the input
+    list. ``kept_indices`` gives the position of each row in the input list, in
+    input order. Use it to line up the embeddings with any per-input data you keep
+    on the side, such as sample IDs.
+    """
+
+    embeddings: NDArray[np.float32]
+    """Float32 array of shape ``(len(kept_indices), embedding_dimension)``."""
+
+    kept_indices: list[int]
+    """Indices into the input list of the inputs that were embedded, in input order."""

--- a/lightly_studio_embed/src/lightly_studio_embed/validation.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/validation.py
@@ -1,0 +1,124 @@
+"""Checks an embedder's result against the contract before it leaves the server.
+
+A wrong dimension or a NaN is far cheaper to find here, in the customer's own
+process, than as a similarity search that misbehaves inside LightlyStudio.
+"""
+
+from __future__ import annotations
+
+import operator
+
+import numpy as np
+from numpy.typing import NDArray
+
+from lightly_studio_embed.errors import EmbedderContractError
+from lightly_studio_embed.protocol import EmbeddingsResponse
+from lightly_studio_embed.types import EmbeddingResult
+
+# Embeddings are one row per kept input, so anything but a matrix is a broken result.
+_EMBEDDINGS_NDIM = 2
+
+
+def build_embeddings_response(
+    *, result: EmbeddingResult, space_key: str, dimension: int, item_count: int
+) -> EmbeddingsResponse:
+    """Validate an embedder's result and convert it into a wire response.
+
+    Args:
+        result: What the embedder returned.
+        space_key: The embedder's embedding space, echoed on the response.
+        dimension: The vector length the embedder declares.
+        item_count: How many items the request carried.
+
+    Returns:
+        The response body for any embed endpoint.
+
+    Raises:
+        EmbedderContractError: If the result does not match the declared dimension,
+            the number of kept indices, or the items of the request.
+    """
+    kept_indices = _as_indices(kept_indices=result.kept_indices)
+    embeddings = _as_array(embeddings=result.embeddings)
+    _validate_kept_indices(kept_indices=kept_indices, item_count=item_count)
+    _validate_embeddings(embeddings=embeddings, kept_count=len(kept_indices), dimension=dimension)
+    return EmbeddingsResponse(
+        space_key=space_key,
+        dimension=dimension,
+        kept_indices=kept_indices,
+        embeddings=embeddings.tolist(),
+    )
+
+
+def _as_indices(*, kept_indices: list[int]) -> list[int]:
+    """Read the kept indices as plain integers, so a non-integral one fails here.
+
+    ``operator.index`` rather than ``int``, which would truncate a float index and line the
+    embeddings up against the wrong request items.
+    """
+    try:
+        return [_as_index(index) for index in kept_indices]
+    except (OverflowError, TypeError, ValueError) as error:
+        raise EmbedderContractError(f"kept_indices must hold integers: {error}") from error
+
+
+def _as_index(index: int) -> int:
+    """Read one kept index, rejecting a bool so a mask cannot pass for a list of indices.
+
+    ``np.bool_`` is checked separately, as it is not a subclass of ``bool`` but
+    ``operator.index`` accepts it.
+    """
+    if isinstance(index, (bool, np.bool_)):
+        raise TypeError(f"{index!r} is a bool, not an index")
+    return operator.index(index)
+
+
+def _as_array(*, embeddings: NDArray[np.float32]) -> NDArray[np.float64]:
+    """Read the embeddings as a float matrix, so a non-numeric or ragged row fails here.
+
+    ``float64`` rather than the declared ``float32``, so a value too large for the
+    narrower type is rejected instead of quietly becoming an infinity.
+    """
+    try:
+        return np.asarray(embeddings, dtype=np.float64)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise EmbedderContractError(
+            f"every embedding must hold numbers, and all rows the same count: {error}"
+        ) from error
+
+
+def _validate_kept_indices(*, kept_indices: list[int], item_count: int) -> None:
+    if any(index < 0 or index >= item_count for index in kept_indices):
+        raise EmbedderContractError(
+            f"kept_indices must point into the {item_count} items of the request, "
+            f"got {kept_indices}."
+        )
+    if any(current >= following for current, following in zip(kept_indices, kept_indices[1:])):
+        raise EmbedderContractError(
+            f"kept_indices must be ascending and unique, got {kept_indices}."
+        )
+
+
+def _validate_embeddings(
+    *, embeddings: NDArray[np.float64], kept_count: int, dimension: int
+) -> None:
+    # An embedder that kept nothing may say so with any empty array, so its width is moot.
+    if kept_count == 0 and embeddings.size == 0:
+        return
+    if embeddings.ndim != _EMBEDDINGS_NDIM:
+        raise EmbedderContractError(
+            f"embeddings must have one row per kept index, so a 2D array, "
+            f"got {embeddings.ndim} dimensions."
+        )
+    rows, values_per_row = embeddings.shape
+    if rows != kept_count:
+        raise EmbedderContractError(
+            f"Got {rows} embeddings for {kept_count} kept indices; "
+            f"the two must have the same length."
+        )
+    if values_per_row != dimension:
+        raise EmbedderContractError(
+            f"Every embedding has {values_per_row} values, but the embedder declares "
+            f"dimension {dimension}."
+        )
+    if not np.isfinite(embeddings).all():
+        raise EmbedderContractError("The embeddings hold a value that is not finite.")

--- a/lightly_studio_embed/tests/test_validation.py
+++ b/lightly_studio_embed/tests/test_validation.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lightly_studio_embed.errors import EmbedderContractError
+from lightly_studio_embed.types import EmbeddingResult
+from lightly_studio_embed.validation import build_embeddings_response
+
+SPACE_KEY = "acme/model@v1"
+
+
+def test_build_embeddings_response() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5], [1.0, 0.0]], dtype=np.float32), kept_indices=[0, 2]
+    )
+
+    response = build_embeddings_response(
+        result=result, space_key=SPACE_KEY, dimension=2, item_count=3
+    )
+
+    assert response.space_key == SPACE_KEY
+    assert response.dimension == 2
+    assert response.kept_indices == [0, 2]
+    assert response.embeddings == [[0.5, -0.5], [1.0, 0.0]]
+
+
+def test_build_embeddings_response__kept_nothing() -> None:
+    """An embedder that could read no input says so with an empty array of any width."""
+    result = EmbeddingResult(embeddings=np.empty((0, 2), dtype=np.float32), kept_indices=[])
+
+    response = build_embeddings_response(
+        result=result, space_key=SPACE_KEY, dimension=2, item_count=2
+    )
+
+    assert response.kept_indices == []
+    assert response.embeddings == []
+
+
+def test_build_embeddings_response__kept_indices_out_of_range() -> None:
+    result = EmbeddingResult(embeddings=np.array([[0.5, -0.5]], dtype=np.float32), kept_indices=[3])
+
+    with pytest.raises(EmbedderContractError, match="must point into the 2 items"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_not_ascending() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5], [1.0, 0.0]], dtype=np.float32), kept_indices=[1, 1]
+    )
+
+    with pytest.raises(EmbedderContractError, match="ascending and unique"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__row_count_mismatch() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32), kept_indices=[0, 1]
+    )
+
+    with pytest.raises(EmbedderContractError, match="1 embeddings for 2 kept indices"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__wrong_dimension() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5, 0.5]], dtype=np.float32), kept_indices=[0]
+    )
+
+    with pytest.raises(EmbedderContractError, match="has 3 values"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__not_a_matrix() -> None:
+    """A flat array of the right size still lines no row up with a kept index."""
+    result = EmbeddingResult(embeddings=np.array([0.5, -0.5], dtype=np.float32), kept_indices=[0])
+
+    with pytest.raises(EmbedderContractError, match="got 1 dimensions"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__value_not_finite() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, np.nan]], dtype=np.float32), kept_indices=[0]
+    )
+
+    with pytest.raises(EmbedderContractError, match="not finite"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__kept_index_not_integral() -> None:
+    """A float index is rejected rather than truncated onto the wrong request item."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=[0.9],  # type: ignore[list-item]
+    )
+
+    with pytest.raises(EmbedderContractError, match="must hold integers"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_are_a_boolean_mask() -> None:
+    """A mask must not pass for indices, which is what bools would convert into."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=[False, True],
+    )
+
+    with pytest.raises(EmbedderContractError, match="is a bool, not an index"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_are_a_numpy_boolean_mask() -> None:
+    """``np.bool_`` is not a ``bool``, but ``operator.index`` would still take it."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=list(np.array([False, True])),
+    )
+
+    with pytest.raises(EmbedderContractError, match="is a bool, not an index"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__ragged_rows() -> None:
+    result = EmbeddingResult(
+        embeddings=[[0.5, -0.5], [1.0]],  # type: ignore[arg-type]
+        kept_indices=[0, 1],
+    )
+
+    with pytest.raises(EmbedderContractError, match="all rows the same count"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__value_too_large_for_a_float() -> None:
+    result = EmbeddingResult(
+        embeddings=[[10**400, 1.0]],  # type: ignore[arg-type]
+        kept_indices=[0],
+    )
+
+    with pytest.raises(EmbedderContractError, match="must hold numbers"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__value_not_a_number() -> None:
+    result = EmbeddingResult(
+        embeddings=[["not a number", 1.0]],  # type: ignore[arg-type]
+        kept_indices=[0],
+    )
+
+    with pytest.raises(EmbedderContractError, match="must hold numbers"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)

--- a/uv.lock
+++ b/uv.lock
@@ -3171,6 +3171,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "labelformat" },
     { name = "lightly-mundig" },
+    { name = "lightly-studio-embed" },
     { name = "open-clip-torch" },
     { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3266,6 +3267,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "labelformat", specifier = ">=0.1.17" },
     { name = "lightly-mundig", specifier = "==0.1.15" },
+    { name = "lightly-studio-embed", editable = "lightly_studio_embed" },
     { name = "open-clip-torch", specifier = ">=2.20.0" },
     { name = "opencv-python-headless", specifier = ">=4.11.0.86" },
     { name = "pandas", specifier = ">=2.2.3,<3.0" },
@@ -3323,6 +3325,9 @@ source = { editable = "lightly_studio_embed" }
 dependencies = [
     { name = "fastapi", version = "0.128.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "fastapi", version = "0.135.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "uvicorn", version = "0.42.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3339,6 +3344,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.5" },
+    { name = "numpy", specifier = ">=1.26.4" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "uvicorn", specifier = ">=0.32.1" },
 ]


### PR DESCRIPTION
## What has changed and why?

Part 1 of a 4-PR stack that splits #2240 (LIG-10691) into reviewable pieces. This one lands the
shared contract and rewires `lightly-studio` onto it, so there is one embedder hierarchy instead
of two that have to be kept behaviourally identical by hand.

**Moved into `lightly-studio-embed`, imported back by `lightly-studio`:**

- **`types.py`** — `EmbeddingSpaceSpec` and `EmbeddingResult`. `lightly_studio.embed.types`
  re-exports both, so `lightly_studio.EmbeddingSpaceSpec` and the docs entry keep working.
- **`embedder.py`** — `BaseEmbedder`, re-exported as `lightly_studio.Embedder`, plus
  `TextEmbedder`, `ImageBytesEmbedder` and `VideoBytesEmbedder`. The base describes its space with
  `embedding_space_spec()`, which is what all six LightlyStudio embedders and generators already
  implement, so **no call site moves** — only the two module headers.

**Stays in `lightly-studio`:** the capabilities that only exist in-process — `ImagePathEmbedder`,
`ImageCropPathEmbedder`, `VideoPathEmbedder`, `ImagePILEmbedder`, the `Capability` enum and
`ImageCrop`. An fsspec path is resolved with LightlyStudio's credentials, so it never crosses the
wire, and PIL is not a dependency the served package should carry.

**This costs the package a numpy dependency**, and the README claim that it "depends on nothing but
an HTTP server" is corrected. `EmbeddingResult.embeddings` has to stay an array: the ingest paths
do `embeddings[kept_indices]`, `embeddings[:position]` and `.tolist()` at ~20 sites, and mypy
rejects all three against a `Sequence[Sequence[float]]`. Torch, CUDA and `lightly-studio` itself
stay out, which is what still lets it install next to a customer's own pins.

**Also in this PR**, the rest of the contract, which has no counterpart in `lightly-studio` yet:

- **`protocol.py`** — the request and response bodies, the wire capability strings, every route
  path and the multipart field the bytes endpoints read. `RemoteEmbedder` (LIG-10641) validates
  against these same models on the client side.
- **`errors.py`** — `EmbedderContractError` (500) and `CapabilityNotImplementedError` (501), which
  tells a client to re-read `/v1/describe` instead of retrying.
- **`validation.py`** — row count, width against the declared dimension, finite values and
  integral indices are checked before a response leaves, so a broken embedder fails in the
  customer's own process rather than as a similarity search misbehaving inside LightlyStudio.
  Moving it to numpy also catches ragged rows and an `np.bool_` mask, neither of which the
  sequence version rejected.

The URL transports keep their capability strings, paths and request model, but no PR in this stack
mounts them: `RemoteEmbedder` will not call them, so mounting them would be dead code. Capabilities
are advertised, so adding them later is purely additive.

## Notes for the reviewer

- `Embedder = BaseEmbedder` is an alias, not a subclass, so an embedder written against
  `lightly-studio-embed` **is** a `lightly_studio.Embedder` and the registry's `isinstance` checks
  match it. A subclass would have made them two types again.
- `BaseEmbedder` brings a `ready` property (default `True`) onto `lightly_studio.Embedder`. It is
  only read by the HTTP server; in-process embedders are unaffected.
- The `Beta` doc badges moved with the docstrings, so `docs/api/embeddings.md` renders unchanged.
  mkdocstrings resolves the re-export, the same way `EmbeddingSpaceSpec` is already documented
  through `lightly_studio.dataset.embedding_generator`.

## How has it been tested?

14 tests over `build_embeddings_response` cover the dimension rejection, a non-matrix array, the
row-count mismatch, non-ascending or out-of-range indices, a non-finite value, a float index, both
a Python and a numpy boolean mask, ragged rows, a value too large for a float, and an embedder that
kept nothing.

On the `lightly-studio` side the full suite passes unchanged: **2459 passed, 46 skipped**. `mypy`
reports no new errors — the 10 that remain are the pre-existing missing-`cloud-storage`-extras
errors also present on `main`, verified by diffing both error sets.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

**Stack** ([#2253](https://github.com/lightly-ai/lightly-studio/stacks/2253))

1. **This PR** — the shared embedder classes and the protocol models
2. #2249 — `create_app`, `/v1/describe` and `/v1/embed/texts`
3. #2250 — the `images/bytes` and `videos/bytes` endpoints
4. #2251 — the ASGI guards (bearer auth, size ceiling) and `serve()`

Alternative reviewer: @lukas-lightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a versioned embedding protocol with supported capabilities, request/response models, and server limits.
  - Added base interfaces for text, image, and video embedders.
  - Added shared embedding result and embedding-space types.
  - Added validation for embedding dimensions, indices, and numeric values.
  - Exposed the package’s public API through a single top-level import.
- **Documentation**
  - Updated the README with package dependencies and protocol module details.
- **Tests**
  - Added coverage for valid responses and invalid embedding results.
- **Chores**
  - Tests now fail when no tests are collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->