### PR TITLE
Add bootstrap defaults and lazy built-ins to EmbedderRegistry

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embedder_registry.py
+++ b/lightly_studio/src/lightly_studio/embed/embedder_registry.py
@@ -1,8 +1,11 @@
-"""Registry that maps embedding spaces to embedders.
+"""Process-wide registry that maps embedding spaces to embedders.
 
-Holds at most one embedder per ``space_key``. Callers look up an embedder by the
-capability they need with the matching typed getter, which returns the space's
-embedder only when it implements that capability.
+Holds at most one embedder per ``space_key`` and the bootstrap defaults that pick a
+space for a capability when no collection default is saved yet. Callers look up an
+embedder by the capability they need with the matching typed getter, which returns
+the space's embedder only when it implements that capability, loading a built-in
+embedder on demand. The registry never touches the database; persisting a
+collection's default space is the caller's responsibility.
 """
 
 from __future__ import annotations
@@ -19,6 +22,7 @@ from lightly_studio.embed.embedder import (
     TextEmbedder,
     VideoPathEmbedder,
 )
+from lightly_studio.embed.types import EmbeddingSpaceSpec
 
 logger = logging.getLogger(__name__)
 
@@ -32,37 +36,64 @@ _CAPABILITY_TO_TYPE = {
     Capability.IMAGE_BYTES: ImageBytesEmbedder,
 }
 
+# Space keys of the built-in embedders that a registry can load lazily.
+_MOBILECLIP_SPACE_KEY = "mobileclip_s0"
+_PERCEPTION_ENCODER_SPACE_KEY = "PE-Core-T16-384"
+
+# Bootstrap defaults every registry starts with: the space_key used to bootstrap a
+# collection default for a capability when none is saved yet. Capabilities absent
+# here (TEXT, IMAGE_BYTES) have no built-in default until an embedder registers for
+# them. Any capability can still be bootstrapped once an embedder is registered.
+_DEFAULT_BOOTSTRAP_SPACE_KEYS: dict[Capability, str] = {
+    Capability.IMAGE_PATH: _MOBILECLIP_SPACE_KEY,
+    Capability.IMAGE_CROP_PATH: _MOBILECLIP_SPACE_KEY,
+    Capability.IMAGE_PIL: _MOBILECLIP_SPACE_KEY,
+    Capability.VIDEO_PATH: _PERCEPTION_ENCODER_SPACE_KEY,
+}
+
 
 class EmbedderRegistry:
-    """Stores at most one embedder per embedding space.
+    """Stores at most one embedder per embedding space and the bootstrap defaults.
 
     An embedder can provide several capabilities. The registry keeps one embedder
-    per ``space_key``; registering another embedder for the same space replaces
-    it. The typed getters return the space's embedder only when it implements the
-    requested capability.
+    per ``space_key``; registering another embedder for the same space replaces it.
+    Capabilities never compose across embedders, so a partial replacement replaces
+    the whole space. Each capability maps to the ``space_key`` used to bootstrap a
+    collection default when none is saved yet. The typed getters return the space's
+    embedder only when it implements the requested capability, loading a built-in
+    embedder on demand. Each instance owns its own state.
     """
 
     def __init__(self) -> None:
-        """Create an empty registry."""
+        """Create a registry seeded with the built-in bootstrap defaults."""
         self._space_key_to_embedder: dict[str, Embedder] = {}
+        self._bootstrap_space_keys: dict[Capability, str] = dict(_DEFAULT_BOOTSTRAP_SPACE_KEYS)
 
-    def register(self, embedder: Embedder) -> None:
-        """Register an embedder for its embedding space.
+    def register(self, embedder: Embedder, bootstrap_for: set[Capability] | None = None) -> None:
+        """Register an embedder for its embedding space and update bootstrap defaults.
 
         The embedding space is read from ``embedder.embedding_space_spec()``. If an
-        embedder is already registered for the same space, it is replaced.
+        embedder is already registered for the same space, it is replaced. The
+        embedder becomes the bootstrap default for the capabilities in
+        ``bootstrap_for`` that it implements, replacing any previous default for
+        those capabilities and leaving other defaults unchanged.
 
         Args:
             embedder: The embedder to register.
+            bootstrap_for: The capabilities to make this the bootstrap default for.
+                ``None`` means every capability the embedder implements. An empty
+                set changes no defaults. Requested capabilities the embedder does
+                not implement are ignored.
 
         Raises:
