### PR TITLE
Read video frame timing from packet headers instead of decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved metadata loading by reducing numeric database queries from 13 to 8 and making responses up to 25% faster.
 - Speed up metadata-weighting sampling by reading all metadata values in one query instead of one query per sample.
 - Change the video decoding backend for the GUI from OpenCV to PyAV, resulting in up to 6× faster decoding performance for parallel streams when loading the grid view and scrolling.
+- Speed up video ingestion by reading frame timing from packet headers instead of decoding every frame. This is about 4× faster and uses about 7× less CPU when frame embeddings are not generated. A video that is damaged part way through is now reported when a frame is viewed instead of when the video is added.
 
 ### Deprecated
 

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -19,6 +19,7 @@ import numpy as np
 from av import FFmpegError, container
 from av.codec.context import ThreadType
 from av.container import InputContainer
+from av.packet import Packet
 from av.video.frame import VideoFrame as AVVideoFrame
 from av.video.stream import VideoStream
 from labelformat.model.instance_segmentation_track import (
@@ -71,6 +72,10 @@ SAMPLE_BATCH_SIZE = 128
 _MAX_FETCH_WORKERS = 3
 _MAX_BUFFERED_VIDEO_BYTES = 128 * 2**20
 
+# Bound the search for the rotation matrix. A decoder holds back the first packets of a
+# stream, so the first frame arrives a few packets in, or the stream cannot be decoded.
+_MAX_ROTATION_DECODE_PACKETS = 64
+
 # Video file extensions
 # These are commonly supported by PyAV/FFmpeg.
 VIDEO_EXTENSIONS = {
@@ -115,6 +120,16 @@ class _FetchedVideo:
     path: str
     content: bytes | None = None
     error: InputFileError | None = None
+
+
+@dataclass
+class _PacketFrameTiming:
+    """Frame timing read from packet headers instead of from decoded frames."""
+
+    pts_values: list[int]
+    """Presentation timestamp of every frame, in ascending (display) order."""
+    rotation_deg: int
+    """Rotation in degrees, shared by every frame of the stream."""
 
 
 def load_into_collection_from_paths(  # noqa: PLR0913
@@ -532,10 +547,12 @@ def _create_video_frame_samples(
     num_decode_threads: int | None = None,
     target_fps: float | None = None,
 ) -> list[UUID]:
-    """Create video frame samples for a video by parsing all frames.
+    """Create video frame samples for a video.
 
-    This function decodes all frames to extract metadata. When frame embedding is enabled,
-    embeddings are generated from the decoded frames in the same pass.
+    A frame row holds timing and rotation, and packet headers already carry the timing.
+    Reading the headers is roughly 20 times faster than decoding every frame, so the full
+    decode runs only when embedding needs the pixels, or when the headers of this file
+    cannot be trusted.
 
     Args:
         context: Frame extraction context (session, dataset and parent video).
@@ -549,11 +566,205 @@ def _create_video_frame_samples(
     Returns:
         A list of UUIDs of the created video frame samples.
     """
+    video_stream = video_container.streams.video[video_channel]
+    # Threading has to be set before the codec opens, and reading the rotation below
+    # opens it.
+    _configure_stream_threading(video_stream=video_stream, num_decode_threads=num_decode_threads)
+
+    if not context.embed_frames:
+        timing = _read_frame_timing_from_packets(
+            video_container=video_container, video_stream=video_stream
+        )
+        if timing is not None:
+            return _create_frame_samples_from_timing(
+                context=context,
+                video_stream=video_stream,
+                timing=timing,
+                target_fps=target_fps,
+            )
+        # Reading the headers consumed the container. Rewind so that the decode below
+        # starts from the first frame again.
+        video_container.seek(0, stream=video_stream, backward=True, any_frame=False)
+
+    return _decode_video_frame_samples(
+        context=context,
+        video_container=video_container,
+        video_stream=video_stream,
+        target_fps=target_fps,
+    )
+
+
+def _read_frame_timing_from_packets(
+    video_container: InputContainer, video_stream: VideoStream
+) -> _PacketFrameTiming | None:
+    """Read the timing of every frame from packet headers, without decoding the video.
+
+    A packet carries the presentation timestamp of its frame, so the frame rows can be
+    built from the headers alone. Rotation is the exception: PyAV exposes DISPLAYMATRIX
+    only on a decoded frame, so the first packet that yields a frame is decoded to read
+    it. The matrix applies to the whole stream.
+
+    Args:
+        video_container: The PyAV container with the opened video, positioned at the start.
+        video_stream: The video stream whose packets are read.
+
+    Returns:
+        The timing of every frame in display order, or None when the headers cannot be
+        trusted and the caller has to decode the video instead.
+    """
+    pts_values: list[int] = []
+    rotation_deg: int | None = None
+    interlaced = False
+    decode_attempts = 0
+
+    for packet in video_container.demux(video_stream):
+        # A demux run ends with an empty packet that flushes the decoder. It holds no
+        # frame, and it is the only packet without a timestamp in a well-formed stream.
+        if packet.size == 0:
+            continue
+        # A frame with no timestamp cannot be ordered here, nor seeked to when the GUI
+        # later serves it. Damaged and dropped packets never become frames.
+        if packet.pts is None or packet.is_corrupt or packet.is_discard:
+            return None
+        pts_values.append(packet.pts)
+        if rotation_deg is None and decode_attempts < _MAX_ROTATION_DECODE_PACKETS:
+            decode_attempts += 1
+            rotation_deg, interlaced = _read_frame_properties(packet=packet)
+
+    if rotation_deg is None or not _frame_count_is_trusted(
+        frame_count=len(pts_values), interlaced=interlaced, video_stream=video_stream
+    ):
+        return None
+
+    # Packets arrive in decode order, which places a B-frame before the frames it
+    # interpolates between. Sorting restores the display order that frame_number counts.
+    pts_values.sort()
+    return _PacketFrameTiming(pts_values=pts_values, rotation_deg=rotation_deg)
+
+
+def _read_frame_properties(packet: Packet) -> tuple[int | None, bool]:
+    """Get the rotation and the interlacing of the first frame a packet yields.
+
+    Args:
+        packet: The packet to decode.
+
+    Returns:
+        The rotation in degrees and whether the frame is interlaced, or (None, False)
+        when the packet yields no frame yet.
+    """
+    # Packets of a video stream decode into video frames, which the return type of
+    # ``decode`` does not express on its own.
+    for frame in cast("list[AVVideoFrame]", packet.decode()):
+        return _get_frame_rotation_deg(frame=frame), bool(frame.interlaced_frame)
+    return None, False
+
+
+def _frame_count_is_trusted(frame_count: int, interlaced: bool, video_stream: VideoStream) -> bool:
+    """Check whether one packet held one frame for the whole stream.
+
+    A packet is normally one frame, but interlaced content stores a frame as two fields
+    and breaks that. Where the container header declares a frame count, it confirms the
+    packet count directly. Matroska and WebM leave the count at zero, and then the
+    absence of interlacing is the only available signal.
+
+    Args:
+        frame_count: The number of frames counted from packet headers.
+        interlaced: Whether the decoded reference frame is interlaced.
+        video_stream: The video stream whose header is checked.
+
+    Returns:
+        True if the frame count can be trusted.
+    """
+    if interlaced:
+        return False
+    declared_frame_count = video_stream.frames
+    if declared_frame_count <= 0:
+        return True
+    return frame_count == declared_frame_count
+
+
+def _create_frame_samples_from_timing(
+    context: FrameExtractionContext,
+    video_stream: VideoStream,
+    timing: _PacketFrameTiming,
+    target_fps: float | None,
+) -> list[UUID]:
+    """Persist frame samples from timing that was read without decoding.
+
+    Args:
+        context: Frame extraction context (session, dataset and parent video).
+        video_stream: The video stream the timing was read from.
+        timing: The timing of every frame, in display order.
+        target_fps: Optional target frame rate for subsampling. If set and lower than the
+            source frame rate, only a subset of frames is persisted; kept frames retain
+            their original frame_number. If omitted, all frames are persisted.
+
+    Returns:
+        A list of UUIDs of the created video frame samples.
+    """
+    time_base = video_stream.time_base if video_stream.time_base else None
+    original_fps = float(video_stream.average_rate) if video_stream.average_rate else 0.0
+
+    created_sample_ids: list[UUID] = []
+    samples_to_create: list[VideoFrameCreate] = []
+    for frame_number, frame_timestamp_pts in enumerate(timing.pts_values):
+        if not _should_keep_frame(
+            decoded_index=frame_number, target_fps=target_fps, original_fps=original_fps
+        ):
+            continue
+
+        samples_to_create.append(
+            VideoFrameCreate(
+                frame_number=frame_number,
+                frame_timestamp_s=(
+                    float(frame_timestamp_pts * time_base) if time_base is not None else -1.0
+                ),
+                frame_timestamp_pts=frame_timestamp_pts,
+                parent_sample_id=context.video_sample_id,
+                rotation_deg=timing.rotation_deg,
+            )
+        )
+        if len(samples_to_create) >= SAMPLE_BATCH_SIZE:
+            created_sample_ids.extend(
+                _flush_frame_batch(
+                    context=context, samples_to_create=samples_to_create, pil_frames=[]
+                )
+            )
+            samples_to_create = []
+
+    if samples_to_create:
+        created_sample_ids.extend(
+            _flush_frame_batch(context=context, samples_to_create=samples_to_create, pil_frames=[])
+        )
+
+    return created_sample_ids
+
+
+def _decode_video_frame_samples(
+    context: FrameExtractionContext,
+    video_container: InputContainer,
+    video_stream: VideoStream,
+    target_fps: float | None = None,
+) -> list[UUID]:
+    """Create video frame samples for a video by decoding all frames.
+
+    This function decodes all frames to extract metadata. When frame embedding is enabled,
+    embeddings are generated from the decoded frames in the same pass.
+
+    Args:
+        context: Frame extraction context (session, dataset and parent video).
+        video_container: The PyAV container with the opened video.
+        video_stream: The video stream from which frames are decoded.
+        target_fps: Optional target frame rate for subsampling. If set and lower than the
+            source frame rate, only a subset of frames is persisted; kept frames retain
+            their original frame_number. If omitted, all frames are persisted.
+
+    Returns:
+        A list of UUIDs of the created video frame samples.
+    """
     created_sample_ids: list[UUID] = []
     samples_to_create: list[VideoFrameCreate] = []
     pil_frames: list[Image.Image] = []
-    video_stream = video_container.streams.video[video_channel]
-    _configure_stream_threading(video_stream=video_stream, num_decode_threads=num_decode_threads)
 
     # Get time base for converting PTS to seconds
     time_base = video_stream.time_base if video_stream.time_base else None
@@ -645,8 +856,9 @@ def _configure_stream_threading(video_stream: VideoStream, num_decode_threads: i
     try:
         codec_context.thread_type = ThreadType.AUTO
         codec_context.thread_count = num_decode_threads
-    except av.FFmpegError:
-        # Some codecs do not support threading—ignore silently.
+    except (av.FFmpegError, RuntimeError):
+        # Some codecs do not support threading, and an already open codec rejects the
+        # change. Neither stops the decode, so keep the single-threaded default.
         logger.warning(
             "Could not set up multithreading to decode videos, will use a single thread."
         )

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -600,9 +600,12 @@ def _read_frame_timing_from_packets(
     """Read the timing of every frame from packet headers, without decoding the video.
 
     A packet carries the presentation timestamp of its frame, so the frame rows can be
-    built from the headers alone. Rotation is the exception: PyAV exposes DISPLAYMATRIX
-    only on a decoded frame, so the first packet that yields a frame is decoded to read
-    it. The matrix applies to the whole stream.
+    built from the headers alone. Rotation is the exception, and not because the format
+    hides it: the display matrix sits in the container header, and ffprobe reads it
+    without decoding. PyAV binds DISPLAYMATRIX only on a decoded frame, so the first
+    packet that yields one is decoded to read it. That frame also carries the interlacing
+    that ``_frame_count_is_trusted`` needs, which PyAV exposes nowhere else either. Both
+    properties apply to the whole stream.
 
     Args:
         video_container: The PyAV container with the opened video, positioned at the start.

--- a/lightly_studio/tests/api/test_video_frames_media.py
+++ b/lightly_studio/tests/api/test_video_frames_media.py
@@ -22,8 +22,10 @@ from sqlmodel import Session
 import lightly_studio.api.routes.video_frames_media as video_frames_media_module
 import lightly_studio.utils.executor as executor_module
 from lightly_studio.api.routes.video_frames_media import FrameTransformOptions
+from lightly_studio.core.video import add_videos
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.settings import GridViewThumbnailQualityType
+from lightly_studio.resolvers import video_frame_resolver
 from tests.helpers_resolvers import create_collection
 from tests.resolvers.video.helpers import VideoStub, create_video_file, create_video_with_frames
 
@@ -301,3 +303,75 @@ def test_stream_frame_multiple_frames_same_video(
     # All should succeed (caching helps with performance)
     assert len(responses) == 3
     assert all(r.status_code == 200 for r in responses)
+
+
+def _create_lossless_video(output_path: Path, num_frames: int) -> Path:
+    """Create a lossless video whose frames all differ, so a frame can be identified.
+
+    Args:
+        output_path: Path where the video file is written.
+        num_frames: Number of frames to generate.
+
+    Returns:
+        The path to the created video file.
+    """
+    with av.open(str(output_path), mode="w") as output_container:
+        stream = cast(VideoStream, output_container.add_stream("ffv1", rate=10))
+        stream.width, stream.height = 32, 16
+        stream.pix_fmt = "bgr0"
+        for frame_number in range(num_frames):
+            pixels = np.full((16, 32, 3), frame_number * 8, dtype=np.uint8)
+            frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+            frame.pts = frame_number
+            for packet in stream.encode(frame):
+                output_container.mux(packet)
+        for packet in stream.encode():
+            output_container.mux(packet)
+    return output_path
+
+
+def test_process_video_frame__serves_frames_ingested_without_decoding(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Timestamps read from packet headers must seek to the frame they belong to.
+
+    A timestamp that is off by one unit still looks valid in the database, but the seek
+    misses and the frame is served from a linear scan. Comparing the served pixels
+    against the frames of the source video is what shows the timestamps are exact.
+    """
+    video_path = _create_lossless_video(output_path=tmp_path / "lossless.mkv", num_frames=8)
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+
+    _, frame_sample_ids = add_videos.load_into_collection_from_paths(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video_paths=[str(video_path)],
+        show_progress=False,
+    )
+    assert len(frame_sample_ids) == 8
+
+    with av.open(str(video_path)) as source_container:
+        source_frames = list(source_container.decode(source_container.streams.video[0]))
+        expected_frames = [frame.to_ndarray(format="rgb24") for frame in source_frames]
+        expected_pts = [frame.pts for frame in source_frames]
+
+    # Assert the timestamps directly. Serving alone does not prove them: a wrong
+    # timestamp makes the seek miss, and the frame is then found by a linear scan on
+    # frame_number, which returns the right pixels from the wrong code path.
+    stored_pts = [
+        video_frame_resolver.get_by_id(session=db_session, sample_id=sample_id).frame_timestamp_pts
+        for sample_id in frame_sample_ids
+    ]
+    assert stored_pts == expected_pts
+
+    for sample_id in frame_sample_ids:
+        video_frame = video_frame_resolver.get_by_id(session=db_session, sample_id=sample_id)
+        buffer, _ = video_frames_media_module._process_video_frame(
+            video_path=str(video_path),
+            frame_number=video_frame.frame_number,
+            frame_timestamp_pts=video_frame.frame_timestamp_pts,
+            rotation_deg=video_frame.rotation_deg,
+            transform=FrameTransformOptions(GridViewThumbnailQualityType.RAW, None, None),
+        )
+        served = np.asarray(Image.open(io.BytesIO(buffer)))
+        np.testing.assert_array_equal(served, expected_frames[video_frame.frame_number])

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import fsspec
+import numpy as np
 import pytest
 from av import container
 from av.codec.context import ThreadType
@@ -478,6 +479,247 @@ def test__create_video_frame_samples__embed_frames(
 
     video_container.close()
     video_file.close()
+
+
+def _extract_frame_rows(
+    session: Session, video_path: Path, target_fps: float | None = None
+) -> list[tuple[int, int, float, int]]:
+    """Extract frames into a fresh collection and return the stored rows.
+
+    Args:
+        session: The database session.
+        video_path: The video to extract frames from.
+        target_fps: Optional target frame rate for subsampling.
+
+    Returns:
+        One (frame_number, frame_timestamp_pts, frame_timestamp_s, rotation_deg) tuple per
+        frame, ordered by frame number.
+    """
+    collection = create_collection(session, sample_type=SampleType.VIDEO)
+    video_sample_ids = video_resolver.create_many(
+        session=session,
+        collection_id=collection.collection_id,
+        samples=[
+            VideoCreate(
+                file_path_abs=str(video_path),
+                file_name=video_path.name,
+                width=64,
+                height=48,
+                duration_s=3.0,
+                fps=10,
+            )
+        ],
+    )
+    frames_collection_id = collection_resolver.get_or_create_child_collection(
+        session=session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.VIDEO_FRAME,
+    )
+    video_container = container.open(file=str(video_path))
+    try:
+        add_videos._create_video_frame_samples(
+            context=FrameExtractionContext(
+                session=session,
+                collection_id=frames_collection_id,
+                video_sample_id=video_sample_ids[0],
+            ),
+            video_container=video_container,
+            video_channel=0,
+            target_fps=target_fps,
+        )
+    finally:
+        video_container.close()
+
+    frames = video_frame_resolver.get_all_by_collection_id(
+        session=session, collection_id=frames_collection_id
+    ).samples
+    return sorted(
+        (
+            frame.frame_number,
+            frame.frame_timestamp_pts,
+            frame.frame_timestamp_s,
+            frame.rotation_deg,
+        )
+        for frame in frames
+    )
+
+
+def test__create_video_frame_samples__packet_timing_matches_decoding(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Rows read from packet headers are identical to rows built by decoding."""
+    video_path = create_video_file(
+        output_path=tmp_path / "b_frames.mp4", width=64, height=48, num_frames=30, fps=10
+    )
+
+    from_packets = _extract_frame_rows(session=db_session, video_path=video_path)
+
+    # Without usable packet headers the extraction rewinds and decodes instead.
+    mocker.patch.object(add_videos, "_read_frame_timing_from_packets", return_value=None)
+    from_decoding = _extract_frame_rows(session=db_session, video_path=video_path)
+
+    assert from_packets == from_decoding
+    assert len(from_packets) == 30
+
+
+def test__create_video_frame_samples__numbers_frames_in_display_order(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """B-frames are stored out of display order, so frame_number must follow the pts."""
+    video_path = create_video_file(
+        output_path=tmp_path / "b_frames.mp4", width=64, height=48, num_frames=30, fps=10
+    )
+    video_container = container.open(file=str(video_path))
+    packet_pts = [
+        packet.pts
+        for packet in video_container.demux(video_container.streams.video[0])
+        if packet.pts is not None
+    ]
+    video_container.close()
+    # The fixture is only meaningful while the encoder emits reordered packets.
+    assert packet_pts[:3] != sorted(packet_pts[:3])
+
+    rows = _extract_frame_rows(session=db_session, video_path=video_path)
+
+    frame_numbers = [row[0] for row in rows]
+    pts_values = [row[1] for row in rows]
+    assert frame_numbers == list(range(30))
+    assert pts_values == sorted(pts_values)
+
+
+def test__create_video_frame_samples__does_not_decode_without_embedding(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Frame rows come from packet headers when no embedding needs the pixels."""
+    video_path = create_video_file(
+        output_path=tmp_path / "no_decode.mp4", width=64, height=48, num_frames=10, fps=10
+    )
+    decode_spy = mocker.spy(add_videos, "_decode_video_frame_samples")
+
+    rows = _extract_frame_rows(session=db_session, video_path=video_path)
+
+    assert len(rows) == 10
+    decode_spy.assert_not_called()
+
+
+def test__create_video_frame_samples__packet_timing_applies_target_fps(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Subsampling selects the same frames on the packet path and the decode path."""
+    video_path = create_video_file(
+        output_path=tmp_path / "subsampled.mp4", width=64, height=48, num_frames=30, fps=10
+    )
+
+    from_packets = _extract_frame_rows(session=db_session, video_path=video_path, target_fps=2.0)
+
+    mocker.patch.object(add_videos, "_read_frame_timing_from_packets", return_value=None)
+    from_decoding = _extract_frame_rows(session=db_session, video_path=video_path, target_fps=2.0)
+
+    assert from_packets == from_decoding
+    assert [row[0] for row in from_packets] == list(range(0, 30, 5))
+
+
+def test__read_frame_timing_from_packets(tmp_path: Path) -> None:
+    video_path = create_video_file(
+        output_path=tmp_path / "timing.mp4", width=64, height=48, num_frames=10, fps=10
+    )
+    video_container = container.open(file=str(video_path))
+
+    timing = add_videos._read_frame_timing_from_packets(
+        video_container=video_container,
+        video_stream=video_container.streams.video[0],
+    )
+
+    video_container.close()
+    assert timing is not None
+    assert len(timing.pts_values) == 10
+    assert timing.pts_values == sorted(timing.pts_values)
+    assert timing.rotation_deg == 0
+
+
+def test__read_frame_timing_from_packets__returns_none_for_untrusted_count(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    video_path = create_video_file(
+        output_path=tmp_path / "untrusted.mp4", width=64, height=48, num_frames=10, fps=10
+    )
+    video_container = container.open(file=str(video_path))
+    mocker.patch.object(add_videos, "_frame_count_is_trusted", return_value=False)
+
+    timing = add_videos._read_frame_timing_from_packets(
+        video_container=video_container,
+        video_stream=video_container.streams.video[0],
+    )
+
+    video_container.close()
+    assert timing is None
+
+
+@pytest.mark.parametrize(
+    ("rotation_matrix", "expected_rotation_deg"),
+    [
+        ([1, 0, 0, 0, 1, 0, 0, 0, 1 << 30], 0),
+        ([0, -(1 << 16), 0, 1 << 16, 0, 0, 0, 0, 1 << 30], 90),
+        ([-(1 << 16), 0, 0, 0, -(1 << 16), 0, 0, 0, 1 << 30], 180),
+        ([0, 1 << 16, 0, -(1 << 16), 0, 0, 0, 0, 1 << 30], 270),
+    ],
+)
+def test__read_frame_properties(
+    rotation_matrix: list[int], expected_rotation_deg: int, mocker: MockerFixture
+) -> None:
+    frame = mocker.MagicMock()
+    frame.side_data = {"DISPLAYMATRIX": np.array(rotation_matrix, dtype=np.int32).tobytes()}
+    frame.interlaced_frame = False
+    packet = mocker.MagicMock()
+    packet.decode.return_value = [frame]
+
+    rotation_deg, interlaced = add_videos._read_frame_properties(packet=packet)
+
+    assert rotation_deg == expected_rotation_deg
+    assert interlaced is False
+
+
+def test__read_frame_properties__no_frame_yet(mocker: MockerFixture) -> None:
+    """A decoder holds back the first packets, which then carry no frame."""
+    packet = mocker.MagicMock()
+    packet.decode.return_value = []
+
+    rotation_deg, interlaced = add_videos._read_frame_properties(packet=packet)
+
+    assert rotation_deg is None
+    assert interlaced is False
+
+
+@pytest.mark.parametrize(
+    ("frame_count", "interlaced", "declared_frame_count", "expected"),
+    [
+        # The container header confirms the packet count.
+        (30, False, 30, True),
+        # One packet did not become one frame.
+        (30, False, 31, False),
+        # Matroska and WebM leave the frame count at zero.
+        (30, False, 0, True),
+        # Interlaced content stores a frame as two fields.
+        (30, True, 30, False),
+        (30, True, 0, False),
+    ],
+)
+def test__frame_count_is_trusted(
+    frame_count: int,
+    interlaced: bool,
+    declared_frame_count: int,
+    expected: bool,
+    mocker: MockerFixture,
+) -> None:
+    video_stream = mocker.MagicMock()
+    video_stream.frames = declared_frame_count
+
+    assert (
+        add_videos._frame_count_is_trusted(
+            frame_count=frame_count, interlaced=interlaced, video_stream=video_stream
+        )
+        is expected
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What has changed and why?

Adding a video decoded every one of its frames. The only thing that came out of that decode was four values per frame row — `frame_number`, `frame_timestamp_s`, `frame_timestamp_pts` and `rotation_deg` — and three of them are already written on the packet header. `embed_frames` gated only the pixel conversion and the embedder call, so ingesting with `embed=False, embed_frames=False` still paid for a full decode of every video.

- Frame rows are now built from packet headers when `embed_frames` is off. Nothing needs the pixels there.
- The first packet that yields a frame is still decoded, because PyAV exposes the rotation matrix (`DISPLAYMATRIX`) on a decoded frame and not on the packet. Rotation is constant for a stream, so one frame is enough.
- When embedding is on, or when the headers cannot be trusted, the container rewinds and the previous full decode runs unchanged.

Measured over the 70 videos in `dataset_examples`, listing every frame:

| | wall time | CPU time |
|---|---|---|
| decode (threaded, as before) | 3.01 s | 14.44 s |
| packet headers | 0.72 s | 2.16 s |

`target_fps` also gets cheaper for the first time. `_should_keep_frame` runs after a frame is decoded, so subsampling to 1 fps used to save nothing.

Two details worth a look during review:

- **Packets arrive in decode order.** A B-frame is stored before the frames it interpolates between, so the packets are sorted by timestamp before `frame_number` is assigned. The decoder used to hand us this ordering for free.
- **One packet is not always one frame.** The count is checked against the frame count in the container header, and interlaced content is rejected. Matroska and WebM leave that count at zero, so there the absence of interlacing is the only signal. Either check failing falls back to the full decode.

### Behaviour change to be aware of

A video that is damaged part way through is no longer noticed while it is added, because the headers are read without decoding the pictures. Such a video now ingests cleanly and its frames return 400 when viewed. Note that the miss is not cheap: `_decode_video_frame` falls back to a linear scan over the whole video before giving up.

## How has it been tested?

- Both paths produce byte-identical rows — same count, `frame_number`, `frame_timestamp_pts` and `rotation_deg` — across all 70 `dataset_examples` videos, `tests/fixtures/dog.mp4`, the same content remuxed to MKV / WebM / AVI / MOV, and files rotated 90/180/270 with a real display matrix.
- The fallback was exercised by forcing the trust check to fail; the rewind reproduces the decode-path rows exactly on every container format above.
- A rewind bug surfaced during that work and is fixed here: decoding for the rotation opens the codec, so the later threading setup raised `RuntimeError`, which `_load_single_video` does not catch and which would have aborted the run. Threading is now configured before anything decodes.
- New unit tests cover packet-header reading, the trust check, the rotation matrix for all four angles, display-order numbering on a B-frame file, and `target_fps` parity between the two paths.
- `tests/api/test_video_frames_media.py` gains an end-to-end test that ingests through the packet path and then serves every frame. It asserts the stored timestamps directly, not just the served pixels: a timestamp that is off by one still returns the right pixels through the linear-scan fallback, so a pixel-only assertion passes even when the timestamps are wrong. Confirmed by mutation — the test fails with `pts + 1` and passes without it.
- `ruff check`, `ruff format --check` and `mypy` are clean on the touched files. Full backend suite: 2618 passed, 46 skipped.

Note: `make static-checks` cannot run here because `check-uv-lock` pins uv `0.12.6` and the installed uv is `0.12.10`, so the tools were run directly. `uv.lock` is untouched.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

---

Suggested reviewer: @MalteEbner, who has the most recent history on `add_videos.py`. Alternative: @michal-lightly.