### PR TITLE
Define the embedding protocol wire models and the result checks (embed stack 2/4)

### DIFF
--- a/lightly_studio_embed/Makefile
+++ b/lightly_studio_embed/Makefile
@@ -12,12 +12,9 @@ build: clean
 	@echo "Building a distribution package..."
 	uv build --package lightly-studio-embed --out-dir dist
 
-# Exit code 5 is "no tests collected". The package has no code to test yet, and any real
-# failure still fails the target.
-# TODO(Iunir, 09/2026): Drop the exit code 5 tolerance once the package has tests.
 .PHONY: test
 test:
 	@echo "Running tests..."
-	uv run pytest || [ $$? -eq 5 ]
+	uv run pytest
 
 include ../make/python.mk

--- a/lightly_studio_embed/src/lightly_studio_embed/errors.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/errors.py
@@ -1,0 +1,11 @@
+"""The errors that an embedder can raise or cause, in one module."""
+
+from __future__ import annotations
+
+
+class EmbedderContractError(RuntimeError):
+    """The embedder returned a result that the protocol does not allow.
+
+    The server answers 500 and names the problem. It does not send the result to
+    LightlyStudio.
+    """

--- a/lightly_studio_embed/src/lightly_studio_embed/protocol.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/protocol.py
@@ -1,0 +1,199 @@
+"""Wire models of the LightlyStudio embedding protocol, version 1.
+
+The module holds the request bodies, the response bodies, the route paths and the
+multipart field name. The server in this package sends these models.
+``lightly-studio`` reads the same models. One definition keeps the two halves equal.
+
+A server serves the capability ``{subject}_{transport}`` at
+``POST /v1/embed/{subjects}/{transport}``. The capability ``text`` has no transport
+segment. Text is already a payload.
+
+``EmbeddingsResponse`` holds every rule that a response body shows.
+``lightly_studio_embed.validation`` adds only the rules that the body cannot show.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Annotated, Any
+
+import numpy as np
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from lightly_studio_embed.embedder import Capability
+
+PROTOCOL_VERSION = "1.0"
+
+BASE_PATH = "/v1"
+
+DESCRIBE_PATH = f"{BASE_PATH}/describe"
+
+EMBED_TEXTS_PATH = f"{BASE_PATH}/embed/texts"
+
+EMBED_IMAGES_BYTES_PATH = f"{BASE_PATH}/embed/images/bytes"
+
+EMBED_VIDEOS_BYTES_PATH = f"{BASE_PATH}/embed/videos/bytes"
+
+# The multipart field that the bytes endpoints read. One part per item, in input order.
+FILES_FIELD_NAME = "files"
+
+# A number, because starlette renamed its constant for this status.
+STATUS_PAYLOAD_TOO_LARGE = 413
+
+# TODO(Iunir, 09/2026): Report a limit per capability. Text queries and videos do not
+# belong under one ceiling.
+DEFAULT_MAX_BATCH_SIZE = 1024
+
+DEFAULT_MAX_REQUEST_BYTES = 32 * 1024 * 1024
+
+# Both ends store the vectors as `float32`. A larger value becomes an infinity there.
+MAX_ABS_EMBEDDING_VALUE = float(np.finfo(np.float32).max)
+
+# `IMAGE_PIL` is an object in memory, so it cannot cross the wire. An fsspec path can.
+WIRE_CAPABILITIES = frozenset(Capability) - {Capability.IMAGE_PIL}
+
+# A kept index names a position in the request, so it is never negative.
+_KeptIndex = Annotated[int, Field(ge=0)]
+
+
+class ServerLimits(BaseModel):
+    """The limits that the server applies and reports. A client does not have to guess them."""
+
+    max_batch_size: int = Field(default=DEFAULT_MAX_BATCH_SIZE, gt=0)
+    """The largest number of items in one request."""
+
+    max_request_bytes: int = Field(default=DEFAULT_MAX_REQUEST_BYTES, gt=0)
+    """The largest request body that the server accepts, in bytes."""
+
+
+class DescribeResponse(BaseModel):
+    """The body of ``GET /v1/describe``. Every server has this endpoint."""
+
+    protocol_version: str = PROTOCOL_VERSION
+    """The version of this contract that the server speaks.
+
+    A client compares this against its own ``PROTOCOL_VERSION`` first. The model accepts
+    any string, so a client can name the version that it met.
+    """
+
+    space_key: str
+    """The identifier of the embedding space that the server produces."""
+
+    dimension: int = Field(gt=0)
+    """The length of every embedding vector that the server returns."""
+
+    # TODO(Iunir, 09/2026): A ServerStatus enum may replace this flag. A model that
+    # failed to load is not the same as a model that is still loading.
+    ready: bool
+    """Whether the model is loaded. ``False`` means try again soon. It is not an error."""
+
+    capabilities: list[Capability]
+    """The input kinds that this server accepts. These are the endpoints that it mounts.
+
+    The model permits only the members of ``WIRE_CAPABILITIES``. LightlyStudio cannot
+    request the other kinds.
+    """
+
+    limits: ServerLimits
+    """The limits that a client must apply to its batches."""
+
+    @field_validator("capabilities")
+    @classmethod
+    def _reject_unservable_capabilities(cls, value: list[Capability]) -> list[Capability]:
+        unservable = [capability for capability in value if capability not in WIRE_CAPABILITIES]
+        if unservable:
+            raise ValueError(
+                f"{unservable} cannot be served over HTTP; only {sorted(WIRE_CAPABILITIES)} can."
+            )
+        return value
+
+
+class EmbedTextsRequest(BaseModel):
+    """The body of ``POST /v1/embed/texts``."""
+
+    texts: list[str]
+    """The strings to embed. The server returns the embeddings in this order."""
+
+
+class EmbeddingsResponse(BaseModel):
+    """The body of every embed endpoint.
+
+    Each response repeats ``space_key`` and ``dimension``. A client reads them to find a
+    server that changed its weights and kept its ``space_key``.
+    """
+
+    space_key: str
+    """The identifier of the embedding space of these vectors."""
+
+    dimension: int = Field(gt=0)
+    """The length of every vector in ``embeddings``."""
+
+    kept_indices: list[_KeptIndex]
+    """The indices of the request items that the server embedded, in ascending order.
+
+    The server omits an item that it cannot decode. It does not fail the batch.
+    """
+
+    embeddings: list[list[float]]
+    """One row for each entry in ``kept_indices``, in the same order."""
+
+    @field_validator("kept_indices", mode="before")
+    @classmethod
+    def _reject_boolean_mask(cls, value: Any) -> Any:
+        """Reject a mask before the field turns it into indices.
+
+        An embedder that derives ``kept_indices`` from a numpy comparison, such as
+        ``scores > 0.5``, holds ``np.bool_`` values. A lax ``int`` field reads those as
+        ``0`` and ``1``. Every vector then lines up with the wrong item, and the database
+        keeps the wrong vector for the sample. The check runs before the conversion,
+        which is the only point where the bool is still visible.
+        """
+        if not isinstance(value, (list, tuple, np.ndarray)):
+            return value
+        for item in value:
+            if isinstance(item, (bool, np.bool_)):
+                raise ValueError(f"kept_indices holds {item!r}, a bool, not an index.")
+        return value
+
+    @model_validator(mode="after")
+    def _check_rows_against_indices(self) -> EmbeddingsResponse:  # noqa: N804
+        """Check the rules that hold between the fields.
+
+        A field type does not show that a response is correct. A client reads this model
+        from a server that it does not control. Without these rules a client aligns the
+        wrong vector with an item.
+        """
+        if len(self.embeddings) != len(self.kept_indices):
+            raise ValueError(
+                f"Got {len(self.embeddings)} embeddings for {len(self.kept_indices)} kept "
+                f"indices. The two must have the same length."
+            )
+        if any(
+            current >= following
+            for current, following in zip(self.kept_indices, self.kept_indices[1:])
+        ):
+            raise ValueError(f"kept_indices must be ascending and unique, got {self.kept_indices}.")
+        for index, row in enumerate(self.embeddings):
+            if len(row) != self.dimension:
+                raise ValueError(
+                    f"Embedding {index} has {len(row)} values. The server declares "
+                    f"dimension {self.dimension}."
+                )
+            _check_values(row=row, index=index)
+        return self
+
+
+def _check_values(row: list[float], index: int) -> None:
+    """Check one vector. A value outside ``float32`` is as wrong as a NaN.
+
+    Both ends store the vectors as ``float32``. A larger value becomes an infinity there,
+    and a similarity search then ranks it.
+    """
+    for value in row:
+        if not math.isfinite(value):
+            raise ValueError(f"Embedding {index} holds a value that is not finite.")
+        if abs(value) > MAX_ABS_EMBEDDING_VALUE:
+            raise ValueError(
+                f"Embedding {index} holds {value}, over the {MAX_ABS_EMBEDDING_VALUE} that "
+                f"the float32 of an embedding can hold. It would become an infinity."
+            )

--- a/lightly_studio_embed/src/lightly_studio_embed/validation.py
+++ b/lightly_studio_embed/src/lightly_studio_embed/validation.py
@@ -1,0 +1,108 @@
+"""Checks the result of an embedder before the server sends it.
+
+A broken result is cheap to find here, in the process of the customer. It is expensive to
+find later, as a similarity search that gives bad results in LightlyStudio.
+
+``EmbeddingsResponse`` holds every rule that a response body shows. This module does not
+repeat them. It checks the two rules that the body cannot show: the embedder returned a
+matrix of numbers, and each kept index names an item of this request.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+from pydantic import ValidationError
+
+from lightly_studio_embed.errors import EmbedderContractError
+from lightly_studio_embed.protocol import EmbeddingsResponse
+from lightly_studio_embed.types import EmbeddingResult
+
+# Float, signed integer and unsigned integer. A `bool` array is a mask, and an `object`
+# array holds anything.
+_NUMERIC_DTYPE_KINDS = frozenset("fiu")
+
+
+def build_embeddings_response(
+    result: EmbeddingResult, space_key: str, dimension: int, item_count: int
+) -> EmbeddingsResponse:
+    """Check the result of an embedder and convert it into a wire response.
+
+    Args:
+        result: What the embedder returned.
+        space_key: The embedding space of the embedder. The response repeats it.
+        dimension: The vector length that the embedder declares.
+        item_count: The number of items in the request.
+
+    Returns:
+        The response body for an embed endpoint.
+
+    Raises:
+        EmbedderContractError: If the result does not agree with the declared dimension,
+            with the number of kept indices, or with the items of the request.
+    """
+    _validate_embeddings(result.embeddings)
+    response = _to_response(result=result, space_key=space_key, dimension=dimension)
+    _validate_kept_indices(kept_indices=response.kept_indices, item_count=item_count)
+    return response
+
+
+def _validate_embeddings(embeddings: NDArray[np.float32]) -> None:
+    """Check that the embedder returned a matrix of numbers.
+
+    The wire model reads lists, so it cannot tell an array from anything else that holds
+    rows. Ragged rows and values that are not numbers never become a numeric array. Both
+    fail here, with the reason named.
+    """
+    if not isinstance(embeddings, np.ndarray):
+        raise EmbedderContractError(
+            f"embeddings must be a numpy array, with every row the same length. "
+            f"Got {type(embeddings).__name__}."
+        )
+    if embeddings.dtype.kind not in _NUMERIC_DTYPE_KINDS:
+        raise EmbedderContractError(
+            f"embeddings must hold numbers. Got an array of dtype {embeddings.dtype}."
+        )
+    # An embedder that kept no input returns an empty array of any shape. No row lines up
+    # with an index. The wire model still rejects a kept index that has no row.
+    if embeddings.ndim > 0 and embeddings.shape[0] == 0:
+        return
+    # A matrix has two axes: one of rows, one of the values in a row.
+    if embeddings.ndim != 2:  # noqa: PLR2004
+        raise EmbedderContractError(
+            f"embeddings must hold one row for each kept index, so a 2D array. "
+            f"Got {embeddings.ndim} dimensions."
+        )
+
+
+def _to_response(result: EmbeddingResult, space_key: str, dimension: int) -> EmbeddingsResponse:
+    """Build the wire body, and name the embedder that broke one of its rules.
+
+    The model raises for a client that reads a bad response. Here the embedder in this
+    process is at fault, so the same rule becomes an ``EmbedderContractError``. The server
+    then answers 500.
+    """
+    try:
+        return EmbeddingsResponse(
+            space_key=space_key,
+            dimension=dimension,
+            kept_indices=result.kept_indices,
+            embeddings=result.embeddings.tolist(),
+        )
+    except ValidationError as error:
+        raise EmbedderContractError(
+            f"The embedder returned a result that the protocol does not allow: {error}"
+        ) from error
+
+
+def _validate_kept_indices(kept_indices: list[int], item_count: int) -> None:
+    """Check that every kept index names an item of this request.
+
+    The wire model rejects a negative index and a repeated one. Only the server knows how
+    many items the request carried, so this function checks the upper bound.
+    """
+    if any(index >= item_count for index in kept_indices):
+        raise EmbedderContractError(
+            f"kept_indices must point into the {item_count} items of the request, "
+            f"got {kept_indices}."
+        )