-            ValueError: If the embedder implements no capability, or if it shares
-                a ``space_key`` with an already registered embedder but does not
-                match its spec.
+            ValueError: If the embedder implements no capability, or if it shares a
+                ``space_key`` with an already registered embedder but does not match
+                its spec. An incompatible replacement leaves the registry unchanged.
         """
         spec = embedder.embedding_space_spec()
         space_key = spec.space_key
-        if not _capabilities_of(embedder=embedder):
+        capabilities = _capabilities_of(embedder=embedder)
+        if not capabilities:
             raise ValueError(f"Embedder {type(embedder).__name__!r} implements no capability.")
         registered = self._space_key_to_embedder.get(space_key)
         if registered is not None:
@@ -73,41 +104,127 @@ class EmbedderRegistry:
                     f"cannot register the incompatible {spec}."
                 )
             logger.warning("Replacing embedder for space %r.", space_key)
-        self._space_key_to_embedder[space_key] = embedder
 
-    def get_image_path_embedder(self, space_key: str) -> ImagePathEmbedder | None:
-        """Get the space's embedder if it embeds images by path, else None."""
-        embedder = self._space_key_to_embedder.get(space_key)
+        self._space_key_to_embedder[space_key] = embedder
+        self._set_bootstrap_defaults(
+            space_key=space_key, capabilities=capabilities, bootstrap_for=bootstrap_for
+        )
+
+    def get_bootstrap_space(self, capability: Capability) -> EmbeddingSpaceSpec | None:
+        """Get the embedding space to bootstrap for a capability, or None if there is none.
+
+        Loads the built-in default lazily when needed. Returns the spec of the
+        selected provider, including a custom one, only when it supports the
+        capability.
+        """
+        embedder = self._get_or_bootstrap(space_key=None, capability=capability)
+        if embedder is None or capability not in _capabilities_of(embedder=embedder):
+            return None
+        return embedder.embedding_space_spec()
+
+    def get_image_path_embedder(self, space_key: str | None = None) -> ImagePathEmbedder | None:
+        """Get the space's image-path embedder, or the bootstrap default when space_key is None."""
+        embedder = self._get_or_bootstrap(space_key=space_key, capability=Capability.IMAGE_PATH)
         return embedder if isinstance(embedder, ImagePathEmbedder) else None
 
-    def get_image_crop_path_embedder(self, space_key: str) -> ImageCropPathEmbedder | None:
-        """Get the space's embedder if it embeds image crops by path, else None."""
-        embedder = self._space_key_to_embedder.get(space_key)
+    def get_image_crop_path_embedder(
+        self, space_key: str | None = None
+    ) -> ImageCropPathEmbedder | None:
+        """Get the space's image-crop embedder, or the bootstrap default when space_key is None."""
+        embedder = self._get_or_bootstrap(
+            space_key=space_key, capability=Capability.IMAGE_CROP_PATH
+        )
         return embedder if isinstance(embedder, ImageCropPathEmbedder) else None
 
-    def get_video_path_embedder(self, space_key: str) -> VideoPathEmbedder | None:
-        """Get the space's embedder if it embeds videos by path, else None."""
-        embedder = self._space_key_to_embedder.get(space_key)
+    def get_video_path_embedder(self, space_key: str | None = None) -> VideoPathEmbedder | None:
+        """Get the space's video-path embedder, or the bootstrap default when space_key is None."""
+        embedder = self._get_or_bootstrap(space_key=space_key, capability=Capability.VIDEO_PATH)
         return embedder if isinstance(embedder, VideoPathEmbedder) else None
 
-    def get_image_pil_embedder(self, space_key: str) -> ImagePILEmbedder | None:
-        """Get the space's embedder if it embeds PIL images, else None."""
-        embedder = self._space_key_to_embedder.get(space_key)
+    def get_image_pil_embedder(self, space_key: str | None = None) -> ImagePILEmbedder | None:
+        """Get the space's PIL-image embedder, or the bootstrap default when space_key is None."""
+        embedder = self._get_or_bootstrap(space_key=space_key, capability=Capability.IMAGE_PIL)
         return embedder if isinstance(embedder, ImagePILEmbedder) else None
 
-    def get_text_embedder(self, space_key: str) -> TextEmbedder | None:
-        """Get the space's embedder if it embeds text, else None."""
-        embedder = self._space_key_to_embedder.get(space_key)
+    def get_text_embedder(self, space_key: str | None = None) -> TextEmbedder | None:
+        """Get the space's text embedder, or the bootstrap default when space_key is None."""
+        embedder = self._get_or_bootstrap(space_key=space_key, capability=Capability.TEXT)
         return embedder if isinstance(embedder, TextEmbedder) else None
 
