### PR TITLE
Serve /v1/describe and /v1/embed/texts from create_app (embed server stack 2/4)

### DIFF
--- a/lightly_studio_embed/pyproject.toml
+++ b/lightly_studio_embed/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 [dependency-groups]
 # The same floors as the repository's other Python packages, so the tooling behaves alike.
 dev = [
+    # The FastAPI test client is an httpx transport.
+    "httpx>=0.27.2",
     "mypy>=1.19.1",
     "pytest>=8.3.3",
     "ruff>=0.7.4",

--- a/lightly_studio_embed/src/lightly_studio_embed/__init__.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/__init__.py
@@ -16,6 +16,7 @@ from lightly_studio_embed.protocol import (
     ServerLimits,
     WireCapability,
 )
+from lightly_studio_embed.server import create_app
 from lightly_studio_embed.types import EmbeddingResult, EmbeddingSpaceSpec
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "TextEmbedder",
     "VideoBytesEmbedder",
     "WireCapability",
+    "create_app",
 ]

--- a/lightly_studio_embed/src/lightly_studio_embed/server.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/server.py
@@ -1,0 +1,170 @@
+"""Turns an embedder into the HTTP endpoints the protocol defines.
+
+``create_app`` inspects which capability classes the embedder implements, mounts
+those endpoints plus ``/v1/describe``, and returns the application. Version 1
+serves the ``texts``, ``images/bytes`` and ``videos/bytes`` transports; the URL
+transports are specified but not mounted, because LightlyStudio does not call them
+yet and capabilities are advertised, so adding them later is purely additive.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Callable
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi import params as fastapi_params
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, Response
+
+from lightly_studio_embed import protocol, validation
+from lightly_studio_embed.embedder import BaseEmbedder, TextEmbedder
+from lightly_studio_embed.errors import CapabilityNotImplementedError, EmbedderContractError
+from lightly_studio_embed.protocol import (
+    DescribeResponse,
+    EmbeddingsResponse,
+    EmbedTextsRequest,
+    ServerLimits,
+    WireCapability,
+)
+from lightly_studio_embed.types import EmbeddingResult
+
+# How long a client should wait before retrying a model that is still loading.
+_RETRY_AFTER_SECONDS = "5"
+
+
+@dataclass(frozen=True)
+class _Mount:
+    """What every embed route is built from, so each mounts with two arguments."""
+
+    router: APIRouter
+    embedder: BaseEmbedder
+    limits: ServerLimits
+    guards: Sequence[fastapi_params.Depends]
+
+
+def create_app(*, embedder: BaseEmbedder, limits: ServerLimits | None = None) -> FastAPI:
+    """Build the application that serves an embedder.
+
+    Use it to mount the protocol inside an application of your own, or to exercise
+    an embedder over a test client without binding a port.
+
+    Args:
+        embedder: The model to serve. Its capability classes decide which endpoints
+            exist: a text-only embedder exposes no image or video routes.
+        limits: Ceilings to advertise and enforce. Defaults to 64 items and 32 MiB
+            per request.
+
+    Returns:
+        An application serving ``/v1/describe`` and the embedder's capabilities.
+    """
+    resolved_limits = limits if limits is not None else ServerLimits()
+    app = FastAPI(title="LightlyStudio embedding server")
+    app.add_exception_handler(EmbedderContractError, _handle_contract_error)
+    app.add_exception_handler(RequestValidationError, _handle_invalid_request)
+    router = APIRouter()
+    _mount_describe(router=router, embedder=embedder, limits=resolved_limits)
+    _mount_embed_routes(router=router, embedder=embedder, limits=resolved_limits)
+    app.include_router(router)
+    return app
+
+
+def _mount_describe(*, router: APIRouter, embedder: BaseEmbedder, limits: ServerLimits) -> None:
+    @router.get(protocol.DESCRIBE_PATH)
+    def describe() -> DescribeResponse:
+        spec = embedder.embedding_space_spec()
+        return DescribeResponse(
+            protocol_version=protocol.PROTOCOL_VERSION,
+            space_key=spec.space_key,
+            dimension=spec.dimension,
+            ready=embedder.ready,
+            capabilities=_capabilities(embedder=embedder),
+            limits=limits,
+        )
+
+
+def _mount_embed_routes(*, router: APIRouter, embedder: BaseEmbedder, limits: ServerLimits) -> None:
+    mount = _Mount(
+        router=router,
+        embedder=embedder,
+        limits=limits,
+        guards=[Depends(_readiness(embedder=embedder))],
+    )
+    if isinstance(embedder, TextEmbedder):
+        _mount_texts(mount=mount, embed=embedder.embed_text)
+
+
+def _mount_texts(*, mount: _Mount, embed: Callable[[list[str]], EmbeddingResult]) -> None:
+    @mount.router.post(protocol.EMBED_TEXTS_PATH, dependencies=mount.guards)
+    def embed_texts(request: EmbedTextsRequest) -> EmbeddingsResponse:
+        _check_batch_size(item_count=len(request.texts), limits=mount.limits)
+        result = _embed(lambda: embed(request.texts))
+        return _respond(result=result, mount=mount, item_count=len(request.texts))
+
+
+def _capabilities(*, embedder: BaseEmbedder) -> list[WireCapability]:
+    served = [(TextEmbedder, WireCapability.TEXT)]
+    return [capability for base, capability in served if isinstance(embedder, base)]
+
+
+def _embed(call: Callable[[], EmbeddingResult]) -> EmbeddingResult:
+    """Run an embedder call, mapping a capability left unfinished to 501."""
+    try:
+        return call()
+    except CapabilityNotImplementedError as error:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="The server mounts this capability but does not implement it.",
+        ) from error
+
+
+def _respond(*, result: EmbeddingResult, mount: _Mount, item_count: int) -> EmbeddingsResponse:
+    spec = mount.embedder.embedding_space_spec()
+    return validation.build_embeddings_response(
+        result=result,
+        space_key=spec.space_key,
+        dimension=spec.dimension,
+        item_count=item_count,
+    )
+
+
+def _check_batch_size(*, item_count: int, limits: ServerLimits) -> None:
+    if item_count > limits.max_batch_size:
+        raise HTTPException(
+            status_code=protocol.STATUS_PAYLOAD_TOO_LARGE,
+            detail=f"The request carries {item_count} items, over the advertised "
+            f"max_batch_size of {limits.max_batch_size}.",
+        )
+
+
+def _readiness(*, embedder: BaseEmbedder) -> Callable[[], None]:
+    def verify() -> None:
+        if not embedder.ready:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="The model is still loading.",
+                headers={"Retry-After": _RETRY_AFTER_SECONDS},
+            )
+
+    return verify
+
+
+def _handle_contract_error(_request: Request, exc: Exception) -> Response:
+    """Answer 500 naming what the embedder returned, rather than shipping it."""
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": str(exc)}
+    )
+
+
+def _handle_invalid_request(_request: Request, exc: Exception) -> Response:
+    """Answer 400, because the protocol reserves 422 for input it cannot use.
+
+    FastAPI answers 422 for both by default, and the two carry opposite advice for a
+    client: a malformed request is its own bug, unusable input is the batch's.
+    """
+    errors = exc.errors() if isinstance(exc, RequestValidationError) else []
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST, content={"detail": jsonable_encoder(errors)}
+    )

--- a/lightly_studio_embed/tests/test_server.py
+++ b/lightly_studio_embed/tests/test_server.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import numpy as np
+from fastapi.testclient import TestClient
+
+from lightly_studio_embed.embedder import TextEmbedder
+from lightly_studio_embed.errors import CapabilityNotImplementedError
+from lightly_studio_embed.protocol import ServerLimits
+from lightly_studio_embed.server import create_app
+from lightly_studio_embed.types import EmbeddingResult, EmbeddingSpaceSpec
+
+SPACE_KEY = "acme/model@v1"
+DIMENSION = 2
+
+
+class FakeTextEmbedder(TextEmbedder):
+    """Returns one fixed row per text, or a canned result when one is given."""
+
+    def __init__(self, *, result: EmbeddingResult | None = None, ready: bool = True) -> None:
+        self.result = result
+        self.is_ready = ready
+        self.received: list[str] = []
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        return EmbeddingSpaceSpec(space_key=SPACE_KEY, dimension=DIMENSION)
+
+    @property
+    def ready(self) -> bool:
+        return self.is_ready
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        self.received = texts
+        return self.result if self.result is not None else _rows(count=len(texts))
+
+
+class UnfinishedTextEmbedder(FakeTextEmbedder):
+    """A mounted capability whose method was never finished."""
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:  # noqa: ARG002
+        raise CapabilityNotImplementedError
+
+
+class BrokenTextEmbedder(FakeTextEmbedder):
+    """A model that fails, the way torch does for an op its backend lacks."""
+
+    def embed_text(self, texts: list[str]) -> EmbeddingResult:
+        raise NotImplementedError("could not run 'aten::foo' on the 'MPS' backend")
+
+
+def _rows(*, count: int) -> EmbeddingResult:
+    embeddings = np.array([[0.5, -0.5]] * count, dtype=np.float32).reshape(count, DIMENSION)
+    return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(count)))
+
+
+def test_create_app__describe() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    response = client.get("/v1/describe")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "protocol_version": "1.0",
+        "space_key": SPACE_KEY,
+        "dimension": DIMENSION,
+        "ready": True,
+        "capabilities": ["text"],
+        "limits": {"max_batch_size": 64, "max_request_bytes": 33554432},
+    }
+
+
+def test_create_app__describe_not_ready() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(ready=False)))
+
+    response = client.get("/v1/describe")
+
+    assert response.json()["ready"] is False
+
+
+def test_create_app__embed_texts() -> None:
+    embedder = FakeTextEmbedder()
+    client = TestClient(create_app(embedder=embedder))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car", "a blue car"]})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "space_key": SPACE_KEY,
+        "dimension": DIMENSION,
+        "kept_indices": [0, 1],
+        "embeddings": [[0.5, -0.5], [0.5, -0.5]],
+    }
+    assert embedder.received == ["a red car", "a blue car"]
+
+
+def test_create_app__embed_texts_with_skipped_item() -> None:
+    result = EmbeddingResult(embeddings=np.array([[0.5, -0.5]], dtype=np.float32), kept_indices=[1])
+    client = TestClient(create_app(embedder=FakeTextEmbedder(result=result)))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["", "a red car"]})
+
+    assert response.status_code == 200
+    assert response.json()["kept_indices"] == [1]
+
+
+def test_create_app__batch_over_max_batch_size() -> None:
+    app = create_app(embedder=FakeTextEmbedder(), limits=ServerLimits(max_batch_size=1))
+    client = TestClient(app)
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car", "a blue car"]})
+
+    assert response.status_code == 413
+    assert "max_batch_size" in response.json()["detail"]
+
+
+def test_create_app__embed_while_not_ready() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder(ready=False)))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "5"
+
+
+def test_create_app__capability_not_implemented() -> None:
+    client = TestClient(create_app(embedder=UnfinishedTextEmbedder()))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 501
+
+
+def test_create_app__model_raises_not_implemented_error() -> None:
+    client = TestClient(create_app(embedder=BrokenTextEmbedder()), raise_server_exceptions=False)
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 500
+
+
+def test_create_app__embedder_returns_wrong_dimension() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5, 0.5]], dtype=np.float32), kept_indices=[0]
+    )
+    client = TestClient(create_app(embedder=FakeTextEmbedder(result=result)))
+
+    response = client.post("/v1/embed/texts", json={"texts": ["a red car"]})
+
+    assert response.status_code == 500
+    assert "dimension 2" in response.json()["detail"]
+
+
+def test_create_app__malformed_request() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    response = client.post("/v1/embed/texts", json={"texts": "a red car"})
+
+    assert response.status_code == 400

--- a/uv.lock
+++ b/uv.lock
@@ -3335,6 +3335,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3351,6 +3352,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "ruff", specifier = ">=0.7.4" },


### PR DESCRIPTION
## What has changed and why?

Part 2 of a 4-PR stack that splits #2240 (LIG-10691) into reviewable pieces. Stacked on #2248.

`/v1/describe` and every embed response read the server's identity through
`embedder.embedding_space_spec()`, the shared accessor #2248 puts on the base class, so the
wire fields come from the same value object LightlyStudio's own embedders return.

`create_app` inspects which capability classes the embedder implements and mounts exactly the
matching endpoints, so `/v1/describe` advertises what the server actually answers: a text-only
model exposes one embed route and nothing else. This PR mounts `describe` and `texts`; the bytes
transports follow in part 3.

The pieces every embed route shares land here too:

- **Readiness** — while `embedder.ready` is `False`, `/v1/describe` reports `ready: false` and the
  embed endpoints answer 503 with a `Retry-After`, instead of running half-loaded weights.
- **The batch ceiling** — over the advertised `max_batch_size`, the request is answered 413.
- **501 vs. 500** — `CapabilityNotImplementedError` from a mounted-but-unfinished method answers
  501, which tells a client to re-read `/v1/describe`. Any other failure of the model is a 500.
  Worth checking: a model that raises a plain `NotImplementedError`, the way torch does for an op
  its backend lacks, must not be mistaken for a retracted capability.
- **400, not 422, for a malformed request** — FastAPI answers 422 for both by default, and the
  protocol reserves 422 for input the server cannot use. The two carry opposite advice for a
  client: a malformed request is its own bug, unusable input is the batch's.

There is no `serve()` yet, and no auth: `create_app` is exercised over a `TestClient` without
binding a port, and both arrive in part 4.

`httpx` joins the dev group, as the FastAPI test client is an httpx transport.

## How has it been tested?

10 new tests over a `TestClient`: the `describe` body, `ready: false`, the text round trip
including the embedder receiving the strings, a per-item skip reflected in `kept_indices`, the 413,
the 503 with its `Retry-After`, the 501, the 500 for a model that fails, the 500 for a wrong
dimension, and the 400. `make static-checks` and `make test` pass on 3.9 and 3.14.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

**Stack** ([#2253](https://github.com/lightly-ai/lightly-studio/stacks/2253))

1. #2248 — the shared embedder classes and the protocol models
2. **This PR** — `create_app`, `/v1/describe` and `/v1/embed/texts`
3. The `images/bytes` and `videos/bytes` endpoints
4. The ASGI guards (bearer auth, size ceiling) and `serve()`

Alternative reviewer: @lukas-lightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
