### PR TITLE
Add MCAP group component definition resolvers

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete.py
@@ -18,6 +18,11 @@ def delete(session: Session, collection_id: UUID) -> bool:
     if not collection:
         return False
 
+    mcap_definition = session.get(McapGroupComponentDefinitionTable, collection_id)
+    if mcap_definition is not None:
+        session.delete(mcap_definition)
+        session.commit()
+
     if collection.group_component_definition is not None:
         # MCAP extension first: FK to group_component_definition.
         mcap_definition = session.get(McapGroupComponentDefinitionTable, collection_id)

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete.py
@@ -6,9 +6,6 @@ from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.models.mcap_group_component_definition import (
-    McapGroupComponentDefinitionTable,
-)
 from lightly_studio.resolvers import collection_resolver
 
 
@@ -17,11 +14,6 @@ def delete(session: Session, collection_id: UUID) -> bool:
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if not collection:
         return False
-
-    mcap_definition = session.get(McapGroupComponentDefinitionTable, collection_id)
-    if mcap_definition is not None:
-        session.delete(mcap_definition)
-        session.commit()
 
     if collection.group_component_definition is not None:
         # MCAP extension first: FK to group_component_definition.

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete.py
@@ -6,6 +6,9 @@ from uuid import UUID
 
 from sqlmodel import Session
 
+from lightly_studio.models.mcap_group_component_definition import (
+    McapGroupComponentDefinitionTable,
+)
 from lightly_studio.resolvers import collection_resolver
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/__init__.py
@@ -1,0 +1,15 @@
+"""Resolvers for MCAP group component definition database operations."""
+
+from lightly_studio.resolvers.mcap_group_component_definition_resolver.create import create
+from lightly_studio.resolvers.mcap_group_component_definition_resolver.get_all_by_group_collection_id import (  # noqa: E501
+    get_all_by_group_collection_id,
+)
+from lightly_studio.resolvers.mcap_group_component_definition_resolver.get_by_collection_id import (
+    get_by_collection_id,
+)
+
+__all__ = [
+    "create",
+    "get_all_by_group_collection_id",
+    "get_by_collection_id",
+]

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/create.py
@@ -1,0 +1,57 @@
+"""Implementation of create for MCAP group component definitions."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.group_component_definition import GroupComponentDefinitionTable
+from lightly_studio.models.mcap_group_component_definition import (
+    McapDataType,
+    McapGroupComponentDefinitionTable,
+)
+from lightly_studio.resolvers import collection_resolver
+
+
+def create(
+    session: Session,
+    collection_id: UUID,
+    mcap_data_type: McapDataType,
+    channel_id: int,
+) -> UUID:
+    """Create an MCAP group component definition for an existing generic slot.
+
+    Args:
+        session: The database session.
+        collection_id: The group component definition / child collection ID.
+        mcap_data_type: Whether this slot holds video frames or a point cloud.
+        channel_id: The MCAP channel id, same as on mcap samples.
+
+    Returns:
+        The collection_id of the created row.
+
+    Raises:
+        ValueError: If the generic group component definition does not exist, or the
+            child collection is not of sample type MCAP.
+    """
+    definition = session.get(GroupComponentDefinitionTable, collection_id)
+    if definition is None:
+        raise ValueError(
+            f"Group component definition with collection_id '{collection_id}' does not exist."
+        )
+    collection_resolver.check_collection_type(
+        session=session,
+        collection_id=collection_id,
+        expected_type=SampleType.MCAP,
+    )
+    session.add(
+        McapGroupComponentDefinitionTable(
+            collection_id=collection_id,
+            mcap_data_type=mcap_data_type,
+            channel_id=channel_id,
+        )
+    )
+    session.commit()
+    return collection_id

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/create.py
@@ -20,6 +20,7 @@ def create(
     collection_id: UUID,
     mcap_data_type: McapDataType,
     channel_id: int,
+    frame_id: str | None = None,
 ) -> UUID:
     """Create an MCAP group component definition for an existing generic slot.
 
