### PR TITLE
Add the images/bytes and videos/bytes endpoints (embed server stack 3/4)

### DIFF
--- a/lightly_studio_embed/pyproject.toml
+++ b/lightly_studio_embed/pyproject.toml
@@ -27,6 +27,14 @@ dependencies = [
     # supporting Python 3.9, so one floor covers everything `requires-python` allows.
     "numpy>=1.26.4",
     "pydantic>=2.0",
+    # Starlette parses the multipart bodies of the bytes endpoints through it. The floor is
+    # the first release fixing CVE-2026-53540, after a run of parser DoS advisories
+    # (CVE-2026-40347, CVE-2026-42561, CVE-2026-53537..53539). Python 3.9 is stuck on
+    # 0.0.20, the last release that supports it, so a 3.9 host keeps those weaknesses in its
+    # multipart parser.
+    # TODO(Iunir, 09/2026): Drop the 3.9 pin once `lightly-studio` drops Python 3.9.
+    "python-multipart>=0.0.31; python_version >= '3.10'",
+    "python-multipart>=0.0.20; python_version < '3.10'",
     "uvicorn>=0.32.1",
 ]
 

--- a/lightly_studio_embed/src/lightly_studio_embed/server.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/server.py
@@ -11,16 +11,30 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Callable
+from typing import Annotated, Callable
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    Request,
+    UploadFile,
+    status,
+)
 from fastapi import params as fastapi_params
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 
 from lightly_studio_embed import protocol, validation
