### PR TITLE
Add: Allow more dataset splits and tidy the dialog

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.svelte
@@ -3,7 +3,7 @@
     import * as Dialog from '$lib/components/ui/dialog';
     import { Input } from '$lib/components/ui/input';
     import { getSplitCounts, getSplitError } from '../splitPreview';
-    import DatasetSplitRow from './DatasetSplitRow/DatasetSplitRow.svelte';
+    import DatasetSplitRows from './DatasetSplitRows/DatasetSplitRows.svelte';
 
     interface Props {
         sampleCount: number;
@@ -57,21 +57,17 @@
 </script>
 
 <Dialog.Root open onOpenChange={(open) => !open && onClose()}>
-    <Dialog.Content>
+    <Dialog.Content class="max-h-[90dvh] overflow-y-auto">
         <Dialog.Header>
             <Dialog.Title>Split dataset</Dialog.Title>
             <Dialog.Description>
-                Randomly divide the {sampleCount} samples matching your current filters into three new
-                tags. Choose a name and weight for each tag. Larger weights get more samples; for example,
-                8:1:1 gives roughly 80%, 10%, and 10%. The counts below preview each tag’s share. Each
-                sample receives one of these tags.
+                Randomly divide the {sampleCount} samples matching your current filters into new tags.
+                Each sample receives one tag. Weights set the share: 8:1:1 gives roughly 80%, 10%, 10%.
             </Dialog.Description>
         </Dialog.Header>
         <form onsubmit={submit} novalidate class="space-y-4">
             <fieldset disabled={pending} class="space-y-3">
-                {#each splits as split, index (split)}
-                    <DatasetSplitRow bind:split={splits[index]} {index} count={counts[index]} />
-                {/each}
+                <DatasetSplitRows bind:splits {counts} {sampleCount} />
                 <label class="block space-y-1 text-sm">
                     Seed (optional)
                     <Input
@@ -81,8 +77,8 @@
                     />
                 </label>
                 <p id="dataset-split-seed-help" class="text-sm text-muted-foreground">
-                    Use the same whole-number seed to repeat a split of the same samples. Clear it
-                    for a random split each time.
+                    Reuse a seed to repeat the split of the same samples. Leave blank for a random
+                    split.
                 </p>
             </fieldset>
             {#if validationError || error}

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitDialog.test.ts
@@ -36,6 +36,41 @@ describe('DatasetSplitDialog', () => {
         expect(onSubmit).toHaveBeenLastCalledWith({ splits, seed: -7 });
     });
 
+    it('adds five splits, validates new names and submits their weights', async () => {
+        const onSubmit = vi.fn();
+        render(DatasetSplitDialog, { ...defaultProps, sampleCount: 5, onSubmit });
+        const add = screen.getByRole('button', { name: 'Add split' });
+        for (const index of [4, 5]) {
+            await fireEvent.click(add);
+            expect(screen.getByRole('button', { name: 'Split dataset' })).toBeDisabled();
+            await fireEvent.input(screen.getByLabelText(`Tag ${index}`), {
+                target: { value: `chunk-${index}` }
+            });
+        }
+        expect(add).toBeDisabled();
+        expect(screen.getByLabelText('Split 1 sample count')).toHaveTextContent('3 samples');
+        await fireEvent.click(screen.getByRole('button', { name: 'Split dataset' }));
+        expect(onSubmit).toHaveBeenCalledWith({
+            splits: ['train', 'val', 'test', 'chunk-4', 'chunk-5'].map((tag_name, index) => ({
+                tag_name,
+                relative_size: index === 0 ? 8 : 1
+            })),
+            seed: 42
+        });
+    });
+
+    it('removes a middle split while preserving remaining values and requires two splits', async () => {
+        render(DatasetSplitDialog, defaultProps);
+        await fireEvent.click(screen.getByRole('button', { name: 'Remove split 2' }));
+        expect(screen.getByLabelText('Tag 2')).toHaveValue('test');
+        expect(screen.getByLabelText('Split 1 sample count')).toHaveTextContent('10 samples');
+        expect(screen.getByLabelText('Split 2 sample count')).toHaveTextContent('1 sample');
+        expect(screen.getAllByRole('button', { name: /Remove split/ })).toHaveLength(2);
+        for (const button of screen.getAllByRole('button', { name: /Remove split/ })) {
+            expect(button).toBeDisabled();
+        }
+    });
+
     it.each([
         ['Tag 1', 'val', 'different name'],
         ['Tag 1', 'existing', 'already exists'],
@@ -62,6 +97,8 @@ describe('DatasetSplitDialog', () => {
         await rerender({ pending: true });
         const button = screen.getByRole('button', { name: 'Splitting…' });
         expect(button).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Add split' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Remove split 1' })).toBeDisabled();
         await fireEvent.submit(button.closest('form')!);
         expect(onSubmit).not.toHaveBeenCalled();
         await rerender({ pending: false, error: 'Unable to split dataset.' });

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitRow/DatasetSplitRow.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitRow/DatasetSplitRow.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { X } from '@lucide/svelte';
+    import { Button } from '$lib/components/ui/button';
     import { Input } from '$lib/components/ui/input';
     import { getSplitCounts } from '../../splitPreview';
 
@@ -6,12 +8,14 @@
         split: Parameters<typeof getSplitCounts>[1][number];
         index: number;
         count?: number;
+        canRemove: boolean;
+        onRemove: () => void;
     }
 
-    let { split = $bindable(), index, count }: Props = $props();
+    let { split = $bindable(), index, count, canRemove, onRemove }: Props = $props();
 </script>
 
-<div class="grid grid-cols-3 items-end gap-3 text-sm">
+<div class="grid grid-cols-[minmax(0,1fr)_5rem_6rem_auto] items-end gap-3 text-sm">
     <label class="space-y-1">
         Tag {index + 1}
         <Input bind:value={split.tag_name} />
@@ -20,5 +24,21 @@
         Weight {index + 1}
         <Input type="number" min={1} step={1} bind:value={split.relative_size} />
     </label>
-    <p aria-label={`Split ${index + 1} sample count`}>{count ?? '—'} samples</p>
+    <p
+        class="flex h-10 items-center justify-end tabular-nums text-muted-foreground"
+        aria-label={`Split ${index + 1} sample count`}
+    >
+        {count ?? '—'}
+        {count === 1 ? 'sample' : 'samples'}
+    </p>
+    <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={`Remove split ${index + 1}`}
+        disabled={!canRemove}
+        onclick={onRemove}
+    >
+        <X />
+    </Button>
 </div>

--- a/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitRows/DatasetSplitRows.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetSplit/DatasetSplitDialog/DatasetSplitRows/DatasetSplitRows.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import { Plus } from '@lucide/svelte';
+    import { Button } from '$lib/components/ui/button';
+    import { getSplitCounts } from '../../splitPreview';
+    import DatasetSplitRow from '../DatasetSplitRow/DatasetSplitRow.svelte';
+
+    interface Props {
+        splits: Parameters<typeof getSplitCounts>[1];
+        counts: number[];
+        sampleCount: number;
+    }
+
+    let { splits = $bindable(), counts, sampleCount }: Props = $props();
+</script>
+
+<div class="space-y-3">
+    {#each splits as split, index (split)}
+        <DatasetSplitRow
+            bind:split={splits[index]}
+            {index}
+            count={counts[index]}
+            canRemove={splits.length > 2}
+            onRemove={() => (splits = splits.filter((_, rowIndex) => rowIndex !== index))}
+        />
+    {/each}
+    <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={splits.length >= sampleCount}
+        onclick={() => (splits = [...splits, { tag_name: '', relative_size: 1 }])}
+    >
+        <Plus /> Add split
+    </Button>
+</div>


### PR DESCRIPTION
## What has changed and why?

- Add and remove splits, including five or more.
- Align sample counts with the input fields.
- Shorten help text and support scrolling for longer lists.



https://github.com/user-attachments/assets/06b94ee2-4872-4508-af26-98db44e13006




## How has it been tested?

- Updated tests and manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls to add and remove dataset splits directly in the split dialog.
  * Split removal is restricted when only two splits remain, and new splits use editable names and relative weights.
  * Added support for managing larger split lists with a scrollable dialog layout.

* **Improvements**
  * Add and remove controls are disabled while changes are being submitted.
  * Sample counts now use singular wording when appropriate.
  * Updated explanatory text for clearer guidance on descriptions and random seeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->