-    def get_image_bytes_embedder(self, space_key: str) -> ImageBytesEmbedder | None:
-        """Get the space's embedder if it embeds images by bytes, else None."""
-        embedder = self._space_key_to_embedder.get(space_key)
+    def get_image_bytes_embedder(self, space_key: str | None = None) -> ImageBytesEmbedder | None:
+        """Get the space's image-bytes embedder, or the bootstrap default when space_key is None."""
+        embedder = self._get_or_bootstrap(space_key=space_key, capability=Capability.IMAGE_BYTES)
         return embedder if isinstance(embedder, ImageBytesEmbedder) else None
 
+    def _get_or_bootstrap(self, space_key: str | None, capability: Capability) -> Embedder | None:
+        """Resolve the space's embedder, falling back to the capability's bootstrap default.
 
-def _capabilities_of(embedder: Embedder) -> list[Capability]:
-    """List the capabilities an embedder implements, inferred from its type."""
-    return [
+        An explicit ``space_key`` selects exactly that space with no fallback.
+        ``None`` selects the capability's bootstrap key, or returns ``None`` when
+        there is no such default. An already registered embedder wins, including a
+        partial provider for a built-in key. Otherwise a known built-in is loaded and
+        registered on demand; an unknown space returns ``None``.
+        """
+        if space_key is None:
+            space_key = self._bootstrap_space_keys.get(capability)
+        if space_key is None:
+            return None
+        registered = self._space_key_to_embedder.get(space_key)
+        if registered is not None:
+            return registered
+        embedder = _load_builtin_embedder(space_key=space_key)
+        if embedder is None:
+            return None
+        # Lazy loading only supplies an object for an already-chosen space; it must
+        # not re-decide bootstrap defaults, e.g. loading PE for a video collection
+        # must not replace the MobileCLIP image defaults.
+        self.register(embedder=embedder, bootstrap_for=set())
+        return embedder
+
+    def _set_bootstrap_defaults(
+        self,
+        space_key: str,
+        capabilities: set[Capability],
+        bootstrap_for: set[Capability] | None,
+    ) -> None:
+        """Make the space the bootstrap default for its capabilities within ``bootstrap_for``.
+
+        ``bootstrap_for`` of ``None`` means every capability the embedder implements.
+        """
+        defaults = capabilities if bootstrap_for is None else capabilities & bootstrap_for
+        for capability in defaults:
+            self._bootstrap_space_keys[capability] = space_key
+
+
+# Process-wide registry shared by the app and by callers that look up embedders.
+_registry = EmbedderRegistry()
+
+
+def get_registry() -> EmbedderRegistry:
+    """Get the process-wide embedder registry."""
+    return _registry
+
+
+def _capabilities_of(embedder: Embedder) -> set[Capability]:
+    """Get the capabilities an embedder implements, inferred from its type."""
+    return {
         capability for capability, cls in _CAPABILITY_TO_TYPE.items() if isinstance(embedder, cls)
-    ]
+    }
+
+
+def _load_builtin_embedder(space_key: str) -> Embedder | None:
+    """Construct the built-in embedder for a space key, or None if there is none.
+
+    Imports lazily so that looking up one built-in does not import the other model.
+    """
+    if space_key == _MOBILECLIP_SPACE_KEY:
+        from lightly_studio.embed.mobileclip_embedder import MobileCLIPEmbedder  # noqa: PLC0415
+
+        return MobileCLIPEmbedder()
+    if space_key == _PERCEPTION_ENCODER_SPACE_KEY:
+        from lightly_studio.embed.perception_encoder_embedder import (  # noqa: PLC0415
+            PerceptionEncoderEmbedder,
+        )
+
+        return PerceptionEncoderEmbedder()
+    return None

--- a/lightly_studio/tests/embed/test_embedder_registry.py
+++ b/lightly_studio/tests/embed/test_embedder_registry.py
@@ -1,15 +1,28 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np
 import pytest
+from pytest_mock import MockerFixture
 
+from lightly_studio.embed import embedder_registry
 from lightly_studio.embed.embedder import (
+    Capability,
     Embedder,
     ImagePathEmbedder,
     TextEmbedder,
+    VideoPathEmbedder,
 )
 from lightly_studio.embed.embedder_registry import EmbedderRegistry
 from lightly_studio.embed.types import EmbeddingResult, EmbeddingSpaceSpec