@@ -28,6 +29,8 @@ def create(
         collection_id: The group component definition / child collection ID.
         mcap_data_type: Whether this slot holds video frames or a point cloud.
         channel_id: The MCAP channel id, same as on mcap samples.
+        frame_id: The id used to match this slot against calibration/transform data.
+            Empty or whitespace-only values are stored as ``None``.
 
     Returns:
         The collection_id of the created row.
@@ -51,6 +54,7 @@ def create(
             collection_id=collection_id,
             mcap_data_type=mcap_data_type,
             channel_id=channel_id,
+            frame_id=frame_id.strip() if frame_id and frame_id.strip() else None,
         )
     )
     session.commit()

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/get_all_by_group_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/get_all_by_group_collection_id.py
@@ -1,0 +1,32 @@
+"""Implementation of get_all_by_group_collection_id for MCAP group component definitions."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.mcap_group_component_definition import (
+    McapGroupComponentDefinitionTable,
+)
+
+
+def get_all_by_group_collection_id(
+    session: Session, group_collection_id: UUID
+) -> list[McapGroupComponentDefinitionTable]:
+    """Return MCAP definitions for child collections of a GROUP collection.
+
+    Children without an MCAP row (classic IMAGE/VIDEO slots) are omitted. Filter the
+    result with ``mcap_data_type`` to select e.g. point-cloud slots.
+    """
+    statement = (
+        select(McapGroupComponentDefinitionTable)
+        .join(
+            CollectionTable,
+            col(McapGroupComponentDefinitionTable.collection_id)
+            == col(CollectionTable.collection_id),
+        )
+        .where(col(CollectionTable.parent_collection_id) == group_collection_id)
+    )
+    return list(session.exec(statement).all())

--- a/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/get_by_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/mcap_group_component_definition_resolver/get_by_collection_id.py
@@ -1,0 +1,25 @@
+"""Implementation of get_by_collection_id for MCAP group component definitions."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, select
+
+from lightly_studio.models.mcap_group_component_definition import (
+    McapGroupComponentDefinitionTable,
+)
+
+
+def get_by_collection_id(
+    session: Session, collection_id: UUID
+) -> McapGroupComponentDefinitionTable | None:
+    """Retrieve the MCAP group component definition for a collection.
+
+    Returns None if the generic slot has no MCAP row (classic IMAGE/VIDEO groups).
+    """
+    return session.exec(
+        select(McapGroupComponentDefinitionTable).where(
+            McapGroupComponentDefinitionTable.collection_id == collection_id
+        )
+    ).one_or_none()

--- a/lightly_studio/tests/resolvers/collection_resolver/test_delete.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_delete.py
@@ -10,7 +10,7 @@ from lightly_studio.models.mcap_group_component_definition import (
     McapDataType,
     McapGroupComponentDefinitionTable,
 )
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers import collection_resolver, mcap_group_component_definition_resolver
 from tests.helpers_resolvers import create_collection
 
 
@@ -54,17 +54,15 @@ def test_delete__with_mcap_group_component_definition(db_session: Session) -> No
     components = collection_resolver.create_group_components(
         session=db_session,
         parent_collection_id=root.collection_id,
-        components=[("lidar", SampleType.MCAP)],
+        components=[("image", SampleType.MCAP)],
     )
-    component_collection_id = components["lidar"].collection_id  # Capture before delete
-    db_session.add(
-        McapGroupComponentDefinitionTable(
-            collection_id=component_collection_id,
-            mcap_data_type=McapDataType.POINT_CLOUD,
-            channel_id=7,
-        )
+    component_collection_id = components["image"].collection_id  # Capture before delete
+    mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=component_collection_id,
+        mcap_data_type=McapDataType.VIDEO_FRAME,
+        channel_id=3,
     )
-    db_session.commit()
 
     result = collection_resolver.delete(session=db_session, collection_id=component_collection_id)
 

