### PR TITLE
Add McapGroupSequence model

### DIFF
--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -34,6 +34,9 @@ from lightly_studio.models.image import (
 from lightly_studio.models.mcap import (
     McapTable,  # noqa: F401, required for SQLModel to work properly
 )
+from lightly_studio.models.mcap_group_sequence import (
+    McapGroupSequenceTable,  # noqa: F401, required for SQLModel to work properly
+)
 from lightly_studio.models.metadata import (
     SampleMetadataTable,  # noqa: F401, required for SQLModel to work properly
 )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1788940800_d6e7f8a9b0c1_add_mcap_group_sequence.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1788940800_d6e7f8a9b0c1_add_mcap_group_sequence.py
@@ -1,0 +1,42 @@
+"""add mcap_group_sequence table.
+
+Adds the optional 1:1 ``mcap_group_sequence`` specialisation on ``sequence``
+(``sample_id`` PK/FK + ``mcap_path``). Sequences without this row stay valid.
+
+Revision ID: d6e7f8a9b0c1
+Revises: c5d6e7f8a9b0
+Create Date: 2026-09-09 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d6e7f8a9b0c1"
+down_revision: str | Sequence[str] | None = "c5d6e7f8a9b0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "mcap_group_sequence",
+        sa.Column("mcap_path", sa.String(), nullable=False),
+        sa.Column("sample_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["sample_id"],
+            ["sequence.sample_id"],
+        ),
+        sa.PrimaryKeyConstraint("sample_id"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("mcap_group_sequence")

--- a/lightly_studio/src/lightly_studio/migrations/versions/1789200000_f7a8b9c0d1e2_add_mcap_group_sequence.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1789200000_f7a8b9c0d1e2_add_mcap_group_sequence.py
@@ -1,11 +1,12 @@
 """add mcap_group_sequence table.
 
 Adds the optional 1:1 ``mcap_group_sequence`` specialisation on ``sequence``
-(``sample_id`` PK/FK + ``mcap_path``). Sequences without this row stay valid.
+(``sample_id`` PK/FK + ``recording_id`` FK to ``recording``). Sequences without this row
+stay valid.
 
-Revision ID: d6e7f8a9b0c1
-Revises: c5d6e7f8a9b0
-Create Date: 2026-09-09 12:00:00.000000
+Revision ID: f7a8b9c0d1e2
+Revises: 44741ab44511
+Create Date: 2026-09-11 15:00:00.000000
 
 """
 
@@ -17,8 +18,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "d6e7f8a9b0c1"
-down_revision: str | Sequence[str] | None = "c5d6e7f8a9b0"
+revision: str = "f7a8b9c0d1e2"
+down_revision: str | Sequence[str] | None = "44741ab44511"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -27,16 +28,27 @@ def upgrade() -> None:
     """Upgrade schema."""
     op.create_table(
         "mcap_group_sequence",
-        sa.Column("mcap_path", sa.String(), nullable=False),
+        sa.Column("recording_id", sa.Uuid(), nullable=False),
         sa.Column("sample_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["recording_id"],
+            ["recording.recording_id"],
+        ),
         sa.ForeignKeyConstraint(
             ["sample_id"],
             ["sequence.sample_id"],
         ),
         sa.PrimaryKeyConstraint("sample_id"),
     )
+    op.create_index(
+        op.f("ix_mcap_group_sequence_recording_id"),
+        "mcap_group_sequence",
+        ["recording_id"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
+    op.drop_index(op.f("ix_mcap_group_sequence_recording_id"), table_name="mcap_group_sequence")
     op.drop_table("mcap_group_sequence")

--- a/lightly_studio/src/lightly_studio/models/mcap_group_sequence.py
+++ b/lightly_studio/src/lightly_studio/models/mcap_group_sequence.py
@@ -1,7 +1,8 @@
-"""MCAP specialisation of a sequence: the bag path lives here, not on ``sequence``.
+"""MCAP specialisation of a sequence: links to the recording holding the bag path.
 
-A sequence with this 1:1 row has an ``.mcap`` path. A sequence without it stays valid
-(classic / non-MCAP sequences). Identity is the parent sequence's ``sample_id``.
+A sequence with this 1:1 row references a ``recording`` (whose ``uri`` is the bag path). A
+sequence without it stays valid (classic / non-MCAP sequences). Identity is the parent
+sequence's ``sample_id``.
 """
 
 from uuid import UUID
@@ -9,15 +10,10 @@ from uuid import UUID
 from sqlmodel import Field, SQLModel
 
 
-class McapGroupSequenceBase(SQLModel):
-    """Shared fields for the MCAP group sequence specialisation."""
-
-    mcap_path: str
-    """Path or URI of the bag. Required, non-empty. Not unique."""
-
-
-class McapGroupSequenceTable(McapGroupSequenceBase, table=True):
-    """1:1 link from a sequence to its MCAP bag path."""
+class McapGroupSequenceTable(SQLModel, table=True):
+    """1:1 link from a sequence to its MCAP recording."""
 
     __tablename__ = "mcap_group_sequence"
     sample_id: UUID = Field(foreign_key="sequence.sample_id", primary_key=True)
+    recording_id: UUID = Field(foreign_key="recording.recording_id", index=True)
+    """FK to the recording holding the bag path. Required. Not unique."""

--- a/lightly_studio/src/lightly_studio/models/mcap_group_sequence.py
+++ b/lightly_studio/src/lightly_studio/models/mcap_group_sequence.py
@@ -1,0 +1,23 @@
+"""MCAP specialisation of a sequence: the bag path lives here, not on ``sequence``.
+
+A sequence with this 1:1 row has an ``.mcap`` path. A sequence without it stays valid
+(classic / non-MCAP sequences). Identity is the parent sequence's ``sample_id``.
+"""
+
+from uuid import UUID
+
+from sqlmodel import Field, SQLModel
+
+
+class McapGroupSequenceBase(SQLModel):
+    """Shared fields for the MCAP group sequence specialisation."""
+
+    mcap_path: str
+    """Path or URI of the bag. Required, non-empty. Not unique."""
+
+
+class McapGroupSequenceTable(McapGroupSequenceBase, table=True):
+    """1:1 link from a sequence to its MCAP bag path."""
+
+    __tablename__ = "mcap_group_sequence"
+    sample_id: UUID = Field(foreign_key="sequence.sample_id", primary_key=True)

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -57,6 +57,7 @@ from lightly_studio.models.group_component_definition import (
 )
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.mcap import McapTable
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
 from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.models.recording import RecordingTable
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
@@ -136,6 +137,7 @@ def deep_copy(
     _copy_video_frames(session=session)
     _copy_groups(session=session)
     _copy_sequences(session=session)
+    _copy_mcap_group_sequences(session=session)
     _copy_captions(session=session, now=now)
     _copy_annotations(session=session, now=now)
     _copy_annotation_details(session=session, detail_table=ObjectDetectionAnnotationTable)
@@ -620,6 +622,21 @@ def _copy_sequences(session: Session) -> None:
     _copy_table(
         session=session,
         target=SequenceTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_mcap_group_sequences(session: Session) -> None:
+    """Copy MCAP group sequences, remapping sample_id and copying mcap_path."""
+    src = _table(McapGroupSequenceTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {"sample_id": map_sample.c.new_id}
+    _copy_table(
+        session=session,
+        target=McapGroupSequenceTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -629,11 +629,17 @@ def _copy_sequences(session: Session) -> None:
 
 
 def _copy_mcap_group_sequences(session: Session) -> None:
-    """Copy MCAP group sequences, remapping sample_id and copying mcap_path."""
+    """Copy MCAP group sequences, remapping sample_id and recording_id."""
     src = _table(McapGroupSequenceTable).alias("src")
     map_sample = _map(_MAP_SAMPLE)
-    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
-    overrides = {"sample_id": map_sample.c.new_id}
+    map_recording = _map(_MAP_RECORDING)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_recording, map_recording.c.old_id == src.c["recording_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "recording_id": map_recording.c.new_id,
+    }
     _copy_table(
         session=session,
         target=McapGroupSequenceTable,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -122,7 +122,8 @@ def delete_dataset(
 
     # 4. Sample type tables.
     _delete_groups(session=session, dataset_id=dataset_id)
-    # Must precede sequences (McapGroupSequenceTable.sample_id -> SequenceTable).
+    # Must precede sequences (McapGroupSequenceTable.sample_id -> SequenceTable) and
+    # recordings, deleted in step 5 (McapGroupSequenceTable.recording_id -> RecordingTable).
     _delete_mcap_group_sequences(session=session, dataset_id=dataset_id)
     _delete_sequences(session=session, dataset_id=dataset_id)
     _delete_videos(session=session, dataset_id=dataset_id)

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -49,6 +49,7 @@ from lightly_studio.models.group_component_definition import (
 )
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.mcap import McapTable
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
 from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.models.recording import RecordingTable
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
@@ -121,6 +122,8 @@ def delete_dataset(
 
     # 4. Sample type tables.
     _delete_groups(session=session, dataset_id=dataset_id)
+    # Must precede sequences (McapGroupSequenceTable.sample_id -> SequenceTable).
+    _delete_mcap_group_sequences(session=session, dataset_id=dataset_id)
     _delete_sequences(session=session, dataset_id=dataset_id)
     _delete_videos(session=session, dataset_id=dataset_id)
     _delete_images(session=session, dataset_id=dataset_id)
@@ -305,6 +308,16 @@ def _delete_groups(session: Session, dataset_id: UUID) -> None:
     """Delete group records for the dataset's samples."""
     session.exec(
         delete(GroupTable).where(col(GroupTable.sample_id).in_(_sample_ids_subquery(dataset_id))),
+        execution_options=_DELETE_EXECUTION_OPTIONS,
+    )
+
+
+def _delete_mcap_group_sequences(session: Session, dataset_id: UUID) -> None:
+    """Delete MCAP group sequence rows for the dataset's sequences."""
+    session.exec(
+        delete(McapGroupSequenceTable).where(
+            col(McapGroupSequenceTable.sample_id).in_(_sample_ids_subquery(dataset_id))
+        ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,7 +11,7 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
-_HANDLED_TABLES_COUNT = 31
+_HANDLED_TABLES_COUNT = 32
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/__init__.py
@@ -1,0 +1,9 @@
+"""Resolvers for MCAP group sequence database operations."""
+
+from lightly_studio.resolvers.mcap_group_sequence_resolver.create import create
+from lightly_studio.resolvers.mcap_group_sequence_resolver.get_by_id import get_by_id
+
+__all__ = [
+    "create",
+    "get_by_id",
+]

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/create.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from urllib import parse
 from uuid import UUID
 
 from sqlmodel import Session
@@ -14,20 +15,21 @@ from lightly_studio.resolvers import collection_resolver, sample_resolver
 
 
 def create(session: Session, collection_id: UUID, mcap_path: str) -> UUID:
-    """Create a sequence sample with an MCAP bag path in a single commit.
+    """Create a sequence sample with an MCAP path in a single commit.
 
     Args:
         session: The database session.
         collection_id: The ID of the sequence collection.
-        mcap_path: Path or URI of the bag. Must be non-empty after stripping and
-            end with ``.mcap``.
+        mcap_path: Path or URI of the MCAP file. Must be non-empty after stripping and
+            its path component must end with ``.mcap``. A URI query string, for example a
+            presigned URL, is ignored by the extension check.
 
     Returns:
         The sample ID of the created sequence.
 
     Raises:
-        ValueError: If ``mcap_path`` is empty or does not end with ``.mcap``, or if
-            the collection does not exist or is not of type SEQUENCE.
+        ValueError: If ``mcap_path`` is empty or its path component does not end with
+            ``.mcap``, or if the collection does not exist or is not of type SEQUENCE.
     """
     path = _validated_mcap_path(mcap_path)
     collection_resolver.check_collection_type(
@@ -49,6 +51,8 @@ def _validated_mcap_path(mcap_path: str) -> str:
     path = mcap_path.strip()
     if not path:
         raise ValueError("mcap_path must be non-empty.")
-    if not path.lower().endswith(".mcap"):
+    # Strip a potential URI query string, for example a presigned URL signature, so that
+    # only the path component is checked for the extension.
+    if not parse.urlsplit(path).path.lower().endswith(".mcap"):
         raise ValueError(f"mcap_path must end with '.mcap', got '{path}'.")
     return path

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/create.py
@@ -2,57 +2,47 @@
 
 from __future__ import annotations
 
-from urllib import parse
 from uuid import UUID
 
 from sqlmodel import Session
 
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
+from lightly_studio.models.recording import RecordingTable
 from lightly_studio.models.sample import SampleCreate
 from lightly_studio.models.sequence import SequenceTable
 from lightly_studio.resolvers import collection_resolver, sample_resolver
 
 
-def create(session: Session, collection_id: UUID, mcap_path: str) -> UUID:
-    """Create a sequence sample with an MCAP path in a single commit.
+def create(session: Session, collection_id: UUID, recording_id: UUID) -> UUID:
+    """Create a sequence sample linked to an existing MCAP recording, in a single commit.
 
     Args:
         session: The database session.
         collection_id: The ID of the sequence collection.
-        mcap_path: Path or URI of the MCAP file. Must be non-empty after stripping and
-            its path component must end with ``.mcap``. A URI query string, for example a
-            presigned URL, is ignored by the extension check.
+        recording_id: The ID of the recording holding the MCAP bag path.
 
     Returns:
         The sample ID of the created sequence.
 
     Raises:
-        ValueError: If ``mcap_path`` is empty or its path component does not end with
-            ``.mcap``, or if the collection does not exist or is not of type SEQUENCE.
+        ValueError: If the collection does not exist or is not of type SEQUENCE, or if
+            the recording does not exist.
     """
-    path = _validated_mcap_path(mcap_path)
     collection_resolver.check_collection_type(
         session=session,
         collection_id=collection_id,
         expected_type=SampleType.SEQUENCE,
     )
+    if session.get(RecordingTable, recording_id) is None:
+        raise ValueError(f"Recording with id {recording_id} not found.")
     sample_id = sample_resolver.create_many(
         session=session,
         samples=[SampleCreate(collection_id=collection_id)],
     )[0]
     session.bulk_save_objects(objects=[SequenceTable(sample_id=sample_id)])
-    session.bulk_save_objects(objects=[McapGroupSequenceTable(sample_id=sample_id, mcap_path=path)])
+    session.bulk_save_objects(
+        objects=[McapGroupSequenceTable(sample_id=sample_id, recording_id=recording_id)]
+    )
     session.commit()
     return sample_id
-
-
-def _validated_mcap_path(mcap_path: str) -> str:
-    path = mcap_path.strip()
-    if not path:
-        raise ValueError("mcap_path must be non-empty.")
-    # Strip a potential URI query string, for example a presigned URL signature, so that
-    # only the path component is checked for the extension.
-    if not parse.urlsplit(path).path.lower().endswith(".mcap"):
-        raise ValueError(f"mcap_path must end with '.mcap', got '{path}'.")
-    return path

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/create.py
@@ -1,0 +1,54 @@
+"""Implementation of create for MCAP group sequences."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
+from lightly_studio.models.sample import SampleCreate
+from lightly_studio.models.sequence import SequenceTable
+from lightly_studio.resolvers import collection_resolver, sample_resolver
+
+
+def create(session: Session, collection_id: UUID, mcap_path: str) -> UUID:
+    """Create a sequence sample with an MCAP bag path in a single commit.
+
+    Args:
+        session: The database session.
+        collection_id: The ID of the sequence collection.
+        mcap_path: Path or URI of the bag. Must be non-empty after stripping and
+            end with ``.mcap``.
+
+    Returns:
+        The sample ID of the created sequence.
+
+    Raises:
+        ValueError: If ``mcap_path`` is empty or does not end with ``.mcap``, or if
+            the collection does not exist or is not of type SEQUENCE.
+    """
+    path = _validated_mcap_path(mcap_path)
+    collection_resolver.check_collection_type(
+        session=session,
+        collection_id=collection_id,
+        expected_type=SampleType.SEQUENCE,
+    )
+    sample_id = sample_resolver.create_many(
+        session=session,
+        samples=[SampleCreate(collection_id=collection_id)],
+    )[0]
+    session.bulk_save_objects(objects=[SequenceTable(sample_id=sample_id)])
+    session.bulk_save_objects(objects=[McapGroupSequenceTable(sample_id=sample_id, mcap_path=path)])
+    session.commit()
+    return sample_id
+
+
+def _validated_mcap_path(mcap_path: str) -> str:
+    path = mcap_path.strip()
+    if not path:
+        raise ValueError("mcap_path must be non-empty.")
+    if not path.lower().endswith(".mcap"):
+        raise ValueError(f"mcap_path must end with '.mcap', got '{path}'.")
+    return path

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/get_by_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_sequence_resolver/get_by_id.py
@@ -1,0 +1,16 @@
+"""Implementation of get_by_id for MCAP group sequences."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, select
+
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
+
+
+def get_by_id(session: Session, sample_id: UUID) -> McapGroupSequenceTable | None:
+    """Retrieve the MCAP specialisation for a sequence, if it has one."""
+    return session.exec(
+        select(McapGroupSequenceTable).where(McapGroupSequenceTable.sample_id == sample_id)
+    ).one_or_none()

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -536,11 +536,16 @@ def test_deep_copy__with_sequences(db_session: Session) -> None:
 
 def test_deep_copy__with_mcap_group_sequences(db_session: Session) -> None:
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
-    mcap_path = "/bags/drive_001.mcap"
+    recording_id = recording_resolver.create(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        uri="/bags/drive_001.mcap",
+        format_=RecordingFormat.MCAP,
+    )
     mcap_sample_id = mcap_group_sequence_resolver.create(
         session=db_session,
         collection_id=collection.collection_id,
-        mcap_path=mcap_path,
+        recording_id=recording_id,
     )
     classic_sample_ids = sample_resolver.create_many(
         session=db_session,
@@ -569,7 +574,12 @@ def test_deep_copy__with_mcap_group_sequences(db_session: Session) -> None:
         select(McapGroupSequenceTable).where(col(McapGroupSequenceTable.sample_id).in_(copied_ids))
     ).all()
     assert len(copied_mcap_rows) == 1
-    assert copied_mcap_rows[0].mcap_path == mcap_path
+    assert copied_mcap_rows[0].recording_id != recording_id
+    copied_recording = recording_resolver.get_by_id(
+        session=db_session, recording_id=copied_mcap_rows[0].recording_id
+    )
+    assert copied_recording is not None
+    assert copied_recording.uri == "/bags/drive_001.mcap"
     assert copied_mcap_rows[0].sample_id != mcap_sample_id
 
 

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -15,6 +15,7 @@ from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotat
 from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
 from lightly_studio.models.image import ImageCreate
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
 from lightly_studio.models.recording import RecordingFormat
 from lightly_studio.models.sample import SampleCreate, SampleTable
 from lightly_studio.models.sequence import SampleSequenceLinkTable, SequenceTable
@@ -29,6 +30,7 @@ from lightly_studio.resolvers import (
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
     image_resolver,
+    mcap_group_sequence_resolver,
     metadata_resolver,
     object_track_resolver,
     recording_resolver,
@@ -530,6 +532,45 @@ def test_deep_copy__with_sequences(db_session: Session) -> None:
     assert [link.seq_number for link in copied_links] == [0, 1]
     assert [link.timestamp_ns for link in copied_links] == [1785699091646722462, None]
     assert {link.sample_id for link in copied_links}.isdisjoint(sample_ids)
+
+
+def test_deep_copy__with_mcap_group_sequences(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+    mcap_path = "/bags/drive_001.mcap"
+    mcap_sample_id = mcap_group_sequence_resolver.create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        mcap_path=mcap_path,
+    )
+    classic_sample_ids = sample_resolver.create_many(
+        session=db_session,
+        samples=[SampleCreate(collection_id=collection.collection_id)],
+    )
+    db_session.add(SequenceTable(sample_id=classic_sample_ids[0]))
+    db_session.commit()
+    original_ids = {mcap_sample_id, classic_sample_ids[0]}
+
+    copied = dataset_resolver.deep_copy(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        copy_name="copied",
+    )
+
+    copied_sequences = db_session.exec(
+        select(SequenceTable)
+        .join(SampleTable, col(SequenceTable.sample_id) == col(SampleTable.sample_id))
+        .where(col(SampleTable.collection_id) == copied.collection_id)
+    ).all()
+    assert len(copied_sequences) == 2
+    copied_ids = {sequence.sample_id for sequence in copied_sequences}
+    assert copied_ids.isdisjoint(original_ids)
+
+    copied_mcap_rows = db_session.exec(
+        select(McapGroupSequenceTable).where(col(McapGroupSequenceTable.sample_id).in_(copied_ids))
+    ).all()
+    assert len(copied_mcap_rows) == 1
+    assert copied_mcap_rows[0].mcap_path == mcap_path
+    assert copied_mcap_rows[0].sample_id != mcap_sample_id
 
 
 def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -19,7 +19,7 @@ from lightly_studio.models.annotation.segmentation import SegmentationAnnotation
 from lightly_studio.models.annotation_collection_coverage import AnnotationCollectionCoverageTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
-from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
@@ -31,17 +31,21 @@ from lightly_studio.models.evaluation_sample_metric import (
 )
 from lightly_studio.models.group import GroupTable, SampleGroupLinkTable
 from lightly_studio.models.image import ImageTable
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
 from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.models.recording import RecordingFormat, RecordingTable
-from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample import SampleCreate, SampleTable, SampleTagLinkTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.sequence import SequenceTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
 from lightly_studio.resolvers import (
     dataset_resolver,
     evaluation_sample_metric_resolver,
+    mcap_group_sequence_resolver,
     object_track_resolver,
     recording_resolver,
+    sample_resolver,
     tag_resolver,
 )
 from tests.helpers_resolvers import (
@@ -88,6 +92,10 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
         "video": count(VideoTable, col(VideoTable.sample_id).in_(sample_ids)),
         "video_frame": count(VideoFrameTable, col(VideoFrameTable.sample_id).in_(sample_ids)),
         "group": count(GroupTable, col(GroupTable.sample_id).in_(sample_ids)),
+        "sequence": count(SequenceTable, col(SequenceTable.sample_id).in_(sample_ids)),
+        "mcap_group_sequence": count(
+            McapGroupSequenceTable, col(McapGroupSequenceTable.sample_id).in_(sample_ids)
+        ),
         "annotation_base": count(
             AnnotationBaseTable, col(AnnotationBaseTable.sample_id).in_(sample_ids)
         ),
@@ -255,6 +263,25 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
             )
         ],
     )
+
+    # Sequences: one with an MCAP bag path, one classic sequence without the row.
+    sequence_collection = create_collection(
+        session=session,
+        collection_name=f"{name}_sequences",
+        parent_collection_id=root.collection_id,
+        sample_type=SampleType.SEQUENCE,
+    )
+    mcap_group_sequence_resolver.create(
+        session=session,
+        collection_id=sequence_collection.collection_id,
+        mcap_path=f"/{name}/drive.mcap",
+    )
+    classic_sample_ids = sample_resolver.create_many(
+        session=session,
+        samples=[SampleCreate(collection_id=sequence_collection.collection_id)],
+    )
+    session.add(SequenceTable(sample_id=classic_sample_ids[0]))
+    session.commit()
     return root.dataset_id
 
 
@@ -286,6 +313,8 @@ def test_deep_copy_then_delete_round_trip(db_session: Session) -> None:
         "evaluation_run",
         "evaluation_sample_metric",
         "evaluation_annotation_metric",
+        "sequence",
+        "mcap_group_sequence",
     ):
         assert original_counts[table] > 0, f"builder did not populate {table}"
 

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -200,7 +200,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
         session=session,
         tracks=[ObjectTrackCreate(object_track_number=1, dataset_id=root.dataset_id)],
     )
-    recording_resolver.create(
+    recording_id = recording_resolver.create(
         session=session,
         dataset_id=root.dataset_id,
         uri=f"/data/{name}.mcap",
@@ -274,7 +274,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
     mcap_group_sequence_resolver.create(
         session=session,
         collection_id=sequence_collection.collection_id,
-        mcap_path=f"/{name}/drive.mcap",
+        recording_id=recording_id,
     )
     classic_sample_ids = sample_resolver.create_many(
         session=session,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -13,6 +13,7 @@ from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotat
 from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
 from lightly_studio.models.group_component_definition import GroupComponentDefinitionTable
+from lightly_studio.models.mcap_group_sequence import McapGroupSequenceTable
 from lightly_studio.models.recording import RecordingFormat
 from lightly_studio.models.sample import SampleCreate
 from lightly_studio.models.sequence import SampleSequenceLinkTable, SequenceTable
@@ -25,6 +26,7 @@ from lightly_studio.resolvers import (
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
     export_job_resolver,
+    mcap_group_sequence_resolver,
     metadata_resolver,
     recording_resolver,
     sample_embedding_resolver,
@@ -274,20 +276,21 @@ def test_delete_dataset__with_group_component_definitions(db_session: Session) -
 def test_delete_dataset__with_sequences(db_session: Session) -> None:
     # Arrange
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
-    sample_ids = sample_resolver.create_many(
+    sequence_id = mcap_group_sequence_resolver.create(
         session=db_session,
-        samples=[SampleCreate(collection_id=collection.collection_id) for _ in range(2)],
+        collection_id=collection.collection_id,
+        mcap_path="/bags/drive_001.mcap",
     )
-    sequence = SequenceTable(sample_id=sample_ids[0])
-    db_session.add(sequence)
-    db_session.flush()
+    linked_sample_ids = sample_resolver.create_many(
+        session=db_session,
+        samples=[SampleCreate(collection_id=collection.collection_id)],
+    )
     db_session.add(
         SampleSequenceLinkTable(
-            sample_id=sample_ids[1], sequence_sample_id=sequence.sample_id, seq_number=0
+            sample_id=linked_sample_ids[0], sequence_sample_id=sequence_id, seq_number=0
         )
     )
     db_session.commit()
-    sequence_id = sequence.sample_id
     collection_id = collection.collection_id
 
     # Act
@@ -296,9 +299,10 @@ def test_delete_dataset__with_sequences(db_session: Session) -> None:
         dataset_id=collection.dataset_id,
     )
 
-    # Assert - collection, sequence, and its links are all deleted
+    # Assert - collection, sequence, MCAP specialisation, and links are all deleted
     assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
     assert db_session.get(SequenceTable, sequence_id) is None
+    assert db_session.get(McapGroupSequenceTable, sequence_id) is None
     assert (
         db_session.exec(
             select(SampleSequenceLinkTable).where(

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -276,10 +276,16 @@ def test_delete_dataset__with_group_component_definitions(db_session: Session) -
 def test_delete_dataset__with_sequences(db_session: Session) -> None:
     # Arrange
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+    recording_id = recording_resolver.create(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        uri="/bags/drive_001.mcap",
+        format_=RecordingFormat.MCAP,
+    )
     sequence_id = mcap_group_sequence_resolver.create(
         session=db_session,
         collection_id=collection.collection_id,
-        mcap_path="/bags/drive_001.mcap",
+        recording_id=recording_id,
     )
     linked_sample_ids = sample_resolver.create_many(
         session=db_session,

--- a/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
@@ -31,6 +31,27 @@ def test_create(db_session: Session) -> None:
     assert sample.collection_id == collection.collection_id
 
 
+@pytest.mark.parametrize(
+    "mcap_path",
+    [
+        "s3://bucket/bags/drive_001.mcap",
+        "https://bucket.s3.amazonaws.com/bags/drive_001.mcap?X-Amz-Signature=abc123",
+    ],
+)
+def test_create__uri(db_session: Session, mcap_path: str) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+
+    sample_id = mcap_group_sequence_resolver.create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        mcap_path=mcap_path,
+    )
+
+    row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_id)
+    assert row is not None
+    assert row.mcap_path == mcap_path
+
+
 def test_create__missing_collection(db_session: Session) -> None:
     with pytest.raises(ValueError, match=r"Collection with id .* not found"):
         mcap_group_sequence_resolver.create(
@@ -63,7 +84,15 @@ def test_create__empty_path(db_session: Session, mcap_path: str) -> None:
         )
 
 
-@pytest.mark.parametrize("mcap_path", ["/bags/drive_001.bag", "/bags/drive_001", "drive.mcap.bak"])
+@pytest.mark.parametrize(
+    "mcap_path",
+    [
+        "/bags/drive_001.bag",
+        "/bags/drive_001",
+        "drive.mcap.bak",
+        "https://bucket.s3.amazonaws.com/bags/drive_001.bag?X-Amz-Signature=abc123",
+    ],
+)
 def test_create__invalid_extension(db_session: Session, mcap_path: str) -> None:
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
 

--- a/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
@@ -1,0 +1,76 @@
+"""Tests for creating MCAP group sequences."""
+
+import uuid
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sequence import SequenceTable
+from lightly_studio.resolvers import mcap_group_sequence_resolver, sample_resolver
+from tests.helpers_resolvers import create_collection
+
+
+def test_create(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+
+    sample_id = mcap_group_sequence_resolver.create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        mcap_path="/bags/drive_001.mcap",
+    )
+
+    sequence = db_session.get(SequenceTable, sample_id)
+    assert sequence is not None
+    row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_id)
+    assert row is not None
+    assert row.sample_id == sample_id
+    assert row.mcap_path == "/bags/drive_001.mcap"
+    sample = sample_resolver.get_by_id(session=db_session, sample_id=sample_id)
+    assert sample is not None
+    assert sample.collection_id == collection.collection_id
+
+
+def test_create__missing_collection(db_session: Session) -> None:
+    with pytest.raises(ValueError, match=r"Collection with id .* not found"):
+        mcap_group_sequence_resolver.create(
+            session=db_session,
+            collection_id=uuid.uuid4(),
+            mcap_path="/bags/drive_001.mcap",
+        )
+
+
+def test_create__non_sequence_collection(db_session: Session) -> None:
+    image_col = create_collection(session=db_session, sample_type=SampleType.IMAGE)
+
+    with pytest.raises(ValueError, match="is having sample type 'image', expected 'sequence'"):
+        mcap_group_sequence_resolver.create(
+            session=db_session,
+            collection_id=image_col.collection_id,
+            mcap_path="/bags/drive_001.mcap",
+        )
+
+
+@pytest.mark.parametrize("mcap_path", ["", "   "])
+def test_create__empty_path(db_session: Session, mcap_path: str) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+
+    with pytest.raises(ValueError, match="mcap_path must be non-empty"):
+        mcap_group_sequence_resolver.create(
+            session=db_session,
+            collection_id=collection.collection_id,
+            mcap_path=mcap_path,
+        )
+
+
+@pytest.mark.parametrize("mcap_path", ["/bags/drive_001.bag", "/bags/drive_001", "drive.mcap.bak"])
+def test_create__invalid_extension(db_session: Session, mcap_path: str) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+
+    with pytest.raises(ValueError, match=r"mcap_path must end with '\.mcap'"):
+        mcap_group_sequence_resolver.create(
+            session=db_session,
+            collection_id=collection.collection_id,
+            mcap_path=mcap_path,
+        )
+

--- a/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
@@ -73,4 +73,3 @@ def test_create__invalid_extension(db_session: Session, mcap_path: str) -> None:
             collection_id=collection.collection_id,
             mcap_path=mcap_path,
         )
-

--- a/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_create.py
@@ -6,18 +6,29 @@ import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.recording import RecordingFormat
 from lightly_studio.models.sequence import SequenceTable
-from lightly_studio.resolvers import mcap_group_sequence_resolver, sample_resolver
+from lightly_studio.resolvers import (
+    mcap_group_sequence_resolver,
+    recording_resolver,
+    sample_resolver,
+)
 from tests.helpers_resolvers import create_collection
 
 
 def test_create(db_session: Session) -> None:
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+    recording_id = recording_resolver.create(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        uri="/bags/drive_001.mcap",
+        format_=RecordingFormat.MCAP,
+    )
 
     sample_id = mcap_group_sequence_resolver.create(
         session=db_session,
         collection_id=collection.collection_id,
-        mcap_path="/bags/drive_001.mcap",
+        recording_id=recording_id,
     )
 
     sequence = db_session.get(SequenceTable, sample_id)
@@ -25,80 +36,52 @@ def test_create(db_session: Session) -> None:
     row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_id)
     assert row is not None
     assert row.sample_id == sample_id
-    assert row.mcap_path == "/bags/drive_001.mcap"
+    assert row.recording_id == recording_id
     sample = sample_resolver.get_by_id(session=db_session, sample_id=sample_id)
     assert sample is not None
     assert sample.collection_id == collection.collection_id
 
 
-@pytest.mark.parametrize(
-    "mcap_path",
-    [
-        "s3://bucket/bags/drive_001.mcap",
-        "https://bucket.s3.amazonaws.com/bags/drive_001.mcap?X-Amz-Signature=abc123",
-    ],
-)
-def test_create__uri(db_session: Session, mcap_path: str) -> None:
+def test_create__missing_collection(db_session: Session) -> None:
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
-
-    sample_id = mcap_group_sequence_resolver.create(
+    recording_id = recording_resolver.create(
         session=db_session,
-        collection_id=collection.collection_id,
-        mcap_path=mcap_path,
+        dataset_id=collection.dataset_id,
+        uri="/bags/drive_001.mcap",
+        format_=RecordingFormat.MCAP,
     )
 
-    row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_id)
-    assert row is not None
-    assert row.mcap_path == mcap_path
-
-
-def test_create__missing_collection(db_session: Session) -> None:
     with pytest.raises(ValueError, match=r"Collection with id .* not found"):
         mcap_group_sequence_resolver.create(
             session=db_session,
             collection_id=uuid.uuid4(),
-            mcap_path="/bags/drive_001.mcap",
+            recording_id=recording_id,
         )
 
 
 def test_create__non_sequence_collection(db_session: Session) -> None:
     image_col = create_collection(session=db_session, sample_type=SampleType.IMAGE)
+    recording_id = recording_resolver.create(
+        session=db_session,
+        dataset_id=image_col.dataset_id,
+        uri="/bags/drive_001.mcap",
+        format_=RecordingFormat.MCAP,
+    )
 
     with pytest.raises(ValueError, match="is having sample type 'image', expected 'sequence'"):
         mcap_group_sequence_resolver.create(
             session=db_session,
             collection_id=image_col.collection_id,
-            mcap_path="/bags/drive_001.mcap",
+            recording_id=recording_id,
         )
 
 
-@pytest.mark.parametrize("mcap_path", ["", "   "])
-def test_create__empty_path(db_session: Session, mcap_path: str) -> None:
+def test_create__missing_recording(db_session: Session) -> None:
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
 
-    with pytest.raises(ValueError, match="mcap_path must be non-empty"):
+    with pytest.raises(ValueError, match=r"Recording with id .* not found"):
         mcap_group_sequence_resolver.create(
             session=db_session,
             collection_id=collection.collection_id,
-            mcap_path=mcap_path,
-        )
-
-
-@pytest.mark.parametrize(
-    "mcap_path",
-    [
-        "/bags/drive_001.bag",
-        "/bags/drive_001",
-        "drive.mcap.bak",
-        "https://bucket.s3.amazonaws.com/bags/drive_001.bag?X-Amz-Signature=abc123",
-    ],
-)
-def test_create__invalid_extension(db_session: Session, mcap_path: str) -> None:
-    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
-
-    with pytest.raises(ValueError, match=r"mcap_path must end with '\.mcap'"):
-        mcap_group_sequence_resolver.create(
-            session=db_session,
-            collection_id=collection.collection_id,
-            mcap_path=mcap_path,
+            recording_id=uuid.uuid4(),
         )

--- a/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_get_by_id.py
+++ b/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_get_by_id.py
@@ -1,0 +1,37 @@
+"""Tests for reading MCAP group sequences."""
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleCreate
+from lightly_studio.models.sequence import SequenceTable
+from lightly_studio.resolvers import mcap_group_sequence_resolver, sample_resolver
+from tests.helpers_resolvers import create_collection
+
+
+def test_get_by_id(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+    sample_id = mcap_group_sequence_resolver.create(
+        session=db_session,
+        collection_id=collection.collection_id,
+        mcap_path="/bags/drive_001.mcap",
+    )
+
+    row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_id)
+
+    assert row is not None
+    assert row.sample_id == sample_id
+    assert row.mcap_path == "/bags/drive_001.mcap"
+
+
+def test_get_by_id__classic_sequence(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+    sample_ids = sample_resolver.create_many(
+        session=db_session,
+        samples=[SampleCreate(collection_id=collection.collection_id)],
+    )
+    db_session.add(SequenceTable(sample_id=sample_ids[0]))
+    db_session.commit()
+
+    row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_ids[0])
+    assert row is None

--- a/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_get_by_id.py
+++ b/lightly_studio/tests/resolvers/mcap_group_sequence_resolver/test_get_by_id.py
@@ -3,25 +3,36 @@
 from sqlmodel import Session
 
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.recording import RecordingFormat
 from lightly_studio.models.sample import SampleCreate
 from lightly_studio.models.sequence import SequenceTable
-from lightly_studio.resolvers import mcap_group_sequence_resolver, sample_resolver
+from lightly_studio.resolvers import (
+    mcap_group_sequence_resolver,
+    recording_resolver,
+    sample_resolver,
+)
 from tests.helpers_resolvers import create_collection
 
 
 def test_get_by_id(db_session: Session) -> None:
     collection = create_collection(session=db_session, sample_type=SampleType.SEQUENCE)
+    recording_id = recording_resolver.create(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        uri="/bags/drive_001.mcap",
+        format_=RecordingFormat.MCAP,
+    )
     sample_id = mcap_group_sequence_resolver.create(
         session=db_session,
         collection_id=collection.collection_id,
-        mcap_path="/bags/drive_001.mcap",
+        recording_id=recording_id,
     )
 
     row = mcap_group_sequence_resolver.get_by_id(session=db_session, sample_id=sample_id)
 
     assert row is not None
     assert row.sample_id == sample_id
-    assert row.mcap_path == "/bags/drive_001.mcap"
+    assert row.recording_id == recording_id
 
 
 def test_get_by_id__classic_sequence(db_session: Session) -> None:


### PR DESCRIPTION
## What has changed and why?

Adds the mcap_group_sequence table: an optional 1:1 specialization of sequence that marks a sequence as MCAP-backed and points at the recording holding its bag file.

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating and retrieving MCAP-backed sequence groups.
  * MCAP sequences can now link samples to recordings while preserving support for classic sequences.
  * Dataset duplication now copies MCAP recordings and sequence links with remapped identifiers.
  * Dataset deletion now removes associated recordings and MCAP sequence links.

* **Bug Fixes**
  * Added database support and migration for MCAP group sequence records.

* **Tests**
  * Added coverage for creation, retrieval, duplication, and deletion of MCAP-backed sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->