+
+
+def _result(dimension: int, count: int) -> EmbeddingResult:
+    return EmbeddingResult(
+        embeddings=np.zeros((count, dimension), dtype=np.float32),
+        kept_indices=list(range(count)),
+    )
 
 
 class _FakeTextImageEmbedder(TextEmbedder, ImagePathEmbedder):
@@ -21,16 +34,34 @@ class _FakeTextImageEmbedder(TextEmbedder, ImagePathEmbedder):
         return EmbeddingSpaceSpec(space_key=self._space_key, dimension=self._dimension)
 
     def embed_text(self, texts: list[str]) -> EmbeddingResult:
-        return EmbeddingResult(
-            embeddings=np.zeros((len(texts), self._dimension), dtype=np.float32),
-            kept_indices=list(range(len(texts))),
-        )
+        return _result(self._dimension, len(texts))
 
     def embed_images(self, paths: list[str]) -> EmbeddingResult:
-        return EmbeddingResult(
-            embeddings=np.zeros((len(paths), self._dimension), dtype=np.float32),
-            kept_indices=list(range(len(paths))),
-        )
+        return _result(self._dimension, len(paths))
+
+
+class _FakeVideoEmbedder(VideoPathEmbedder):
+    def __init__(self, space_key: str, dimension: int = 2) -> None:
+        self._space_key = space_key
+        self._dimension = dimension
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        return EmbeddingSpaceSpec(space_key=self._space_key, dimension=self._dimension)
+
+    def embed_videos(self, paths: list[str]) -> EmbeddingResult:
+        return _result(self._dimension, len(paths))
+
+
+class _FakeImagePathEmbedder(ImagePathEmbedder):
+    def __init__(self, space_key: str, dimension: int = 2) -> None:
+        self._space_key = space_key
+        self._dimension = dimension
+
+    def embedding_space_spec(self) -> EmbeddingSpaceSpec:
+        return EmbeddingSpaceSpec(space_key=self._space_key, dimension=self._dimension)
+
+    def embed_images(self, paths: list[str]) -> EmbeddingResult:
+        return _result(self._dimension, len(paths))
 
 
 class _FakeNoCapabilityEmbedder(Embedder):
@@ -38,7 +69,7 @@ class _FakeNoCapabilityEmbedder(Embedder):
         return EmbeddingSpaceSpec(space_key="none", dimension=2)
 
 
-class TestEmbedderRegistry:
+class TestEmbedderRegistryRegister:
     def test_register(self) -> None:
         registry = EmbedderRegistry()
         embedder = _FakeTextImageEmbedder(space_key="space-a")
@@ -74,10 +105,14 @@ class TestEmbedderRegistry:
 
     def test_register__conflicting_spec_raises(self) -> None:
         registry = EmbedderRegistry()
-        registry.register(embedder=_FakeTextImageEmbedder(space_key="space-a", dimension=2))
+        first = _FakeTextImageEmbedder(space_key="space-a", dimension=2)
+        registry.register(embedder=first)
 
         with pytest.raises(ValueError, match="already registered"):
             registry.register(embedder=_FakeTextImageEmbedder(space_key="space-a", dimension=3))
+
+        # The registry is unchanged after the rejected replacement.
+        assert registry.get_text_embedder(space_key="space-a") is first
 
     def test_register__separate_spaces(self) -> None:
         registry = EmbedderRegistry()
@@ -90,7 +125,196 @@ class TestEmbedderRegistry:
         assert registry.get_text_embedder(space_key="space-a") is embedder_a
         assert registry.get_text_embedder(space_key="space-b") is embedder_b
 