-from lightly_studio_embed.embedder import BaseEmbedder, TextEmbedder
+from lightly_studio_embed.embedder import (
+    BaseEmbedder,
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
 from lightly_studio_embed.errors import CapabilityNotImplementedError, EmbedderContractError
 from lightly_studio_embed.protocol import (
     DescribeResponse,
@@ -33,6 +47,8 @@ from lightly_studio_embed.types import EmbeddingResult
 
 # How long a client should wait before retrying a model that is still loading.
 _RETRY_AFTER_SECONDS = "5"
+
+_MultipartFiles = Annotated[list[UploadFile], File(alias=protocol.FILES_FIELD_NAME)]
 
 
 @dataclass(frozen=True)
@@ -94,6 +110,18 @@ def _mount_embed_routes(*, router: APIRouter, embedder: BaseEmbedder, limits: Se
     )
     if isinstance(embedder, TextEmbedder):
         _mount_texts(mount=mount, embed=embedder.embed_text)
+    if isinstance(embedder, ImageBytesEmbedder):
+        _mount_bytes(
+            mount=mount,
+            path=protocol.EMBED_IMAGES_BYTES_PATH,
+            embed=embedder.embed_image_bytes,
+        )
+    if isinstance(embedder, VideoBytesEmbedder):
+        _mount_bytes(
+            mount=mount,
+            path=protocol.EMBED_VIDEOS_BYTES_PATH,
+            embed=embedder.embed_video_bytes,
+        )
 
 
 def _mount_texts(*, mount: _Mount, embed: Callable[[list[str]], EmbeddingResult]) -> None:
@@ -104,8 +132,34 @@ def _mount_texts(*, mount: _Mount, embed: Callable[[list[str]], EmbeddingResult]
         return _respond(result=result, mount=mount, item_count=len(request.texts))
 
 
+def _mount_bytes(
+    *, mount: _Mount, path: str, embed: Callable[[list[bytes]], EmbeddingResult]
+) -> None:
+    """Mount one of the two bytes endpoints; they differ only in the path."""
+
+    # A synchronous handler, so that FastAPI runs the forward pass in a worker
+    # thread rather than on the event loop.
+    @mount.router.post(path, dependencies=mount.guards)
+    def embed_bytes(files: _MultipartFiles) -> EmbeddingsResponse:
+        _check_batch_size(item_count=len(files), limits=mount.limits)
+        items = [_read_part(file=file) for file in files]
+        result = _embed(lambda: embed(items))
+        return _respond(result=result, mount=mount, item_count=len(items))
+
+
+def _read_part(*, file: UploadFile) -> bytes:
+    """Read one multipart part, releasing the copy starlette spooled for it."""
+    data = file.file.read()
+    file.file.close()
+    return data
+
+
 def _capabilities(*, embedder: BaseEmbedder) -> list[WireCapability]:
-    served = [(TextEmbedder, WireCapability.TEXT)]
+    served = [
+        (TextEmbedder, WireCapability.TEXT),
+        (ImageBytesEmbedder, WireCapability.IMAGE_BYTES),
+        (VideoBytesEmbedder, WireCapability.VIDEO_BYTES),
+    ]
     return [capability for base, capability in served if isinstance(embedder, base)]
 
 

--- a/lightly_studio_embed/tests/test_server.py
+++ b/lightly_studio_embed/tests/test_server.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import numpy as np
 from fastapi.testclient import TestClient
 
-from lightly_studio_embed.embedder import TextEmbedder
+from lightly_studio_embed.embedder import (
+    ImageBytesEmbedder,
+    TextEmbedder,
+    VideoBytesEmbedder,
+)
 from lightly_studio_embed.errors import CapabilityNotImplementedError
 from lightly_studio_embed.protocol import ServerLimits
 from lightly_studio_embed.server import create_app
@@ -31,6 +35,24 @@ class FakeTextEmbedder(TextEmbedder):
     def embed_text(self, texts: list[str]) -> EmbeddingResult:
         self.received = texts
         return self.result if self.result is not None else _rows(count=len(texts))
+
+
+class FakeBytesEmbedder(ImageBytesEmbedder, VideoBytesEmbedder):
+    """Embeds images and videos, recording the bytes it was handed."""
+
+    def __init__(self) -> None:
+        self.received: list[bytes] = []
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        return EmbeddingSpaceSpec(space_key=SPACE_KEY, dimension=DIMENSION)
+
+    def embed_image_bytes(self, images: list[bytes]) -> EmbeddingResult:
+        self.received = images
+        return _rows(count=len(images))
+
+    def embed_video_bytes(self, videos: list[bytes]) -> EmbeddingResult:
+        self.received = videos
+        return _rows(count=len(videos))
 
 
 class UnfinishedTextEmbedder(FakeTextEmbedder):
@@ -68,12 +90,27 @@ def test_create_app__describe() -> None:
     }
 
 
+def test_create_app__describe_bytes_capabilities() -> None:
+    client = TestClient(create_app(embedder=FakeBytesEmbedder()))
+
+    response = client.get("/v1/describe")
+
+    assert response.json()["capabilities"] == ["image_bytes", "video_bytes"]
+
+
 def test_create_app__describe_not_ready() -> None:
     client = TestClient(create_app(embedder=FakeTextEmbedder(ready=False)))
 
     response = client.get("/v1/describe")
 
     assert response.json()["ready"] is False
+
+
+def test_create_app__text_only_mounts_no_other_route() -> None:
+    client = TestClient(create_app(embedder=FakeTextEmbedder()))
+
+    assert client.post("/v1/embed/images/bytes", files={"files": b"\xff\xd8"}).status_code == 404
+    assert client.post("/v1/embed/videos/bytes", files={"files": b"\x00\x00"}).status_code == 404
 
 
 def test_create_app__embed_texts() -> None:
@@ -100,6 +137,33 @@ def test_create_app__embed_texts_with_skipped_item() -> None:
 
     assert response.status_code == 200
     assert response.json()["kept_indices"] == [1]
+
+
+def test_create_app__embed_images_bytes() -> None:
+    embedder = FakeBytesEmbedder()
+    client = TestClient(create_app(embedder=embedder))
+
+    response = client.post(
+        "/v1/embed/images/bytes",
+        files=[
+            ("files", ("a.jpg", b"\xff\xd8a", "image/jpeg")),
+            ("files", ("b.png", b"\x89P", "image/png")),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert response.json()["kept_indices"] == [0, 1]
+    assert embedder.received == [b"\xff\xd8a", b"\x89P"]
+
+
+def test_create_app__embed_videos_bytes() -> None:
+    embedder = FakeBytesEmbedder()
+    client = TestClient(create_app(embedder=embedder))
+
+    response = client.post("/v1/embed/videos/bytes", files=[("files", ("a.mp4", b"\x00moov"))])
+
+    assert response.status_code == 200
+    assert embedder.received == [b"\x00moov"]
 
 
 def test_create_app__batch_over_max_batch_size() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3183,7 +3183,7 @@ dependencies = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "python-multipart", version = "0.0.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "requests" },
     { name = "scikit-learn", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3329,6 +3329,8 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
+    { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "uvicorn", version = "0.42.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -3347,6 +3349,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.5" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "python-multipart", marker = "python_full_version < '3.10'", specifier = ">=0.0.20" },
+    { name = "python-multipart", marker = "python_full_version >= '3.10'", specifier = ">=0.0.31" },
     { name = "uvicorn", specifier = ">=0.32.1" },
 ]
 
@@ -6107,7 +6111,7 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -6116,9 +6120,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version == '3.10.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What has changed and why?

Part 3 of a 4-PR stack that splits #2240 (LIG-10691) into reviewable pieces. Stacked on #2249.

Mounts `POST /v1/embed/images/bytes` and `POST /v1/embed/videos/bytes`, each conditional on the
matching capability class, and adds the two capability strings to `/v1/describe`. Both take a
`multipart/form-data` body with one part per item in the `files` field, in input order.

- The handlers are **synchronous**, so FastAPI runs the forward pass in a worker thread rather
  than blocking the event loop.
- Each part is read and closed immediately, releasing the copy starlette spooled for it.
- **Annotation crops get no endpoint.** LightlyStudio crops with a margin and posts the result to
  `images/bytes`, so an image-capable embedder supports crops with no extra work.

`python-multipart` joins the dependencies, since starlette parses these bodies with it. The floor
is the first release past the parser DoS advisories, and Python 3.9 cannot reach it — 0.0.20 is
the last release supporting 3.9 — so it is pinned separately there and the comment names the
exposure. Dropping 3.9 for this package is the open question; `requires-python` currently matches
`lightly-studio`.

The body size ceiling that bounds these multipart bodies is part 4; this PR enforces only the item
count.

## How has it been tested?

4 new tests over a `TestClient`: the two capability strings in `describe`, both bytes round trips
asserting the embedder received the exact bytes, and a text-only embedder answering 404 on both
bytes paths, which is the check that a capability the model lacks is genuinely not mounted.
`make static-checks` and `make test` pass on 3.9 and 3.14.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

**Stack** ([#2253](https://github.com/lightly-ai/lightly-studio/stacks/2253))

1. #2248 — the shared embedder classes and the protocol models
2. #2249 — `create_app`, `/v1/describe` and `/v1/embed/texts`
3. **This PR** — the `images/bytes` and `videos/bytes` endpoints
4. The ASGI guards (bearer auth, size ceiling) and `serve()`

Alternative reviewer: @lukas-lightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
