### PR TITLE
Fix: Reduce repeated work when loading metadata schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved metadata loading by reducing latency by up to 70% and increasing throughput by up to 4× under concurrent requests.
 - Speed up distribution plot tag comparisons by up to 4.9x by requesting and calculating only the metadata field being viewed.
 - Improved categorical metadata loading performance, reducing database work and page-load latency for large datasets.
 - Improved metadata loading by reducing numeric database queries from 13 to 8 and making responses up to 25% faster.

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/metadata_helpers.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/metadata_helpers.py
@@ -18,6 +18,7 @@ def get_merged_schema(session: Session, collection_id: UUID) -> dict[str, str]:
     """Merge the metadata schemas of all samples in a collection."""
     rows = session.exec(
         sqlmodel.select(SampleMetadataTable.metadata_schema)
+        .distinct()
         .select_from(SampleTable)
         .join(
             SampleMetadataTable,


### PR DESCRIPTION
## What has changed and why?

- Reduce metadata endpoint latency by up to 70%.
- Increase throughput by up to 4× when handling concurrent requests.
- Remove repeated schema transfer and processing to make metadata requests more efficient.

## How has it been tested?

- tested that postgres and duckdb still work

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved metadata loading performance, reducing latency by up to 70% and increasing throughput by up to 4× under concurrent requests.

- **Bug Fixes**
  - Prevented duplicate metadata schemas from appearing when retrieving schemas across samples in a collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->