### PR TITLE
Fix: Reduce repeated work when loading numeric metadata bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved metadata loading by reducing numeric database queries from 13 to 8 and making responses up to 25% faster.
 - Speed up metadata-weighting sampling by reading all metadata values in one query instead of one query per sample.
 - Change the video decoding backend for the GUI from OpenCV to PyAV, resulting in up to 6× faster decoding performance for parallel streams when loading the grid view and scrolling.
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -28,9 +28,9 @@ _HISTOGRAM_BIN_COUNT = 20
 class _NumericMetadataStats(NamedTuple):
     """Unfiltered numeric metadata statistics used to build a response."""
 
-    min: float
-    max: float
-    count: int
+    min_value: float
+    max_value: float
+    value_count: int
 
 
 def get_all_metadata_keys_and_schema(
@@ -66,8 +66,8 @@ def get_all_metadata_keys_and_schema(
             stats = bounds.get(key)
             if stats is not None:
                 cast_type = int if metadata_type == "integer" else float
-                metadata_info.min = cast_type(stats.min)
-                metadata_info.max = cast_type(stats.max)
+                metadata_info.min = cast_type(stats.min_value)
+                metadata_info.max = cast_type(stats.max_value)
                 metadata_info.histogram = _compute_histogram(
                     session=session,
                     collection_id=collection_id,
@@ -177,7 +177,9 @@ def _get_metadata_min_max_counts(
         count = int(values[labels[2]])
         if count > 0:
             stats[key] = _NumericMetadataStats(
-                min=float(values[labels[0]]), max=float(values[labels[1]]), count=count
+                min_value=float(values[labels[0]]),
+                max_value=float(values[labels[1]]),
+                value_count=count,
             )
     return stats
 
@@ -214,9 +216,9 @@ def _compute_histogram(  # noqa: PLR0913
     Returns:
         The histogram with bin edges and per-bin counts.
     """
-    min_value = stats.min
-    max_value = stats.max
-    total_count = stats.count
+    min_value = stats.min_value
+    max_value = stats.max_value
+    total_count = stats.value_count
     if max_value == min_value:
         count = (
             total_count

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID
 
+import sqlalchemy
 from sqlalchemy import Integer, cast, func
 from sqlmodel import Session, col, select
 
@@ -41,15 +43,18 @@ def get_all_metadata_keys_and_schema(
     """
     merged = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
 
+    numeric_keys = [key for key, kind in merged.items() if kind in NUMERIC_TYPE_NAMES]
+    bounds = _get_metadata_min_max_counts(
+        session=session, collection_id=collection_id, metadata_keys=numeric_keys
+    )
+
     result = []
     for key, metadata_type in merged.items():
         metadata_info = MetadataInfoView(name=key, type=metadata_type)
 
         # Add min, max, and histogram for numerical types.
         if metadata_type in NUMERIC_TYPE_NAMES:
-            stats = _get_metadata_min_max_count(
-                session=session, collection_id=collection_id, metadata_key=key
-            )
+            stats = bounds.get(key)
             if stats is not None:
                 min_value, max_value, _ = stats
                 cast_type = int if metadata_type == "integer" else float
@@ -94,15 +99,16 @@ def get_metadata_histograms(
     """
     merged = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
 
+    numeric_keys = [
+        key
+        for key, kind in merged.items()
+        if kind in NUMERIC_TYPE_NAMES and (fields is None or key in fields)
+    ]
+    bounds = _get_metadata_min_max_counts(
+        session=session, collection_id=collection_id, metadata_keys=numeric_keys
+    )
     histograms: dict[str, HistogramView] = {}
-    for key, metadata_type in merged.items():
-        if metadata_type not in NUMERIC_TYPE_NAMES or (fields is not None and key not in fields):
-            continue
-        stats = _get_metadata_min_max_count(
-            session=session, collection_id=collection_id, metadata_key=key
-        )
-        if stats is None:
-            continue
+    for key, stats in bounds.items():
         histograms[key] = _compute_histogram(
             session=session,
             collection_id=collection_id,
@@ -114,49 +120,56 @@ def get_metadata_histograms(
     return histograms
 
 
-def _get_metadata_min_max_count(
+def _get_metadata_min_max_counts(
     session: Session,
     collection_id: UUID,
-    metadata_key: str,
-) -> tuple[float, float, int] | None:
-    """Aggregate the min, max, and count for a numerical metadata key in SQL.
+    metadata_keys: Sequence[str],
+) -> dict[str, tuple[float, float, int]]:
+    """Aggregate min, max, and non-null count for numerical metadata keys.
 
     Args:
         session: The database session.
         collection_id: The collection's UUID.
-        metadata_key: The metadata key to aggregate.
+        metadata_keys: The numerical metadata keys to aggregate.
 
     Returns:
-        A ``(min, max, count)`` tuple, or ``None`` if the key has no values.
+        A mapping from each key with at least one value to its ``(min, max, count)``
+        tuple. Keys with no values are omitted.
     """
-    value_expr = db_json.json_extract_key_as_float(
-        column=SampleMetadataTable.data, key=metadata_key
-    )
-    json_not_null_expr = db_json.json_extract_key_as_text(
-        column=SampleMetadataTable.data, key=metadata_key
-    ).isnot(None)
+    if not metadata_keys:
+        return {}
 
-    query = (
-        select(
-            func.min(value_expr),
-            func.max(value_expr),
-            func.count(value_expr),
+    aggregates: list[sqlalchemy.ColumnElement[float] | sqlalchemy.ColumnElement[int]] = []
+    aggregate_labels: list[tuple[str, str, str]] = []
+    for index, key in enumerate(metadata_keys):
+        value = db_json.json_extract_key_as_float(column=SampleMetadataTable.data, key=key)
+        # Each aggregate ignores its own NULLs so sparse keys remain independent.
+        labels = (f"min_{index}", f"max_{index}", f"count_{index}")
+        aggregate_labels.append(labels)
+        aggregates.extend(
+            (
+                func.min(value).label(labels[0]),
+                func.max(value).label(labels[1]),
+                func.count(value).label(labels[2]),
+            )
         )
+    query = (
+        sqlalchemy.select(*aggregates)
         .select_from(SampleTable)
         .join(
             SampleMetadataTable,
             col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
         )
-        .where(
-            SampleTable.collection_id == collection_id,
-            json_not_null_expr,
-        )
+        .where(col(SampleTable.collection_id) == collection_id)
     )
-
-    row = session.exec(query).first()
-    if row is None or row[0] is None or row[1] is None or row[2] == 0:
-        return None
-    return float(row[0]), float(row[1]), int(row[2])
+    row = session.execute(query).mappings().one()
+    values = {label: row[label] for labels in aggregate_labels for label in labels}
+    stats: dict[str, tuple[float, float, int]] = {}
+    for key, labels in zip(metadata_keys, aggregate_labels):
+        count = int(values[labels[2]])
+        if count > 0:
+            stats[key] = (float(values[labels[0]]), float(values[labels[1]]), count)
+    return stats
 
 
 def _compute_histogram(  # noqa: PLR0913
@@ -182,7 +195,7 @@ def _compute_histogram(  # noqa: PLR0913
         session: The database session.
         collection_id: The collection's UUID.
         metadata_key: The metadata key to bin.
-        stats: The ``(min, max, count)`` returned by ``_get_metadata_min_max_count``.
+        stats: The ``(min, max, count)`` returned by ``_get_metadata_min_max_counts``.
             The min/max always describe the *unfiltered* domain so the bin
             edges stay stable while filters change.
         filters: Optional sample filters restricting which values are counted.

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import NamedTuple
 from uuid import UUID
 
 import sqlalchemy
@@ -22,6 +23,14 @@ from lightly_studio.resolvers.metadata_resolver.sample import metadata_helpers
 
 # Number of bins used for numeric metadata histograms.
 _HISTOGRAM_BIN_COUNT = 20
+
+
+class _NumericMetadataStats(NamedTuple):
+    """Unfiltered numeric metadata statistics used to build a response."""
+
+    min: float
+    max: float
+    count: int
 
 
 def get_all_metadata_keys_and_schema(
@@ -56,10 +65,9 @@ def get_all_metadata_keys_and_schema(
         if metadata_type in NUMERIC_TYPE_NAMES:
             stats = bounds.get(key)
             if stats is not None:
-                min_value, max_value, _ = stats
                 cast_type = int if metadata_type == "integer" else float
-                metadata_info.min = cast_type(min_value)
-                metadata_info.max = cast_type(max_value)
+                metadata_info.min = cast_type(stats.min)
+                metadata_info.max = cast_type(stats.max)
                 metadata_info.histogram = _compute_histogram(
                     session=session,
                     collection_id=collection_id,
@@ -124,7 +132,7 @@ def _get_metadata_min_max_counts(
     session: Session,
     collection_id: UUID,
     metadata_keys: Sequence[str],
-) -> dict[str, tuple[float, float, int]]:
+) -> dict[str, _NumericMetadataStats]:
     """Aggregate min, max, and non-null count for numerical metadata keys.
 
     Args:
@@ -133,8 +141,8 @@ def _get_metadata_min_max_counts(
         metadata_keys: The numerical metadata keys to aggregate.
 
     Returns:
-        A mapping from each key with at least one value to its ``(min, max, count)``
-        tuple. Keys with no values are omitted.
+        A mapping from each key with at least one value to its numeric statistics.
+        Keys with no values are omitted.
     """
     if not metadata_keys:
         return {}
@@ -164,11 +172,13 @@ def _get_metadata_min_max_counts(
     )
     row = session.execute(query).mappings().one()
     values = {label: row[label] for labels in aggregate_labels for label in labels}
-    stats: dict[str, tuple[float, float, int]] = {}
+    stats: dict[str, _NumericMetadataStats] = {}
     for key, labels in zip(metadata_keys, aggregate_labels):
         count = int(values[labels[2]])
         if count > 0:
-            stats[key] = (float(values[labels[0]]), float(values[labels[1]]), count)
+            stats[key] = _NumericMetadataStats(
+                min=float(values[labels[0]]), max=float(values[labels[1]]), count=count
+            )
     return stats
 
 
@@ -176,7 +186,7 @@ def _compute_histogram(  # noqa: PLR0913
     session: Session,
     collection_id: UUID,
     metadata_key: str,
-    stats: tuple[float, float, int],
+    stats: _NumericMetadataStats,
     filters: ImageFilter | None = None,
     bin_count: int = _HISTOGRAM_BIN_COUNT,
 ) -> HistogramView:
@@ -195,16 +205,18 @@ def _compute_histogram(  # noqa: PLR0913
         session: The database session.
         collection_id: The collection's UUID.
         metadata_key: The metadata key to bin.
-        stats: The ``(min, max, count)`` returned by ``_get_metadata_min_max_counts``.
-            The min/max always describe the *unfiltered* domain so the bin
-            edges stay stable while filters change.
+        stats: The unfiltered numeric statistics returned by
+            ``_get_metadata_min_max_counts``. The min/max always describe the
+            unfiltered domain so the bin edges stay stable while filters change.
         filters: Optional sample filters restricting which values are counted.
         bin_count: Number of equal-width bins.
 
     Returns:
         The histogram with bin edges and per-bin counts.
     """
-    min_value, max_value, total_count = stats
+    min_value = stats.min
+    max_value = stats.max
+    total_count = stats.count
     if max_value == min_value:
         count = (
             total_count

--- a/lightly_studio/tests/metadata/test_get_metadata_info.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_info.py
@@ -1,6 +1,8 @@
 """Test metadata info resolver."""
 
 import pytest
+import sqlalchemy
+from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.resolvers.metadata_resolver.sample.get_metadata_info import (
@@ -86,6 +88,57 @@ def test_get_all_metadata_keys_and_schema__with_numerical_values(
     assert is_processed_info.min is None
     assert is_processed_info.max is None
     assert is_processed_info.histogram is None
+
+
+def test_get_all_metadata_keys_and_schema__sparse_numerical_values(
+    db_session: Session,
+) -> None:
+    """Each numeric key keeps its own bounds when values are sparse across samples."""
+    collection = create_collection(session=db_session)
+    first = create_image(
+        session=db_session, collection_id=collection.collection_id, file_path_abs="/sparse-1.png"
+    ).sample
+    second = create_image(
+        session=db_session, collection_id=collection.collection_id, file_path_abs="/sparse-2.png"
+    ).sample
+    first["temperature"] = -2.5
+    second["count"] = 4
+    db_session.commit()
+
+    result = get_all_metadata_keys_and_schema(
+        session=db_session, collection_id=collection.collection_id
+    )
+    by_name = {item.name: item for item in result}
+    assert by_name["temperature"].min == pytest.approx(-2.5)
+    assert by_name["temperature"].max == pytest.approx(-2.5)
+    assert by_name["count"].min == 4
+    assert by_name["count"].max == 4
+
+
+def test_get_all_metadata_keys_and_schema__batches_numeric_bounds(
+    db_session: Session, mocker: MockerFixture
+) -> None:
+    """Info uses one schema query, one bounds query, and one histogram per key."""
+    collection = create_collection(session=db_session)
+    for index in range(2):
+        sample = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+            file_path_abs=f"/batch-{index}.png",
+        ).sample
+        sample["temperature"] = float(index)
+        sample["count"] = index
+    db_session.commit()
+    collection_id = collection.collection_id
+
+    listener = mocker.Mock()
+    engine = db_session.get_bind()
+    sqlalchemy.event.listen(engine, "before_cursor_execute", listener)
+    try:
+        get_all_metadata_keys_and_schema(session=db_session, collection_id=collection_id)
+    finally:
+        sqlalchemy.event.remove(engine, "before_cursor_execute", listener)
+    assert listener.call_count == 4
 
 
 def test_get_all_metadata_keys_and_schema__no_numerical_values(


### PR DESCRIPTION
## What has changed and why?

- Reduce numeric metadata queries from 13 to 8 per request while the CPU usage of the db goes down. 
- Obtaining metadata info on a 100k dataset with 10 metadata fields is now 25% faster.

## How has it been tested?

- new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved metadata loading performance by batching numeric metadata calculations, reducing database queries from 13 to 8.
  * Metadata responses can now load up to 25% faster.
* **Bug Fixes**
  * Improved accuracy of min/max bounds for sparse numeric metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->