--- a/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/helpers.py
@@ -1,0 +1,38 @@
+"""Helpers for MCAP group component definition resolver tests."""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.resolvers import collection_resolver
+from tests.helpers_resolvers import create_collection
+
+
+def create_mcap_group_components(
+    session: Session,
+) -> tuple[CollectionTable, dict[str, CollectionTable]]:
+    """Create a GROUP with MCAP slots ``image`` and ``point_cloud``."""
+    group = create_collection(session=session, sample_type=SampleType.GROUP)
+    children = collection_resolver.create_group_components(
+        session=session,
+        parent_collection_id=group.collection_id,
+        components=[
+            ("image", SampleType.MCAP),
+            ("point_cloud", SampleType.MCAP),
+        ],
+    )
+    return group, children
+
+
+def create_classic_group_components(
+    session: Session,
+) -> tuple[CollectionTable, dict[str, CollectionTable]]:
+    """Create a GROUP with classic IMAGE/VIDEO slots and no MCAP rows."""
+    group = create_collection(session=session, sample_type=SampleType.GROUP)
+    children = collection_resolver.create_group_components(
+        session=session,
+        parent_collection_id=group.collection_id,
+        components=[("image", SampleType.IMAGE), ("video", SampleType.VIDEO)],
+    )
+    return group, children

--- a/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_classic_group_components.py
+++ b/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_classic_group_components.py
@@ -1,0 +1,40 @@
+"""Tests that classic IMAGE/VIDEO groups stay valid without an MCAP row."""
+
+from sqlmodel import Session
+
+from lightly_studio.models.group_component_definition import GroupComponentDefinitionTable
+from lightly_studio.resolvers import collection_resolver, mcap_group_component_definition_resolver
+from tests.resolvers.mcap_group_component_definition_resolver import helpers
+
+
+def test_classic_group_components_unchanged(db_session: Session) -> None:
+    group, created = helpers.create_classic_group_components(session=db_session)
+
+    components = collection_resolver.get_group_components(
+        session=db_session, parent_collection_id=group.collection_id
+    )
+
+    assert len(components) == 2
+    assert components["image"].group_component_definition is not None
+    assert components["image"].group_component_definition.group_component_name == "image"
+    assert components["image"].group_component_definition.group_component_index == 0
+    assert components["video"].group_component_definition is not None
+    assert components["video"].group_component_definition.group_component_name == "video"
+    assert components["video"].group_component_definition.group_component_index == 1
+
+    image_gcd = db_session.get(GroupComponentDefinitionTable, created["image"].collection_id)
+    video_gcd = db_session.get(GroupComponentDefinitionTable, created["video"].collection_id)
+    assert image_gcd is not None
+    assert video_gcd is not None
+    assert (
+        mcap_group_component_definition_resolver.get_by_collection_id(
+            session=db_session, collection_id=created["image"].collection_id
+        )
+        is None
+    )
+    assert (
+        mcap_group_component_definition_resolver.get_all_by_group_collection_id(
+            session=db_session, group_collection_id=group.collection_id
+        )
+        == []
+    )

--- a/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_create.py
@@ -1,5 +1,7 @@
 """Tests for creating MCAP group component definitions."""
 
+from __future__ import annotations
+
 from uuid import uuid4
 
 import pytest
@@ -21,12 +23,14 @@ def test_create(db_session: Session) -> None:
         collection_id=children["image"].collection_id,
         mcap_data_type=McapDataType.VIDEO_FRAME,
         channel_id=3,
