### PR TITLE
Add: Dataset splitting to the image and video menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a Split dataset menu action to divide images or videos into tagged splits using the current filters.
 - Add a Glossary page to the docs.
 
 ### Changed

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
@@ -30,7 +30,7 @@
         { tag_name: 'val', relative_size: 1 },
         { tag_name: 'test', relative_size: 1 }
     ]);
-    let seed = $state('');
+    let seed = $state('42');
     const splitError = $derived(getSplitError({ splits, sampleCount, existingTagNames }));
     const seedError = $derived(
         seed.trim() && !Number.isSafeInteger(Number(seed))
@@ -41,7 +41,6 @@
     const counts = $derived(splitError ? [] : getSplitCounts(sampleCount, splits));
 
     let submitting = false;
-
     async function submit(event: SubmitEvent) {
         event.preventDefault();
         if (submitting || pending || validationError) return;
@@ -62,7 +61,10 @@
         <Dialog.Header>
             <Dialog.Title>Split dataset</Dialog.Title>
             <Dialog.Description>
-                Split {sampleCount} matching samples into three tags using relative weights.
+                Randomly divide the {sampleCount} samples matching your current filters into three new
+                tags. Choose a name and weight for each tag. Larger weights get more samples; for example,
+                8:1:1 gives roughly 80%, 10%, and 10%. The counts below preview each tag’s share. Each
+                sample receives one of these tags.
             </Dialog.Description>
         </Dialog.Header>
         <form onsubmit={submit} novalidate class="space-y-4">
@@ -72,8 +74,16 @@
                 {/each}
                 <label class="block space-y-1 text-sm">
                     Seed (optional)
-                    <Input bind:value={seed} placeholder="Random" />
+                    <Input
+                        bind:value={seed}
+                        inputmode="numeric"
+                        aria-describedby="dataset-split-seed-help"
+                    />
                 </label>
+                <p id="dataset-split-seed-help" class="text-sm text-muted-foreground">
+                    Use the same whole-number seed to repeat a split of the same samples. Clear it
+                    for a random split each time.
+                </p>
             </fieldset>
             {#if validationError || error}
                 <p role="alert" class="text-sm text-destructive">{validationError || error}</p>

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.test.ts
@@ -25,6 +25,9 @@ describe('DatasetSplitDialog', () => {
             tag_name,
             relative_size: 1
         }));
+        expect(onSubmit).toHaveBeenLastCalledWith({ splits, seed: 42 });
+        await fireEvent.input(screen.getByLabelText('Seed (optional)'), { target: { value: '' } });
+        await fireEvent.click(button);
         expect(onSubmit).toHaveBeenLastCalledWith({ splits });
         await fireEvent.input(screen.getByLabelText('Seed (optional)'), {
             target: { value: '-7' }

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.svelte.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.svelte.ts
@@ -40,9 +40,12 @@ export function useDatasetSplit(getOptions: () => Options) {
             // Tags have a separate store; refresh both it and queries that may depend on tags.
             await Promise.all([loadTags(), client.invalidateQueries()]);
             toast.success(
-                counts
-                    .map(({ tag_name, sample_count }) => `${tag_name}: ${sample_count}`)
-                    .join(', ')
+                `Created the following tags: ${counts
+                    .map(
+                        ({ tag_name, sample_count }) =>
+                            `${tag_name} (${sample_count} ${sample_count === 1 ? 'sample' : 'samples'})`
+                    )
+                    .join(', ')}.`
             );
             onClose();
         } catch {

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.test.ts
@@ -97,6 +97,8 @@ describe('useDatasetSplit', () => {
         await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
         expect(loadTags).toHaveBeenCalledOnce();
         expect(invalidate).toHaveBeenCalledOnce();
-        expect(toast.success).toHaveBeenCalledWith('training: 9');
+        expect(toast.success).toHaveBeenCalledWith(
+            'Created the following tags: training (9 samples).'
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplitDialog/index.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplitDialog/index.ts
@@ -1,11 +1,12 @@
 import { writable } from 'svelte/store';
 
-const isDatasetSplitDialogOpen = writable(false);
+const datasetSplitCollectionId = writable<string | null>(null);
 
 export function useDatasetSplitDialog() {
     return {
-        isDatasetSplitDialogOpen,
-        openDatasetSplitDialog: () => isDatasetSplitDialogOpen.set(true),
-        closeDatasetSplitDialog: () => isDatasetSplitDialogOpen.set(false)
+        datasetSplitCollectionId,
+        openDatasetSplitDialog: (collectionId: string) =>
+            datasetSplitCollectionId.set(collectionId),
+        closeDatasetSplitDialog: () => datasetSplitCollectionId.set(null)
     };
 }

--- a/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplitDialog/index.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/useDatasetSplitDialog/index.ts
@@ -1,0 +1,11 @@
+import { writable } from 'svelte/store';
+
+const isDatasetSplitDialogOpen = writable(false);
+
+export function useDatasetSplitDialog() {
+    return {
+        isDatasetSplitDialogOpen,
+        openDatasetSplitDialog: () => isDatasetSplitDialogOpen.set(true),
+        closeDatasetSplitDialog: () => isDatasetSplitDialogOpen.set(false)
+    };
+}

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -46,6 +46,10 @@
 
     type MenuAction = SelectItem & { onSelect: () => void };
 
+    const addAction = (items: MenuAction[], enabled: boolean, action: MenuAction) => {
+        if (enabled) items.push(action);
+    };
+
     const hasClassifier = $derived(isImages && hasEmbeddings);
     const hasSampling = $derived(isImages || isVideos);
     const hasExport = $derived(
@@ -59,69 +63,61 @@
     const menuActions = $derived.by<MenuAction[]>(() => {
         const items: MenuAction[] = [];
 
-        if (hasClassifier && isEditor) {
-            items.push({
-                value: 'menu-classifiers',
-                label: 'Few Shot Classifier',
-                icon: BrainCircuitIcon,
-                testId: 'menu-classifiers',
-                onSelect: openClassifiersMenu
-            });
-        }
+        addAction(items, hasClassifier && isEditor, {
+            value: 'menu-classifiers',
+            label: 'Few Shot Classifier',
+            icon: BrainCircuitIcon,
+            testId: 'menu-classifiers',
+            onSelect: openClassifiersMenu
+        });
 
-        if (hasSampling && isEditor) {
-            items.push({
-                value: 'menu-sampling',
-                label: 'Sampling',
-                icon: WandSparklesIcon,
-                testId: 'menu-sampling',
-                onSelect: () =>
-                    openSamplingDialog({
-                        collection_id: page.params.collection_id!,
-                        filtered_sample_count: get(filteredSampleCount)
-                    })
-            });
-        }
+        addAction(items, hasSampling && isEditor, {
+            value: 'menu-sampling',
+            label: 'Sampling',
+            icon: WandSparklesIcon,
+            testId: 'menu-sampling',
+            onSelect: () =>
+                openSamplingDialog({
+                    collection_id: page.params.collection_id!,
+                    filtered_sample_count: get(filteredSampleCount)
+                })
+        });
 
-        if (hasSampling && isEditor && ['image', 'video'].includes(collection.sample_type)) {
-            items.push({
+        addAction(
+            items,
+            hasSampling && isEditor && ['image', 'video'].includes(collection.sample_type),
+            {
                 value: 'menu-dataset-split',
                 label: 'Split dataset',
                 icon: SplitIcon,
                 testId: 'menu-dataset-split',
                 onSelect: () => openDatasetSplitDialog(collection.collection_id)
-            });
-        }
+            }
+        );
 
-        if (isEditor) {
-            items.push({
-                value: 'menu-operators',
-                label: 'Plugins',
-                icon: PuzzleIcon,
-                testId: 'menu-operators',
-                onSelect: openOperatorsDialog
-            });
-        }
+        addAction(items, isEditor, {
+            value: 'menu-operators',
+            label: 'Plugins',
+            icon: PuzzleIcon,
+            testId: 'menu-operators',
+            onSelect: openOperatorsDialog
+        });
 
-        if (hasExport) {
-            items.push({
-                value: 'menu-export',
-                label: 'Export',
-                icon: DownloadIcon,
-                testId: 'menu-export',
-                onSelect: () => openExportDialog({ collectionId: collection.collection_id })
-            });
-        }
+        addAction(items, hasExport, {
+            value: 'menu-export',
+            label: 'Export',
+            icon: DownloadIcon,
+            testId: 'menu-export',
+            onSelect: () => openExportDialog({ collectionId: collection.collection_id })
+        });
 
-        if (isEditor) {
-            items.push({
-                value: 'menu-settings',
-                label: 'Settings',
-                icon: SettingsIcon,
-                testId: 'menu-settings',
-                onSelect: openSettingsDialog
-            });
-        }
+        addAction(items, isEditor, {
+            value: 'menu-settings',
+            label: 'Settings',
+            icon: SettingsIcon,
+            testId: 'menu-settings',
+            onSelect: openSettingsDialog
+        });
 
         return items;
     });

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -89,7 +89,7 @@
                 label: 'Split dataset',
                 icon: SplitIcon,
                 testId: 'menu-dataset-split',
-                onSelect: openDatasetSplitDialog
+                onSelect: () => openDatasetSplitDialog(collection.collection_id)
             });
         }
 

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { useDatasetSplitDialog } from '$lib/components/DatasetSplit/useDatasetSplitDialog';
     import { page } from '$app/state';
     import { Select, type SelectItem } from '$lib/components/Select';
     import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
@@ -9,6 +10,7 @@
     import { get } from 'svelte/store';
     import { useGlobalStorage } from '$lib/hooks';
     import {
+        Split as SplitIcon,
         Puzzle as PuzzleIcon,
         Download as DownloadIcon,
         Settings as SettingsIcon,
@@ -34,6 +36,7 @@
         user?: LightlyEnterpriseSession['user'];
     }>();
 
+    const { openDatasetSplitDialog } = useDatasetSplitDialog();
     const { openClassifiersMenu } = useClassifiersMenu();
     const { openSamplingDialog } = useSamplingDialog();
     const { filteredSampleCount } = useGlobalStorage();
@@ -77,6 +80,16 @@
                         collection_id: page.params.collection_id!,
                         filtered_sample_count: get(filteredSampleCount)
                     })
+            });
+        }
+
+        if (hasSampling && isEditor && ['image', 'video'].includes(collection.sample_type)) {
+            items.push({
+                value: 'menu-dataset-split',
+                label: 'Split dataset',
+                icon: SplitIcon,
+                testId: 'menu-dataset-split',
+                onSelect: openDatasetSplitDialog
             });
         }
 

--- a/lightly_studio_view/src/lib/components/Header/Menu.test.ts
+++ b/lightly_studio_view/src/lib/components/Header/Menu.test.ts
@@ -76,21 +76,6 @@ describe('Split dataset menu', () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
-    it.each(['viewer', 'labeler', 'editor', 'admin'] as const)(
-        'respects the %s role',
-        async (role) => {
-            render(Menu, {
-                collection,
-                isImages: true,
-                user: { role, username: 'user', email: 'user@example.com' }
-            });
-            await openMenu();
-            expect(screen.queryByTestId('menu-dataset-split') !== null).toBe(
-                role === 'editor' || role === 'admin'
-            );
-        }
-    );
-
     it.each(['image', 'video_frame', 'group'] as const)(
         'hides splitting outside image/video grids (%s)',
         async (sample_type) => {

--- a/lightly_studio_view/src/lib/components/Header/Menu.test.ts
+++ b/lightly_studio_view/src/lib/components/Header/Menu.test.ts
@@ -25,7 +25,7 @@ const collection: CollectionView = {
     updated_at: new Date('2026-01-01')
 };
 
-const { closeDatasetSplitDialog } = useDatasetSplitDialog();
+const { openDatasetSplitDialog, closeDatasetSplitDialog } = useDatasetSplitDialog();
 
 async function openMenu() {
     await fireEvent.keyDown(screen.getByTestId('menu-trigger'), { key: 'Enter' });
@@ -59,6 +59,22 @@ describe('Split dataset menu', () => {
             expect(await screen.findByLabelText('Tag 1')).toHaveValue('train');
         }
     );
+
+    it('discards the open dialog when navigating or unmounting the host', async () => {
+        const props = { collection, isImages: true };
+        const host = render(MenuDialogHost, props);
+        openDatasetSplitDialog(collection.collection_id);
+        expect(await screen.findByRole('dialog')).toBeInTheDocument();
+        await host.rerender({ collection: { ...collection, collection_id: 'other-collection' } });
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        await host.rerender(props);
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        openDatasetSplitDialog(collection.collection_id);
+        expect(await screen.findByRole('dialog')).toBeInTheDocument();
+        host.unmount();
+        render(MenuDialogHost, props);
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
 
     it.each(['viewer', 'labeler', 'editor', 'admin'] as const)(
         'respects the %s role',

--- a/lightly_studio_view/src/lib/components/Header/Menu.test.ts
+++ b/lightly_studio_view/src/lib/components/Header/Menu.test.ts
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { writable } from 'svelte/store';
+import type { CollectionView } from '$lib/api/lightly_studio_local';
+import { useDatasetSplitDialog } from '$lib/components/DatasetSplit/useDatasetSplitDialog';
+import Menu from './Menu.svelte';
+import MenuDialogHost from './MenuDialogHost.svelte';
+
+vi.mock('$lib/components/DatasetSplit/useDatasetSplit/useDatasetSplit.svelte', () => ({
+    useDatasetSplit: () => ({
+        sampleCount: 10,
+        tags: writable([]),
+        pending: writable(false),
+        error: writable(undefined),
+        submit: vi.fn()
+    })
+}));
+
+const collection: CollectionView = {
+    collection_id: 'collection-id',
+    dataset_id: 'dataset-id',
+    name: 'Collection',
+    sample_type: 'image',
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01')
+};
+
+const { closeDatasetSplitDialog } = useDatasetSplitDialog();
+
+async function openMenu() {
+    await fireEvent.keyDown(screen.getByTestId('menu-trigger'), { key: 'Enter' });
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+}
+
+describe('Split dataset menu', () => {
+    afterEach(closeDatasetSplitDialog);
+
+    it.each(['image', 'video'] as const)(
+        'opens, closes and reopens on the %s grid',
+        async (sample_type) => {
+            const props = {
+                collection: { ...collection, sample_type },
+                isImages: sample_type === 'image',
+                isVideos: sample_type === 'video'
+            };
+            render(Menu, props);
+            render(MenuDialogHost, props);
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            await openMenu();
+            await fireEvent.pointerUp(screen.getByTestId('menu-dataset-split'));
+            expect(await screen.findByRole('dialog')).toBeInTheDocument();
+            await fireEvent.input(screen.getByLabelText('Tag 1'), {
+                target: { value: 'training' }
+            });
+            await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            await openMenu();
+            await fireEvent.pointerUp(screen.getByTestId('menu-dataset-split'));
+            expect(await screen.findByLabelText('Tag 1')).toHaveValue('train');
+        }
+    );
+
+    it.each(['viewer', 'labeler', 'editor', 'admin'] as const)(
+        'respects the %s role',
+        async (role) => {
+            render(Menu, {
+                collection,
+                isImages: true,
+                user: { role, username: 'user', email: 'user@example.com' }
+            });
+            await openMenu();
+            expect(screen.queryByTestId('menu-dataset-split') !== null).toBe(
+                role === 'editor' || role === 'admin'
+            );
+        }
+    );
+
+    it.each(['image', 'video_frame', 'group'] as const)(
+        'hides splitting outside image/video grids (%s)',
+        async (sample_type) => {
+            render(Menu, { collection: { ...collection, sample_type } });
+            await openMenu();
+            expect(screen.queryByTestId('menu-dataset-split')).not.toBeInTheDocument();
+        }
+    );
+});

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onDestroy } from 'svelte';
     import { useDatasetSplitDialog } from '$lib/components/DatasetSplit/useDatasetSplitDialog';
     import type { CollectionView } from '$lib/api/lightly_studio_local';
     import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
@@ -27,11 +28,18 @@
     );
 
     const { isDialogOpen: isClassifiersDialogOpen } = useClassifiersMenu();
-    const { isDatasetSplitDialogOpen, closeDatasetSplitDialog } = useDatasetSplitDialog();
+    const { datasetSplitCollectionId, closeDatasetSplitDialog } = useDatasetSplitDialog();
     const { isSamplingDialogOpen } = useSamplingDialog();
     const { isExportDialogOpen } = useExportDialog();
     const { isOperatorsDialogOpen } = useOperatorsDialog();
     const { isSettingsDialogOpen } = useSettingsDialog();
+
+    $effect(() => {
+        if (!hasSelection || $datasetSplitCollectionId !== collection.collection_id) {
+            closeDatasetSplitDialog();
+        }
+    });
+    onDestroy(closeDatasetSplitDialog);
 
     let hasClassifierFlowLoaded = $state(false);
     let hasOperatorsMenuLoaded = $state(false);
@@ -73,7 +81,7 @@
     {/await}
 {/if}
 
-{#if hasSelection && $isDatasetSplitDialogOpen && (collection.sample_type === 'image' || collection.sample_type === 'video')}
+{#if hasSelection && $datasetSplitCollectionId === collection.collection_id && (collection.sample_type === 'image' || collection.sample_type === 'video')}
     {#await import('$lib/components/DatasetSplit/ConnectedDatasetSplitDialog/ConnectedDatasetSplitDialog.svelte') then { default: ConnectedDatasetSplitDialog }}
         <ConnectedDatasetSplitDialog
             collectionId={collection.collection_id}

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { useDatasetSplitDialog } from '$lib/components/DatasetSplit/useDatasetSplitDialog';
     import type { CollectionView } from '$lib/api/lightly_studio_local';
     import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
     import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
@@ -26,6 +27,7 @@
     );
 
     const { isDialogOpen: isClassifiersDialogOpen } = useClassifiersMenu();
+    const { isDatasetSplitDialogOpen, closeDatasetSplitDialog } = useDatasetSplitDialog();
     const { isSamplingDialogOpen } = useSamplingDialog();
     const { isExportDialogOpen } = useExportDialog();
     const { isOperatorsDialogOpen } = useOperatorsDialog();
@@ -68,5 +70,15 @@
 {#if $isSettingsDialogOpen}
     {#await import('$lib/components/Settings/SettingsDialog.svelte') then { default: SettingsDialog }}
         <SettingsDialog />
+    {/await}
+{/if}
+
+{#if hasSelection && $isDatasetSplitDialogOpen && (collection.sample_type === 'image' || collection.sample_type === 'video')}
+    {#await import('$lib/components/DatasetSplit/ConnectedDatasetSplitDialog/ConnectedDatasetSplitDialog.svelte') then { default: ConnectedDatasetSplitDialog }}
+        <ConnectedDatasetSplitDialog
+            collectionId={collection.collection_id}
+            sampleType={collection.sample_type}
+            onClose={closeDatasetSplitDialog}
+        />
     {/await}
 {/if}


### PR DESCRIPTION
## What has changed and why?

- Let users open the split dataset menu from image and video grids.
- Connect the existing split dialog and test menu access and reopening. (last few PRs)


https://github.com/user-attachments/assets/c3b91f77-dbe4-492e-bb60-833221fb2778

Note: there will be another follow up issue to allow adding/removing tags to the GUI menu so the user can split datasets into an arbitrary number of tags.

## How has it been tested?

- new tests + manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Split dataset** menu action for eligible image and video datasets.
  * Added options to divide filtered samples into tagged splits with weighting controls.
  * Splits now use a reproducible default seed of `42`.
  * Improved success messages to clearly list created tags and sample counts.
  * The split dialog now opens for the selected dataset and closes when switching datasets.
* **Accessibility**
  * Added numeric input guidance and descriptive help text for the seed field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->