-    def test_get_text_embedder__missing(self) -> None:
+
+class TestEmbedderRegistryBootstrapFor:
+    def test_none_sets_defaults_for_all_capabilities(self) -> None:
+        registry = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a")
+
+        registry.register(embedder=embedder, bootstrap_for=None)
+
+        # TEXT has no built-in default, so registering with None makes this the default.
+        assert registry.get_text_embedder() is embedder
+        assert registry.get_image_path_embedder() is embedder
+
+    def test_empty_set_changes_no_defaults(self) -> None:
+        registry = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a")
+
+        registry.register(embedder=embedder, bootstrap_for=set())
+
+        # TEXT still has no default; the embedder did not become one.
+        assert registry.get_text_embedder() is None
+
+    def test_explicit_set_updates_only_requested(self) -> None:
+        registry = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a")
+
+        registry.register(embedder=embedder, bootstrap_for={Capability.TEXT})
+
+        assert registry.get_text_embedder() is embedder
+        # IMAGE_PATH was not requested, so its default is unchanged (still mobileclip).
+        assert registry.get_image_path_embedder() is not embedder
+
+    def test_explicit_set_ignores_unsupported_capability(self) -> None:
+        registry = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a")
+
+        # VIDEO_PATH is not implemented by this embedder, so it is ignored.
+        registry.register(embedder=embedder, bootstrap_for={Capability.TEXT, Capability.VIDEO_PATH})
+
+        assert registry.get_text_embedder() is embedder
+        # The video default was left pointing at its built-in space.
+        assert registry.get_video_path_embedder(space_key="space-a") is None
+
+
+class TestEmbedderRegistryBootstrapDefaults:
+    def test_text_and_bytes_have_no_default(self) -> None:
         registry = EmbedderRegistry()
 