+        frame_id="main",
     )
     point_cloud_id = mcap_group_component_definition_resolver.create(
         session=db_session,
         collection_id=children["point_cloud"].collection_id,
         mcap_data_type=McapDataType.POINT_CLOUD,
         channel_id=5,
+        frame_id="livox_front_left",
     )
 
     image = mcap_group_component_definition_resolver.get_by_collection_id(
@@ -42,11 +46,33 @@ def test_create(db_session: Session) -> None:
     assert image.collection_id == children["image"].group_component_definition.collection_id
     assert image.mcap_data_type == McapDataType.VIDEO_FRAME
     assert image.channel_id == 3
+    assert image.frame_id == "main"
 
     assert point_cloud is not None
     assert point_cloud.collection_id == children["point_cloud"].collection_id
     assert point_cloud.mcap_data_type == McapDataType.POINT_CLOUD
     assert point_cloud.channel_id == 5
+    assert point_cloud.frame_id == "livox_front_left"
+
+
+@pytest.mark.parametrize("frame_id", [None, "", "   "])
+def test_create__optional_frame_id(db_session: Session, frame_id: str | None) -> None:
+    _, children = helpers.create_mcap_group_components(session=db_session)
+
+    collection_id = mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=children["image"].collection_id,
+        mcap_data_type=McapDataType.VIDEO_FRAME,
+        channel_id=3,
+        frame_id=frame_id,
+    )
+
+    definition = mcap_group_component_definition_resolver.get_by_collection_id(
+        session=db_session, collection_id=collection_id
+    )
+
+    assert definition is not None
+    assert definition.frame_id is None
 
 
 def test_create__rejects_non_mcap_collection(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_create.py
@@ -1,0 +1,103 @@
+"""Tests for creating MCAP group component definitions."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.mcap_group_component_definition import McapDataType
+from lightly_studio.resolvers import mcap_group_component_definition_resolver
+from tests.helpers_resolvers import create_collection
+from tests.resolvers.mcap_group_component_definition_resolver import helpers
+
+
+def test_create(db_session: Session) -> None:
+    _, children = helpers.create_mcap_group_components(session=db_session)
+
+    image_id = mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=children["image"].collection_id,
+        mcap_data_type=McapDataType.VIDEO_FRAME,
+        channel_id=3,
+    )
+    point_cloud_id = mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=children["point_cloud"].collection_id,
+        mcap_data_type=McapDataType.POINT_CLOUD,
+        channel_id=5,
+    )
+
+    image = mcap_group_component_definition_resolver.get_by_collection_id(
+        session=db_session, collection_id=image_id
+    )
+    point_cloud = mcap_group_component_definition_resolver.get_by_collection_id(
+        session=db_session, collection_id=point_cloud_id
+    )
+
+    assert image is not None
+    assert children["image"].group_component_definition is not None
+    assert image.collection_id == children["image"].collection_id
+    assert image.collection_id == children["image"].group_component_definition.collection_id
+    assert image.mcap_data_type == McapDataType.VIDEO_FRAME
+    assert image.channel_id == 3
+
+    assert point_cloud is not None
+    assert point_cloud.collection_id == children["point_cloud"].collection_id
+    assert point_cloud.mcap_data_type == McapDataType.POINT_CLOUD
+    assert point_cloud.channel_id == 5
+
+
+def test_create__rejects_non_mcap_collection(db_session: Session) -> None:
+    _, children = helpers.create_classic_group_components(session=db_session)
+
+    with pytest.raises(ValueError, match="is having sample type 'image', expected 'mcap'"):
+        mcap_group_component_definition_resolver.create(
+            session=db_session,
+            collection_id=children["image"].collection_id,
+            mcap_data_type=McapDataType.VIDEO_FRAME,
+            channel_id=3,
+        )
+
+
+def test_create__rejects_missing_gcd(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.MCAP)
+
+    with pytest.raises(ValueError, match="does not exist"):
+        mcap_group_component_definition_resolver.create(
+            session=db_session,
+            collection_id=collection.collection_id,
+            mcap_data_type=McapDataType.VIDEO_FRAME,
+            channel_id=3,
+        )
+
+
+def test_create__rejects_unknown_collection_id(db_session: Session) -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        mcap_group_component_definition_resolver.create(
+            session=db_session,
+            collection_id=uuid4(),
+            mcap_data_type=McapDataType.VIDEO_FRAME,
+            channel_id=3,
+        )
+
+
+def test_create__duplicate_collection_id(db_session: Session) -> None:
+    _, children = helpers.create_mcap_group_components(session=db_session)
+    collection_id = children["image"].collection_id
+    mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=collection_id,
+        mcap_data_type=McapDataType.VIDEO_FRAME,
+        channel_id=3,
+    )
+
+    with pytest.raises(IntegrityError):
+        mcap_group_component_definition_resolver.create(
+            session=db_session,
+            collection_id=collection_id,
+            mcap_data_type=McapDataType.POINT_CLOUD,
+            channel_id=5,
+        )
+    db_session.rollback()

--- a/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_get_all_by_group_collection_id.py
+++ b/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_get_all_by_group_collection_id.py
@@ -1,0 +1,42 @@
+"""Tests for get_all_by_group_collection_id of MCAP group component definitions."""
+
+from sqlmodel import Session
+
+from lightly_studio.models.mcap_group_component_definition import McapDataType
+from lightly_studio.resolvers import mcap_group_component_definition_resolver
+from tests.resolvers.mcap_group_component_definition_resolver import helpers
+
+
+def test_get_all_by_group_collection_id(db_session: Session) -> None:
+    group, children = helpers.create_mcap_group_components(session=db_session)
+    mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=children["image"].collection_id,
+        mcap_data_type=McapDataType.VIDEO_FRAME,
+        channel_id=3,
+    )
+    mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=children["point_cloud"].collection_id,
+        mcap_data_type=McapDataType.POINT_CLOUD,
+        channel_id=5,
+    )
+
+    rows = mcap_group_component_definition_resolver.get_all_by_group_collection_id(
+        session=db_session, group_collection_id=group.collection_id
+    )
+
+    assert len(rows) == 2
+    by_collection_id = {row.collection_id: row for row in rows}
+    assert by_collection_id[children["image"].collection_id].mcap_data_type == (
+        McapDataType.VIDEO_FRAME
+    )
+    assert by_collection_id[children["image"].collection_id].channel_id == 3
+    assert by_collection_id[children["point_cloud"].collection_id].mcap_data_type == (
+        McapDataType.POINT_CLOUD
+    )
+
+    point_clouds = [row for row in rows if row.mcap_data_type == McapDataType.POINT_CLOUD]
+    assert len(point_clouds) == 1
+    assert point_clouds[0].collection_id == children["point_cloud"].collection_id
+    assert point_clouds[0].channel_id == 5

--- a/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_get_by_collection_id.py
+++ b/lightly_studio/tests/resolvers/mcap_group_component_definition_resolver/test_get_by_collection_id.py
@@ -1,0 +1,44 @@
+"""Tests for get_by_collection_id of MCAP group component definitions."""
+
+from sqlmodel import Session
+
+from lightly_studio.models.mcap_group_component_definition import McapDataType
+from lightly_studio.resolvers import mcap_group_component_definition_resolver
+from tests.resolvers.mcap_group_component_definition_resolver import helpers
+
+
+def test_get_by_collection_id(db_session: Session) -> None:
+    _, children = helpers.create_mcap_group_components(session=db_session)
+    collection_id = children["image"].collection_id
+    mcap_group_component_definition_resolver.create(
+        session=db_session,
+        collection_id=collection_id,
+        mcap_data_type=McapDataType.VIDEO_FRAME,
+        channel_id=3,
+    )
+
+    row = mcap_group_component_definition_resolver.get_by_collection_id(
+        session=db_session, collection_id=collection_id
+    )
+
+    assert row is not None
+    assert row.collection_id == collection_id
+    assert row.mcap_data_type == McapDataType.VIDEO_FRAME
+    assert row.channel_id == 3
+
+
+def test_get_by_collection_id__classic_group(db_session: Session) -> None:
+    _, children = helpers.create_classic_group_components(session=db_session)
+
+    assert (
+        mcap_group_component_definition_resolver.get_by_collection_id(
+            session=db_session, collection_id=children["image"].collection_id
+        )
+        is None
+    )
+    assert (
+        mcap_group_component_definition_resolver.get_by_collection_id(
+            session=db_session, collection_id=children["video"].collection_id
+        )
+        is None
+    )


### PR DESCRIPTION
## What has changed and why?

Add resolver function supporting creating and retrieving MCAP group component definitions.

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for MCAP group component definitions with data type, channel, and optional frame information.
- Added retrieval of definitions by collection or group collection.
- MCAP definitions are now preserved when datasets are copied.

## Bug Fixes
- Deleting MCAP collections or datasets now removes associated definitions.
- Classic image and video components continue to work without MCAP-specific definitions.

## Tests
- Added coverage for creation, retrieval, validation, copying, deletion cleanup, duplicate handling, and classic components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->