### PR TITLE
Add screenshot reminder to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## What has changed and why?
 
-(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)
+(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If there are frontend changes, please include screenshots or video demos.)
 
 ## How has it been tested?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 ## What has changed and why?
 
-(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If there are frontend changes, please include screenshots or video demos.)
+(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)
 
 ## How has it been tested?
 
-(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)
+(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. If there are frontend changes, please include screenshots or video demos.)
 
 ## Did you update [CHANGELOG.md](../CHANGELOG.md)?
 


### PR DESCRIPTION
## What has changed and why?

Added a reminder in the PR template to include screenshots or video demos for frontend changes.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template to request screenshots or video demonstrations for frontend-related changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->