-        assert registry.get_text_embedder(space_key="space-a") is None
+        assert registry.get_text_embedder() is None
+        assert registry.get_image_bytes_embedder() is None
+        assert registry.get_bootstrap_space(capability=Capability.TEXT) is None
+        assert registry.get_bootstrap_space(capability=Capability.IMAGE_BYTES) is None
+
+    def test_get_bootstrap_space_returns_custom_provider_spec(self) -> None:
+        registry = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a", dimension=7)
+
+        registry.register(embedder=embedder, bootstrap_for={Capability.TEXT})
+
+        spec = registry.get_bootstrap_space(capability=Capability.TEXT)
+        assert spec == EmbeddingSpaceSpec(space_key="space-a", dimension=7)
+
+    def test_get_bootstrap_space_none_when_default_lacks_capability(self) -> None:
+        registry = EmbedderRegistry()
+        # A partial provider registered under the mobileclip key that only embeds
+        # text and images, not crops.
+        partial = _FakeTextImageEmbedder(space_key="mobileclip_s0", dimension=512)
+        registry.register(embedder=partial, bootstrap_for=set())
+
+        # The IMAGE_CROP_PATH default points at mobileclip_s0, but the registered
+        # provider there lacks that capability, so lookup returns None.
+        assert registry.get_bootstrap_space(capability=Capability.IMAGE_CROP_PATH) is None
+
+
+class TestEmbedderRegistryInstanceIsolation:
+    def test_instances_have_independent_state(self) -> None:
+        registry_a = EmbedderRegistry()
+        registry_b = EmbedderRegistry()
+        embedder = _FakeTextImageEmbedder(space_key="space-a")
+
+        registry_a.register(embedder=embedder, bootstrap_for={Capability.TEXT})
+
+        assert registry_a.get_text_embedder() is embedder
+        assert registry_b.get_text_embedder() is None
+        assert registry_b.get_text_embedder(space_key="space-a") is None
+
+
+class TestEmbedderRegistryLookup:
+    def test_explicit_key_does_not_fall_back(self) -> None:
+        registry = EmbedderRegistry()
+
+        # An unknown explicit key returns None even though a bootstrap default exists.
+        assert registry.get_image_path_embedder(space_key="unknown") is None
+
+    def test_unknown_key_returns_none(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        mocker.patch.object(embedder_registry, "_load_builtin_embedder", return_value=None)
+
+        assert registry.get_video_path_embedder(space_key="unknown") is None
+
+
+class TestEmbedderRegistryLazyLoading:
+    def test_deferred_construction(self, mocker: MockerFixture) -> None:
+        load = mocker.patch.object(embedder_registry, "_load_builtin_embedder", return_value=None)
+        EmbedderRegistry()
+
+        # Constructing the registry loads no built-in.
+        load.assert_not_called()
+
+    def test_loads_and_registers_on_demand(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        builtin = _FakeImagePathEmbedder(space_key="mobileclip_s0", dimension=512)
+        load = mocker.patch.object(
+            embedder_registry, "_load_builtin_embedder", return_value=builtin
+        )
+
+        first = registry.get_image_path_embedder()
+
+        assert first is builtin
+        load.assert_called_once_with(space_key="mobileclip_s0")
+
+    def test_object_reuse(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        builtin = _FakeImagePathEmbedder(space_key="mobileclip_s0", dimension=512)
+        load = mocker.patch.object(
+            embedder_registry, "_load_builtin_embedder", return_value=builtin
+        )
+
+        first = registry.get_image_path_embedder()
+        second = registry.get_image_path_embedder()
+
+        assert first is second
+        load.assert_called_once()
+
+    def test_reconstruction_by_explicit_key(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        builtin = _FakeVideoEmbedder(space_key="PE-Core-T16-384", dimension=512)
+        load = mocker.patch.object(
+            embedder_registry, "_load_builtin_embedder", return_value=builtin
+        )
+
+        embedder = registry.get_video_path_embedder(space_key="PE-Core-T16-384")
+
+        assert embedder is builtin
+        load.assert_called_once_with(space_key="PE-Core-T16-384")
+
+    def test_registered_provider_is_authoritative(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        registered = _FakeImagePathEmbedder(space_key="mobileclip_s0", dimension=512)
+        registry.register(embedder=registered, bootstrap_for=set())
+        load = mocker.patch.object(embedder_registry, "_load_builtin_embedder")
+
+        # A registered provider for a built-in key is used without loading the built-in.
+        assert registry.get_image_path_embedder(space_key="mobileclip_s0") is registered
+        load.assert_not_called()
+
+    def test_partial_registered_provider_used_for_builtin_key(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        # A partial provider under the mobileclip key that only embeds text.
+        partial = _FakeTextImageEmbedder(space_key="mobileclip_s0", dimension=512)
+        registry.register(embedder=partial, bootstrap_for=set())
+        load = mocker.patch.object(embedder_registry, "_load_builtin_embedder")
+
+        assert registry.get_text_embedder(space_key="mobileclip_s0") is partial
+        load.assert_not_called()
+
+    def test_lazy_loading_preserves_builtin_defaults(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        mobileclip = _FakeImagePathEmbedder(space_key="mobileclip_s0", dimension=512)
+        perception = _FakeVideoEmbedder(space_key="PE-Core-T16-384", dimension=1024)
+
+        def fake_load(space_key: str) -> Embedder | None:
+            return {"mobileclip_s0": mobileclip, "PE-Core-T16-384": perception}.get(space_key)
+
+        mocker.patch.object(embedder_registry, "_load_builtin_embedder", side_effect=fake_load)
+
+        # Loading PE for the video default must not change the image default.
+        registry.get_video_path_embedder()
+
+        assert registry.get_bootstrap_space(capability=Capability.IMAGE_PATH) == (
+            EmbeddingSpaceSpec(space_key="mobileclip_s0", dimension=512)
+        )
+
+    def test_lazy_loading_preserves_custom_defaults(self, mocker: MockerFixture) -> None:
+        registry = EmbedderRegistry()
+        custom = _FakeImagePathEmbedder(space_key="custom-image", dimension=4)
+        registry.register(embedder=custom, bootstrap_for={Capability.IMAGE_PATH})
+        perception = _FakeVideoEmbedder(space_key="PE-Core-T16-384", dimension=1024)
+        mocker.patch.object(embedder_registry, "_load_builtin_embedder", return_value=perception)
+
+        # Loading a built-in for the video default must not overwrite the custom image default.
+        registry.get_video_path_embedder()
+
+        assert registry.get_image_path_embedder() is custom


### PR DESCRIPTION
## What has changed and why?

First PR of the `embed_samples` → `EmbedderRegistry` migration (LIG-10707). Registry-only; no callers touched yet.

- Each `EmbedderRegistry` instance owns its bootstrap defaults (space chosen for a capability when no collection default is saved).
- `register(embedder, bootstrap_for=...)`: `None` sets defaults for all implemented capabilities, `set()` changes none, an explicit set updates the intersection and ignores unsupported capabilities. Incompatible replacement raises without mutating state.
- Typed getters take an optional `space_key`; `None` resolves the capability's bootstrap default.
- `get_bootstrap_space(capability)` returns the selected space's spec, including custom providers.
- Lazy loading of the MobileCLIP and PE built-ins on first lookup; a lazily loaded provider never re-decides another capability's default.
- Process-wide instance exposed via `get_registry()`.

Seed defaults: image capabilities → `mobileclip_s0`, video → `PE-Core-T16-384`; text and image-bytes have no built-in default.

## How has it been tested?

New unit tests (23) covering all `bootstrap_for` modes, unsupported requests, instance isolation, compatible/incompatible replacement, partial providers, exact-key resolution, unknown keys, and lazy loading (deferred construction, reuse, reconstruction by key, registered-provider authority, default preservation). Lazy loading is mocked to avoid model downloads.

`make static-checks` and the embed tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @iunir. Alternative: whoever last touched `embed/`.