### PR TITLE
Fix: Slow python api on remote datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Speed up distribution plot tag comparisons by up to 4.9x by requesting and calculating only the metadata field being viewed.
+- Speed up Python SDK iteration and sampling setup with remote databases by avoiding an extra database query for each sample.
 - Improved categorical metadata loading performance, reducing database work and page-load latency for large datasets.
 - Improved metadata loading by reducing numeric database queries from 13 to 8 and making responses up to 25% faster.
 - Speed up metadata-weighting sampling by reading all metadata values in one query instead of one query per sample.

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Mapping
 from typing import Generic, cast
 from uuid import UUID
 
-from sqlalchemy.orm import joinedload
+from sqlalchemy import orm
 from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import SelectOfScalar
 from typing_extensions import Self, TypeVar
@@ -274,10 +274,12 @@ class DatasetQuery(Generic[T]):
         Returns:
             Iterator of Sample objects from the database.
         """
+        # Reuse the joined base sample so wrapper construction needs no per-sample query.
         if self.dataset.sample_type == SampleType.IMAGE:
             image_query: SelectOfScalar[ImageTable] = (
                 select(ImageTable)
                 .join(ImageTable.sample)
+                .options(orm.contains_eager(ImageTable.sample))
                 .where(SampleTable.collection_id == self.dataset.collection_id)
             )
             image_query = self._compose_query(image_query)
@@ -288,6 +290,7 @@ class DatasetQuery(Generic[T]):
             video_query: SelectOfScalar[VideoTable] = (
                 select(VideoTable)
                 .join(VideoTable.sample)
+                .options(orm.contains_eager(VideoTable.sample))
                 .where(SampleTable.collection_id == self.dataset.collection_id)
             )
             video_query = self._compose_query(video_query)
@@ -298,6 +301,7 @@ class DatasetQuery(Generic[T]):
             group_query: SelectOfScalar[GroupTable] = (
                 select(GroupTable)
                 .join(GroupTable.sample)
+                .options(orm.contains_eager(GroupTable.sample))
                 .where(SampleTable.collection_id == self.dataset.collection_id)
             )
             group_query = self._compose_query(group_query)
@@ -308,10 +312,11 @@ class DatasetQuery(Generic[T]):
             video_frame_query: SelectOfScalar[VideoFrameTable] = (
                 select(VideoFrameTable)
                 .join(VideoFrameTable.sample)
+                .options(orm.contains_eager(VideoFrameTable.sample))
                 .where(SampleTable.collection_id == self.dataset.collection_id)
                 # Eager-load the parent video so VideoFrameSample.parent_video does not
                 # trigger a query per frame (many-to-one, so no row multiplication).
-                .options(joinedload(VideoFrameTable.video))
+                .options(orm.joinedload(VideoFrameTable.video))
             )
             video_frame_query = self._compose_query(video_frame_query)
             for video_frame_table in self.session.exec(video_frame_query):


### PR DESCRIPTION
## What has changed and why?

- Remove an extra database request for every sample. Before this PR iterating naively over samples would create individual db queries and with remote datasets (higher latency) it makes queries very slow. Now, we tell the db resolver to already get the data if possible.
- Make listing samples and preparing sampling faster.

## How has it been tested?

- manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Sped up Python SDK iteration and sampling setup with remote databases by avoiding an additional database query for each sample.
  - Improved dataset access efficiency when working with image, video, group, and video-frame samples.

- **Documentation**
  - Added an entry to the unreleased changelog describing the performance improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->