### PR TITLE
Add: Connect dataset split submission and refresh

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetSplit/ConnectedDatasetSplitDialog/ConnectedDatasetSplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/ConnectedDatasetSplitDialog/ConnectedDatasetSplitDialog.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import DatasetSplitDialog from '../DatasetSplitDialog/DatasetSplitDialog.svelte';
+    import { useDatasetSplit } from '../useDatasetSplit/useDatasetSplit.svelte';
+
+    interface Props {
+        collectionId: string;
+        sampleType: 'image' | 'video';
+        onClose: () => void;
+    }
+
+    let { collectionId, sampleType, onClose }: Props = $props();
+    const { sampleCount, tags, pending, error, submit } = useDatasetSplit(() => ({
+        collectionId,
+        sampleType,
+        onClose: () => onClose()
+    }));
+</script>
+
+<DatasetSplitDialog
+    {sampleCount}
+    existingTagNames={$tags.map((tag) => tag.name)}
+    pending={$pending}
+    error={$error}
+    onSubmit={submit}
+    {onClose}
+/>

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/DatasetSplitHarness.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/DatasetSplitHarness.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import { QueryClientProvider, type QueryClient } from '@tanstack/svelte-query';
+    import ConnectedDatasetSplitDialog from '../ConnectedDatasetSplitDialog/ConnectedDatasetSplitDialog.svelte';
+
+    interface Props {
+        client: QueryClient;
+        sampleType: 'image' | 'video';
+        onClose: () => void;
+    }
+    let { client, sampleType, onClose }: Props = $props();
+</script>
+
+<QueryClientProvider {client}>
+    <ConnectedDatasetSplitDialog collectionId="collection" {sampleType} {onClose} />
+</QueryClientProvider>

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.svelte.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.svelte.ts
@@ -1,0 +1,56 @@
+import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+import { get, writable } from 'svelte/store';
+import { toast } from 'svelte-sonner';
+import { splitDatasetMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { useGlobalStorage, useImageFilters, useTags, useVideoFilters } from '$lib/hooks';
+
+interface Options {
+    collectionId: string;
+    sampleType: 'image' | 'video';
+    onClose: () => void;
+}
+
+export function useDatasetSplit(getOptions: () => Options) {
+    const { collectionId, sampleType, onClose } = getOptions();
+    const client = useQueryClient();
+    const mutation = createMutation(() => splitDatasetMutation());
+    const { tags, loadTags } = useTags({ collection_id: collectionId });
+    const { filteredSampleCount } = useGlobalStorage();
+    // Capture once per opening so later filter changes cannot alter the submitted scope.
+    const filter = structuredClone(
+        sampleType === 'image'
+            ? { ...get(useImageFilters().imageFilter), filter_type: 'image' as const }
+            : { ...get(useVideoFilters().videoFilter), filter_type: 'video' as const }
+    );
+    const sampleCount = get(filteredSampleCount);
+    const pending = writable(false);
+    const error = writable<string | undefined>();
+
+    async function submit(
+        values: Omit<Parameters<typeof mutation.mutateAsync>[0]['body'], 'filter'>
+    ) {
+        if (get(pending)) return;
+        pending.set(true);
+        error.set(undefined);
+        try {
+            const counts = await mutation.mutateAsync({
+                path: { collection_id: collectionId },
+                body: { ...values, filter }
+            });
+            // Tags have a separate store; refresh both it and queries that may depend on tags.
+            await Promise.all([loadTags(), client.invalidateQueries()]);
+            toast.success(
+                counts
+                    .map(({ tag_name, sample_count }) => `${tag_name}: ${sample_count}`)
+                    .join(', ')
+            );
+            onClose();
+        } catch {
+            error.set('Unable to split dataset. Please try again.');
+        } finally {
+            pending.set(false);
+        }
+    }
+
+    return { sampleCount, tags, pending, error, submit };
+}

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.test.ts
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { QueryClient } from '@tanstack/svelte-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { splitDataset } from '$lib/api/lightly_studio_local/sdk.gen';
+import { toast } from 'svelte-sonner';
+import DatasetSplitHarness from './DatasetSplitHarness.svelte';
+
+const { loadTags, imageFilter, videoFilter, filteredSampleCount, tags } = await vi.hoisted(
+    async () => {
+        const { writable } = await import('svelte/store');
+        return {
+            loadTags: vi.fn(),
+            imageFilter: writable({ filter_type: 'image', sample_filter: { tag_ids: ['images'] } }),
+            videoFilter: writable({ filter_type: 'video', sample_filter: { tag_ids: ['videos'] } }),
+            filteredSampleCount: writable(11),
+            tags: writable([])
+        };
+    }
+);
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({ splitDataset: vi.fn() }));
+vi.mock('svelte-sonner', () => ({ toast: { success: vi.fn() } }));
+vi.mock('$lib/hooks', () => ({
+    useImageFilters: () => ({ imageFilter }),
+    useVideoFilters: () => ({ videoFilter }),
+    useGlobalStorage: () => ({ filteredSampleCount }),
+    useTags: () => ({ tags, loadTags })
+}));
+
+function setup(sampleType: 'image' | 'video') {
+    const client = new QueryClient();
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    const onClose = vi.fn();
+    render(DatasetSplitHarness, { client, sampleType, onClose });
+    return { invalidate, onClose };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    filteredSampleCount.set(11);
+    imageFilter.set({
+        filter_type: 'image',
+        sample_filter: { tag_ids: ['images'] }
+    });
+    videoFilter.set({
+        filter_type: 'video',
+        sample_filter: { tag_ids: ['videos'] }
+    });
+});
+
+describe('useDatasetSplit', () => {
+    it.each(['image', 'video'] as const)(
+        'submits the captured %s scope and blocks repeats',
+        async (sampleType) => {
+            setup(sampleType);
+            const filter = {
+                filter_type: sampleType,
+                sample_filter: { tag_ids: [`${sampleType}s`] }
+            };
+            const store = sampleType === 'image' ? imageFilter : videoFilter;
+            store.update((filter) => ({ ...filter, sample_filter: { tag_ids: [] } }));
+            filteredSampleCount.set(100);
+            expect(screen.getByLabelText('Split 1 sample count')).toHaveTextContent('9 samples');
+            await fireEvent.input(screen.getByLabelText('Seed (optional)'), {
+                target: { value: '-7' }
+            });
+            vi.mocked(splitDataset).mockReturnValue(new Promise<never>(() => {}));
+            const form = screen.getByRole('button', { name: 'Split dataset' }).closest('form')!;
+            await fireEvent.submit(form);
+            await fireEvent.submit(form);
+            expect(splitDataset).toHaveBeenCalledOnce();
+            expect(splitDataset).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    path: { collection_id: 'collection' },
+                    body: expect.objectContaining({ filter, seed: -7 })
+                })
+            );
+            expect(screen.getByRole('button', { name: 'Splitting…' })).toBeDisabled();
+        }
+    );
+
+    it('preserves inputs on failure and refreshes on a successful retry', async () => {
+        const { invalidate, onClose } = setup('image');
+        await fireEvent.input(screen.getByLabelText('Tag 1'), { target: { value: 'training' } });
+        vi.mocked(splitDataset).mockRejectedValueOnce(new Error('Network error'));
+        await fireEvent.click(screen.getByRole('button', { name: 'Split dataset' }));
+        await waitFor(() =>
+            expect(screen.getByRole('alert')).toHaveTextContent('Unable to split dataset')
+        );
+        expect(screen.getByLabelText('Tag 1')).toHaveValue('training');
+        expect(onClose).not.toHaveBeenCalled();
+        vi.mocked(splitDataset).mockResolvedValueOnce({
+            data: [{ tag_name: 'training', sample_count: 9 }],
+            request: new Request('http://localhost'),
+            response: new Response()
+        });
+        await fireEvent.click(screen.getByRole('button', { name: 'Split dataset' }));
+        await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+        expect(loadTags).toHaveBeenCalledOnce();
+        expect(invalidate).toHaveBeenCalledOnce();
+        expect(toast.success).toHaveBeenCalledWith('training: 9');
+    });
+});


### PR DESCRIPTION
## What has changed and why?

- Add logic to split images or videos into several tags using the current filters.
- Refresh tags and show split counts after success.

Follow up from #2246 

## How has it been tested?

- Adds new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dataset splitting for image and video collections.
  * Displays sample counts, existing tags, submission progress, and errors.
  * Shows per-tag results after a successful split and refreshes related data.
  * Prevents duplicate submissions while processing.

* **Tests**
  * Added coverage for successful submissions, failures, filter handling, and pending-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->