--- a/lightly_studio_embed/tests/test_protocol.py
+++ b/lightly_studio_embed/tests/test_protocol.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from lightly_studio_embed.embedder import Capability
+from lightly_studio_embed.protocol import (
+    MAX_ABS_EMBEDDING_VALUE,
+    WIRE_CAPABILITIES,
+    DescribeResponse,
+    EmbeddingsResponse,
+    ServerLimits,
+)
+
+SPACE_KEY = "acme/model@v1"
+
+
+def test_describe_response() -> None:
+    response = _describe(capabilities=[Capability.TEXT, Capability.IMAGE_BYTES])
+
+    assert response.protocol_version == "1.0"
+    assert response.capabilities == [Capability.TEXT, Capability.IMAGE_BYTES]
+
+
+def test_describe_response__every_wire_capability_is_accepted() -> None:
+    response = _describe(capabilities=sorted(WIRE_CAPABILITIES))
+
+    assert set(response.capabilities) == WIRE_CAPABILITIES
+
+
+def test_describe_response__rejects_an_unservable_capability() -> None:
+    """LightlyStudio cannot request this kind. A server must not advertise it."""
+    with pytest.raises(ValidationError, match="cannot be served over HTTP"):
+        _describe(capabilities=[Capability.TEXT, Capability.IMAGE_PIL])
+
+
+def test_describe_response__rejects_a_dimension_of_zero() -> None:
+    """A zero-width space puts empty vectors into a similarity search."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        DescribeResponse(
+            space_key=SPACE_KEY,
+            dimension=0,
+            ready=True,
+            capabilities=[Capability.TEXT],
+            limits=ServerLimits(),
+        )
+
+
+def test_describe_response__keeps_a_numpy_integer_dimension() -> None:
+    """An embedder reads its dimension from a model. A model returns an ``np.int64``."""
+    response = DescribeResponse(
+        space_key=SPACE_KEY,
+        dimension=np.int64(512),  # type: ignore[arg-type]
+        ready=True,
+        capabilities=[Capability.TEXT],
+        limits=ServerLimits(),
+    )
+
+    assert response.dimension == 512
+
+
+def test_describe_response__keeps_an_unknown_protocol_version() -> None:
+    """A client must name the version that it met. The body must still parse."""
+    response = DescribeResponse.model_validate(
+        {
+            "protocol_version": "99.0",
+            "space_key": SPACE_KEY,
+            "dimension": 2,
+            "ready": True,
+            "capabilities": [Capability.TEXT],
+            "limits": {},
+        }
+    )
+
+    assert response.protocol_version == "99.0"
+
+
+def test_wire_capabilities__holds_every_kind_but_the_pil_image() -> None:
+    """An fsspec path crosses the wire. A PIL image is an object in this process only."""
+    assert frozenset(Capability) - WIRE_CAPABILITIES == {Capability.IMAGE_PIL}
+
+
+def test_embeddings_response() -> None:
+    response = _embeddings(kept_indices=[0, 2], embeddings=[[0.5, -0.5], [1.0, 0.0]])
+
+    assert response.kept_indices == [0, 2]
+    assert response.embeddings == [[0.5, -0.5], [1.0, 0.0]]
+
+
+def test_embeddings_response__row_count_mismatch() -> None:
+    """A client reads this model from a server that it does not control. The model checks."""
+    with pytest.raises(ValidationError, match="1 embeddings for 2 kept indices"):
+        _embeddings(kept_indices=[0, 1], embeddings=[[0.5, -0.5]])
+
+
+def test_embeddings_response__kept_indices_not_ascending() -> None:
+    with pytest.raises(ValidationError, match="ascending and unique"):
+        _embeddings(kept_indices=[1, 1], embeddings=[[0.5, -0.5], [1.0, 0.0]])
+
+
+def test_embeddings_response__negative_kept_index() -> None:
+    """A negative index selects an item from the end of the request."""
+    with pytest.raises(ValidationError, match="greater than or equal to 0"):
+        _embeddings(kept_indices=[-1], embeddings=[[0.5, -0.5]])
+
+
+def test_embeddings_response__kept_indices_are_a_json_boolean_mask() -> None:
+    """A lax int field reads ``[false, true]`` as the indices ``[0, 1]``."""
+    with pytest.raises(ValidationError, match="bool, not an index"):
+        EmbeddingsResponse.model_validate(
+            {
+                "space_key": SPACE_KEY,
+                "dimension": 2,
+                "kept_indices": [False, True],
+                "embeddings": [[0.5, -0.5], [1.0, 0.0]],
+            }
+        )
+
+
+def test_embeddings_response__kept_indices_are_a_numpy_boolean_mask() -> None:
+    """``np.bool_`` is not a ``bool``. An embedder in this process produces one."""
+    with pytest.raises(ValidationError, match="bool, not an index"):
+        _embeddings(
+            kept_indices=list(np.array([False, True])),
+            embeddings=[[0.5, -0.5], [1.0, 0.0]],
+        )
+
+
+def test_embeddings_response__kept_index_not_integral() -> None:
+    """The model rejects a float index. It does not truncate the index onto the wrong item."""
+    with pytest.raises(ValidationError, match="valid integer"):
+        _embeddings(
+            kept_indices=[0.9],  # type: ignore[list-item]
+            embeddings=[[0.5, -0.5]],
+        )
+
+
+def test_embeddings_response__wrong_dimension() -> None:
+    with pytest.raises(ValidationError, match="has 3 values"):
+        _embeddings(kept_indices=[0], embeddings=[[0.5, -0.5, 0.5]])
+
+
+def test_embeddings_response__rejects_a_dimension_of_zero() -> None:
+    """A zero-width vector clears every other check. It carries no data."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        _embeddings(kept_indices=[0], embeddings=[[]], dimension=0)
+
+
+def test_embeddings_response__value_not_finite() -> None:
+    with pytest.raises(ValidationError, match="not finite"):
+        _embeddings(kept_indices=[0], embeddings=[[0.5, float("nan")]])
+
+
+def test_embeddings_response__value_too_large_for_a_float32() -> None:
+    """The wire carries float64. Both ends store float32, so 1e300 becomes an infinity."""
+    with pytest.raises(ValidationError, match="would become an infinity"):
+        _embeddings(kept_indices=[0], embeddings=[[1e300, 1.0]])
+
+
+def test_embeddings_response__value_at_the_float32_limit() -> None:
+    response = _embeddings(kept_indices=[0], embeddings=[[MAX_ABS_EMBEDDING_VALUE, 1.0]])
+
+    assert response.embeddings == [[MAX_ABS_EMBEDDING_VALUE, 1.0]]
+
+
+def _describe(capabilities: list[Capability]) -> DescribeResponse:
+    return DescribeResponse(
+        space_key=SPACE_KEY,
+        dimension=2,
+        ready=True,
+        capabilities=capabilities,
+        limits=ServerLimits(),
+    )
+
+
+def _embeddings(
+    kept_indices: list[int], embeddings: list[list[float]], dimension: int = 2
+) -> EmbeddingsResponse:
+    return EmbeddingsResponse(
+        space_key=SPACE_KEY,
+        dimension=dimension,
+        kept_indices=kept_indices,
+        embeddings=embeddings,
+    )

