### PR TITLE
Return no group preview for MCAP components

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_group_previews.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_group_previews.py
@@ -21,7 +21,7 @@ def get_group_previews(
     group_collection_id: UUID,
     group_sample_ids: list[UUID],
 ) -> dict[UUID, ImageView | None] | dict[UUID, VideoView | None]:
-    """Get the first sample (image or video) for each group.
+    """Get the first image or video preview for each group.
 
     Args:
         session: Database session for executing queries.
@@ -30,7 +30,8 @@ def get_group_previews(
 
     Returns:
         Dictionary mapping group sample_id to ImageView or VideoView of the first
-        sample in that group. Images are preferred over videos when both exist.
+        sample in that group. Images are preferred over videos when both exist. MCAP
+        components have no preview, so every group maps to None.
     """
     component_collections = collection_resolver.get_group_components(
         session=session,
@@ -47,6 +48,11 @@ def get_group_previews(
         key=lambda c: c.group_component_definition.group_component_index,  # type: ignore[union-attr]
     )
     first_component_type = first_component.sample_type
+
+    if first_component_type == SampleType.MCAP:
+        # MCAP samples locate frames inside a recording. The frame is decoded in the
+        # browser, so there is no image or video preview to return here.
+        return dict.fromkeys(group_sample_ids)
 
     # For every group, get the sample in the first component.
     # The result is a list of tuples (sample_id, group_sample_id).

--- a/lightly_studio/tests/resolvers/group_resolver/test_get_group_previews.py
+++ b/lightly_studio/tests/resolvers/group_resolver/test_get_group_previews.py
@@ -5,7 +5,7 @@ from lightly_studio.models.collection import SampleType
 from lightly_studio.models.image import ImageView
 from lightly_studio.models.video import VideoView
 from lightly_studio.resolvers import collection_resolver, group_resolver
-from tests.helpers_resolvers import ImageStub, create_collection, create_images
+from tests.helpers_resolvers import ImageStub, create_collection, create_images, create_mcap
 from tests.resolvers.video.helpers import VideoStub, create_video
 
 
@@ -117,6 +117,36 @@ def test_get_group_previews__with_videos(db_session: Session) -> None:
     assert isinstance(snapshot, VideoView)
     assert snapshot.sample_id == video1.sample_id
     assert snapshot.file_name == "video1.mp4"
+
+
+def test_get_group_previews__with_mcap_components(db_session: Session) -> None:
+    group_collection = create_collection(session=db_session, sample_type=SampleType.GROUP)
+    components = collection_resolver.create_group_components(
+        session=db_session,
+        parent_collection_id=group_collection.collection_id,
+        components=[("lidar", SampleType.MCAP)],
+    )
+    mcap_samples = [
+        create_mcap(
+            session=db_session,
+            collection_id=components["lidar"].collection_id,
+            log_time_ns=log_time_ns,
+        )
+        for log_time_ns in (10, 20)
+    ]
+    group_ids = group_resolver.create_many(
+        session=db_session,
+        collection_id=group_collection.collection_id,
+        groups=[{sample.sample_id} for sample in mcap_samples],
+    )
+
+    previews = group_resolver.get_group_previews(
+        session=db_session,
+        group_collection_id=group_collection.collection_id,
+        group_sample_ids=group_ids,
+    )
+
+    assert previews == dict.fromkeys(group_ids)
 
 
 def test_get_group_previews__prefers_images_over_videos(db_session: Session) -> None:


### PR DESCRIPTION
## What has changed and why?

`get_group_previews` raised an error when a group's first component contained MCAP samples because it only handled image and video previews. MCAP samples locate frames inside a recording and do not have a server-generated image or video preview, so the resolver now returns `None` for each requested group without querying the group links.

This is extracted from #2263 so the independent group-grid fix can land separately from the recording and playback design.

## How has it been tested?

- `uv run pytest tests/resolvers/group_resolver/test_get_group_previews.py`
- `uv run ruff check`
- `uv run ruff format --check src/lightly_studio/resolvers/group_resolver/get_group_previews.py tests/resolvers/group_resolver/test_get_group_previews.py`
- `uv run mypy src/lightly_studio/resolvers/group_resolver/get_group_previews.py tests/resolvers/group_resolver/test_get_group_previews.py`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCAP-based groups now load correctly without image or video previews.
  * Preview selection continues to prioritize images when both images and videos are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->