### PR TITLE
Fix: Thumbnails on the grid are not properly rendered with 503 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Increase max_concurrency of requests to the backend from 100 to 128 to reduce chance of seeing 503 errors in the frontend.
 - Improved metadata loading by reducing latency by up to 70% and increasing throughput by up to 4× under concurrent requests.
 - Speed up distribution plot tag comparisons by up to 4.9x by requesting and calculating only the metadata field being viewed.
 - Improved categorical metadata loading performance, reducing database work and page-load latency for large datasets.

--- a/lightly_studio/src/lightly_studio/api/server.py
+++ b/lightly_studio/src/lightly_studio/api/server.py
@@ -53,7 +53,7 @@ class Server:
             port=self.port,
             http="h11",
             # https://uvicorn.dev/settings/#resource-limits
-            limit_concurrency=100,  # Max concurrent connections
+            limit_concurrency=128,  # Max concurrent connections. More cause 503
             # https://uvicorn.dev/settings/#timeouts
             timeout_keep_alive=5,  # Keep-alive timeout in seconds
             timeout_graceful_shutdown=30,  # Graceful shutdown timeout


### PR DESCRIPTION
## What has changed and why?

- We increase the max number of concurrent requests the backend can handle from 100 to 128. Note, we only increase to 128 to avoid putting too much pressure on the backend. If not enough we can increase further.

## How has it been tested?

- some local load testing showed that the concurrency limit was the most likely reason to get 503 errors

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum number of concurrent backend requests from 100 to 128.
  * Reduced the likelihood of frontend 503 errors during periods of high request volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->