--- a/lightly_studio_embed/tests/test_validation.py
+++ b/lightly_studio_embed/tests/test_validation.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lightly_studio_embed.errors import EmbedderContractError
+from lightly_studio_embed.types import EmbeddingResult
+from lightly_studio_embed.validation import build_embeddings_response
+
+SPACE_KEY = "acme/model@v1"
+
+
+def test_build_embeddings_response() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5], [1.0, 0.0]], dtype=np.float32), kept_indices=[0, 2]
+    )
+
+    response = build_embeddings_response(
+        result=result, space_key=SPACE_KEY, dimension=2, item_count=3
+    )
+
+    assert response.space_key == SPACE_KEY
+    assert response.dimension == 2
+    assert response.kept_indices == [0, 2]
+    assert response.embeddings == [[0.5, -0.5], [1.0, 0.0]]
+
+
+def test_build_embeddings_response__kept_nothing() -> None:
+    """An embedder that read no input returns an empty array of any width."""
+    result = EmbeddingResult(embeddings=np.empty((0, 0), dtype=np.float32), kept_indices=[])
+
+    response = build_embeddings_response(
+        result=result, space_key=SPACE_KEY, dimension=2, item_count=2
+    )
+
+    assert response.kept_indices == []
+    assert response.embeddings == []
+
+
+def test_build_embeddings_response__empty_array_that_still_has_a_row() -> None:
+    """``np.empty((1, 0))`` is empty. It still holds one row, and no index names it."""
+    result = EmbeddingResult(embeddings=np.empty((1, 0), dtype=np.float32), kept_indices=[])
+
+    with pytest.raises(EmbedderContractError, match="1 embeddings for 0 kept indices"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__kept_indices_out_of_range() -> None:
+    """Only the server knows how many items the request carried."""
+    result = EmbeddingResult(embeddings=np.array([[0.5, -0.5]], dtype=np.float32), kept_indices=[3])
+
+    with pytest.raises(EmbedderContractError, match="must point into the 2 items"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__negative_kept_index() -> None:
+    """The wire model owns this rule. The error still names the embedder."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32), kept_indices=[-1]
+    )
+
+    with pytest.raises(EmbedderContractError, match="greater than or equal to 0"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_not_ascending() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5], [1.0, 0.0]], dtype=np.float32), kept_indices=[1, 1]
+    )
+
+    with pytest.raises(EmbedderContractError, match="ascending and unique"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__row_count_mismatch() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32), kept_indices=[0, 1]
+    )
+
+    with pytest.raises(EmbedderContractError, match="1 embeddings for 2 kept indices"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__wrong_dimension() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5, 0.5]], dtype=np.float32), kept_indices=[0]
+    )
+
+    with pytest.raises(EmbedderContractError, match="has 3 values"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__not_a_matrix() -> None:
+    """A flat array holds the right number of values. It holds no rows."""
+    result = EmbeddingResult(embeddings=np.array([0.5, -0.5], dtype=np.float32), kept_indices=[0])
+
+    with pytest.raises(EmbedderContractError, match="Got 1 dimensions"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__value_not_finite() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, np.nan]], dtype=np.float32), kept_indices=[0]
+    )
+
+    with pytest.raises(EmbedderContractError, match="not finite"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__value_too_large_for_a_float32() -> None:
+    """A float64 array holds 1e300. The float32 of the database makes it an infinity."""
+    result = EmbeddingResult(
+        embeddings=np.array([[1e300, 1.0]], dtype=np.float64),
+        kept_indices=[0],
+    )
+
+    with pytest.raises(EmbedderContractError, match="would become an infinity"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__kept_index_not_integral() -> None:
+    """The model rejects a float index. It does not truncate the index onto the wrong item."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=[0.9],  # type: ignore[list-item]
+    )
+
+    with pytest.raises(EmbedderContractError, match="valid integer"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_are_a_boolean_mask() -> None:
+    """A lax int field converts a bool into 0 or 1. A mask must not pass for indices."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=[False, True],
+    )
+
+    with pytest.raises(EmbedderContractError, match="bool, not an index"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_are_a_numpy_boolean_mask() -> None:
+    """``np.bool_`` is not a ``bool``. A lax int field still converts it."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=list(np.array([False, True])),
+    )
+
+    with pytest.raises(EmbedderContractError, match="bool, not an index"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__kept_indices_hold_numpy_integers() -> None:
+    """``np.int64`` is a valid index. An embedder produces one often."""
+    result = EmbeddingResult(
+        embeddings=np.array([[0.5, -0.5]], dtype=np.float32),
+        kept_indices=list(np.array([1])),
+    )
+
+    response = build_embeddings_response(
+        result=result, space_key=SPACE_KEY, dimension=2, item_count=2
+    )
+
+    assert response.kept_indices == [1]
+
+
+def test_build_embeddings_response__ragged_rows() -> None:
+    """Ragged rows do not make a numeric array. The result is not an array at all."""
+    result = EmbeddingResult(
+        embeddings=[[0.5, -0.5], [1.0]],  # type: ignore[arg-type]
+        kept_indices=[0, 1],
+    )
+
+    with pytest.raises(EmbedderContractError, match="must be a numpy array"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=2)
+
+
+def test_build_embeddings_response__values_not_numbers() -> None:
+    result = EmbeddingResult(
+        embeddings=np.array([["not a number", 1.0]]),
+        kept_indices=[0],
+    )
+
+    with pytest.raises(EmbedderContractError, match="must hold numbers"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)
+
+
+def test_build_embeddings_response__a_none_among_the_values() -> None:
+    """``np.asarray`` maps ``None`` onto a NaN. The dtype names the fault."""
+    result = EmbeddingResult(
+        embeddings=np.array([[None, 1.0]]),
+        kept_indices=[0],
+    )
+
+    with pytest.raises(EmbedderContractError, match="must hold numbers"):
+        build_embeddings_response(result=result, space_key=SPACE_KEY, dimension=2, item_count=1)


### PR DESCRIPTION
## What has changed and why?

Part 2 of a 4-PR stack that splits #2240 (LIG-10691) into reviewable pieces. Stacked on #2257,
which has landed.

The shared definition of the contract, version 1. Still no server: this is what both halves
validate against.

- **`protocol.py`** — the request and response bodies, every route path and the multipart field
  the bytes endpoints read. `RemoteEmbedder` (LIG-10641) validates against these same models on
  the client side, so the two halves cannot drift apart.
- **`errors.py`** — `EmbedderContractError`, for a result the protocol does not allow.
- **`validation.py`** — the two things a response body cannot show about itself: that the embedder
  returned a matrix of numbers at all, and that each kept index names an item of *this* request. A
  broken embedder then fails in the customer's own process rather than as a similarity search
  misbehaving inside LightlyStudio.

Most of the line count is declarations and docstrings.

### One rule, one home

`EmbeddingsResponse` owns every rule that a body does show: one row per kept index, indices that
ascend and never go negative, the declared vector length, and values a `float32` can hold. That is
where the rules have to live, because a client reads this model from a server we did not write.
`validation.py` therefore does not repeat any of them — it builds the model and turns a
`ValidationError` into an `EmbedderContractError`, so the server still answers 500 and names the
embedder in its own process.

Three of those rules are new, and each one was reachable:

- **A negative index.** `kept_indices=[-1]` validated cleanly and would have selected the *last*
  item of the request on any `items[index]` lookup.
- **A boolean mask for `kept_indices`.** A lax `int` field reads `true` as `1`. An embedder that
  derives `kept_indices` from a numpy comparison, such as `scores > 0.5`, holds `np.bool_` values,
  and the field read those as `0` and `1`. Every vector then lined up with the wrong item. A
  `mode="before"` validator rejects a bool ahead of the coercion, which is the only point where the
  bool is still visible. `dimension` and the `ServerLimits` fields keep the lax conversion on
  purpose: a bool there reads as 1, and the next check fails and names the problem, so a guard buys
  nothing. Strict mode would reject the bool, but it would also reject the `np.int64` that an
  embedder reports as its dimension.
- **A value outside `float32`.** Both ends store the vectors as `float32`, so `1e300` reached the
  database as an infinity. Reading the array as `float64` never caught that, despite the comment
  which said it did.

`dimension` must now be positive on both responses. `dimension=0` cleared every other check and
put zero-width vectors on the wire.

`_as_indices` and `_as_array` are gone, and with them the transformation they did. `validation.py`
checks the type instead of converting it: a ragged or non-numeric result is not a numeric array,
which is now the error it gets. The wire model handles `np.int64` and rejects a float index on the
way in, so nothing is lost.

### Capabilities

**The protocol no longer carries its own capability enum.** `WireCapability` duplicated three of
`Capability`'s strings, so `DescribeResponse` now uses `Capability` itself (moved in #2257) and
`WIRE_CAPABILITIES` names the kinds that can cross the wire: every one except `IMAGE_PIL`, which is
an object in this process and nothing else — LightlyStudio would have to encode it to send it, and
`IMAGE_BYTES` is that transport already. An fsspec path *does* cross the wire, so a GPU host that
holds its own credentials can serve the ingest kinds once an endpoint mounts them. A validator
rejects `IMAGE_PIL`, so a server advertising it is refused rather than trusted. That check matters
most on the client side, where the response comes from a server we did not write.

`WireCapability`'s two URL kinds are dropped rather than merged in, along with `EmbedUrlsRequest`
and the two URL paths: nothing implements them, no capability names them, and `RemoteEmbedder` will
not call them. They come back with signed URL support and its own protocol.

**`CapabilityNotImplementedError` is gone.** A capability an embedder does not implement is an
interface it does not subclass, so the error had no case left to cover. The 501 path in stack 3
goes with it.

`__init__.py` re-exports only the embedder classes and the value types. `errors` and `protocol` are
imported from their submodules, so the top level stays a small surface rather than one bag of
symbols.

## Notes for the reviewer

- Dropping the enum costs the wire field its type-level guarantee, since `Capability` also names
  `IMAGE_PIL`. The validator buys it back at runtime, and covers a server written in another
  language too, which the type never did.
- `DEFAULT_MAX_BATCH_SIZE` is 1024, with a TODO on the design problem it surfaces: one ceiling for
  every endpoint is too coarse, and a batch of text queries does not belong under the same number
  as a batch of videos.
- `protocol_version` accepts any string on purpose. A client that can parse `/v1/describe` can
  report the version it met; a rejected body would only say the response did not parse. The field
  docstring says who compares it.
- `validation.py` keeps one explicit `ndim` check. A flat array of the right size lines no row up
  with a kept index, and `.tolist()` would only reach the wire model as a confusing type error.
- The package now has tests, so the Makefile drops its tolerance of pytest's "no tests collected"
  exit code.

## How has it been tested?

37 tests. `make static-checks` and `make test` pass on 3.9 and 3.14.

Nineteen over `protocol.py`: five on `DescribeResponse` (a normal body, all wire capabilities
accepted, `IMAGE_PIL` rejected, a zero dimension rejected, an `np.int64` dimension kept, an unknown
`protocol_version` kept), one on `WIRE_CAPABILITIES` itself, and twelve on `EmbeddingsResponse` —
the row-count mismatch, non-ascending indices, a negative index, a JSON boolean mask, a numpy
boolean mask, a float index, the wrong width, a zero dimension, a non-finite value, a value too
large for `float32`, and a value exactly at the `float32` limit that must pass.

Eighteen over `build_embeddings_response`: the happy path, an embedder that kept nothing, an empty
array that still has a row, indices out of range, a negative index, non-ascending indices, the
row-count mismatch, the wrong width, a non-matrix array, a non-finite value, a value too large for
`float32`, a float index, a Python and a numpy boolean mask, `np.int64` indices that must pass,
ragged rows, values that are not numbers, and a `None` among the values.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

**Stack** ([#2260](https://github.com/lightly-ai/lightly-studio/stacks/2260))

1. ~~#2257 — move the embedder interface into the workspace member~~ (merged)
2. #2258 — the protocol wire models and the result checks
3. #2259 — `create_app` and the embed endpoints
4. #2251 — the ASGI guards (bearer auth, size ceiling) and `serve()`

Alternative reviewer: @lukas-lightly.
