### PR TITLE
Fallback to loading the default model from the DB if not present in-memory during text/image search

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image_embedding.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 from fastapi import Path as FastAPIPath
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_INTERNAL_SERVER_ERROR
+from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.embed import embed_samples
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ image_embedding_router = APIRouter()
     "/image_embedding/from_file/for_collection/{collection_id}", response_model=list[float]
 )
 def embed_image_from_file(
+    session: SessionDep,
     collection_id: Annotated[UUID, FastAPIPath(title="The ID of the collection.")],
     file: Annotated[UploadFile, File(description="The image file to embed.")],
     embedding_model_id: Annotated[
@@ -47,7 +49,7 @@ def embed_image_from_file(
 
         try:
             return embed_samples.embed_image_for_collection(
-                collection_id=collection_id, filepath=tmp_path
+                session=session, collection_id=collection_id, filepath=tmp_path
             )
         finally:
             if os.path.exists(tmp_path):

--- a/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Path, Query
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_INTERNAL_SERVER_ERROR,
 )
+from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.embed import embed_samples
 
 text_embedding_router = APIRouter()
@@ -19,6 +20,7 @@ text_embedding_router = APIRouter()
     "/text_embedding/for_collection/{collection_id}", response_model=list[float]
 )
 def embed_text(
+    session: SessionDep,
     collection_id: Annotated[UUID, Path(title="The ID of the collection for which to embed.")],
     query_text: str = Query(..., description="The text to embed."),
     embedding_model_id: Annotated[
@@ -34,7 +36,7 @@ def embed_text(
         )
     try:
         text_embeddings = embed_samples.embed_text_for_collection(
-            collection_id=collection_id, text=query_text
+            session=session, collection_id=collection_id, text=query_text
         )
     except ValueError as exc:
         raise HTTPException(

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -42,10 +42,9 @@ def embed_image_for_collection(session: Session, collection_id: UUID, filepath: 
         ValueError: If the collection has no default embedding model, or the model does
             not support images.
     """
-    manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
-    if model_id is None:
+    if not collection_has_default_embedder(session=session, collection_id=collection_id):
         raise ValueError("No default embedding model registered for this collection.")
+    manager = EmbeddingManagerProvider.get_embedding_manager()
     return manager.compute_image_embedding(collection_id=collection_id, filepath=filepath)
 
 
@@ -65,10 +64,9 @@ def embed_text_for_collection(session: Session, collection_id: UUID, text: str) 
     Raises:
         ValueError: If the collection has no default embedding model.
     """
-    manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
-    if model_id is None:
+    if not collection_has_default_embedder(session=session, collection_id=collection_id):
         raise ValueError("No default embedding model registered for this collection.")
+    manager = EmbeddingManagerProvider.get_embedding_manager()
     return manager.embed_text(collection_id=collection_id, text_query=TextEmbedQuery(text=text))
 
 

--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -25,10 +25,13 @@ from lightly_studio.dataset.embedding_manager import (
 logger = logging.getLogger(__name__)
 
 
-def embed_image_for_collection(collection_id: UUID, filepath: str) -> list[float]:
+def embed_image_for_collection(session: Session, collection_id: UUID, filepath: str) -> list[float]:
     """Embed a single image with the collection's default model, without storing it.
 
+    Loads the collection's default model from the database if it is not already held in memory.
+
     Args:
+        session: Database session for resolver operations.
         collection_id: The collection whose default embedding model is used.
         filepath: fsspec path or URL of the image to embed.
 
@@ -40,13 +43,19 @@ def embed_image_for_collection(collection_id: UUID, filepath: str) -> list[float
             not support images.
     """
     manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        raise ValueError("No default embedding model registered for this collection.")
     return manager.compute_image_embedding(collection_id=collection_id, filepath=filepath)
 
 
-def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
+def embed_text_for_collection(session: Session, collection_id: UUID, text: str) -> list[float]:
     """Embed a text query with the collection's default model, without storing it.
 
+    Loads the collection's default model from the database if it is not already held in memory.
+
     Args:
+        session: Database session for resolver operations.
         collection_id: The collection whose default embedding model is used.
         text: The text to embed.
 
@@ -57,6 +66,9 @@ def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
         ValueError: If the collection has no default embedding model.
     """
     manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
+    if model_id is None:
+        raise ValueError("No default embedding model registered for this collection.")
     return manager.embed_text(collection_id=collection_id, text_query=TextEmbedQuery(text=text))
 
 

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -73,7 +73,7 @@ def test_embed_image_for_collection(
     )
 
     embedding = embed_samples.embed_image_for_collection(
-        collection_id=collection.collection_id, filepath="/path/to/image.jpg"
+        session=db_session, collection_id=collection.collection_id, filepath="/path/to/image.jpg"
     )
 
     assert len(embedding) == 5
@@ -81,15 +81,48 @@ def test_embed_image_for_collection(
     assert _stored_embeddings(session=db_session) == []
 
 
+def test_embed_image_for_collection__loads_default_from_db_when_cache_cold(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    collection = create_collection(session=db_session)
+    # A prior process registered the default in the database; its manager is discarded so
+    # the manager under test starts with a cold cache.
+    model_id = _register_default_random_model(
+        manager=EmbeddingManager(),
+        session=db_session,
+        collection_id=collection.collection_id,
+        dimension=5,
+    )
+    cold_manager = _cold_manager_with_env_generator(mocker=mocker, dimension=5)
+
+    embedding = embed_samples.embed_image_for_collection(
+        session=db_session, collection_id=collection.collection_id, filepath="/path/to/image.jpg"
+    )
+
+    assert len(embedding) == 5
+    # The default was rehydrated from the database.
+    assert (
+        cold_manager.load_or_get_default_model(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == model_id
+    )
+
+
 @pytest.mark.usefixtures("patched_manager")
 def test_embed_image_for_collection__no_default_model(
     db_session: Session,
+    mocker: MockerFixture,
 ) -> None:
     """Without a default model the interactive image path raises a clear error."""
+    _disable_env_loader(mocker=mocker)
     collection = create_collection(session=db_session)
-    with pytest.raises(ValueError, match="No embedding_model_id provided and no default embedding"):
+    with pytest.raises(ValueError, match="No default embedding model registered"):
         embed_samples.embed_image_for_collection(
-            collection_id=collection.collection_id, filepath="/path/to/image.jpg"
+            session=db_session,
+            collection_id=collection.collection_id,
+            filepath="/path/to/image.jpg",
         )
 
 
@@ -107,21 +140,52 @@ def test_embed_text_for_collection(
     )
 
     embedding = embed_samples.embed_text_for_collection(
-        collection_id=collection.collection_id, text="a red car"
+        session=db_session, collection_id=collection.collection_id, text="a red car"
     )
 
     assert len(embedding) == 3
 
 
+def test_embed_text_for_collection__loads_default_from_db_when_cache_cold(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    collection = create_collection(session=db_session)
+    # A prior process registered the default in the database; its manager is discarded so
+    # the manager under test starts with a cold cache.
+    model_id = _register_default_random_model(
+        manager=EmbeddingManager(),
+        session=db_session,
+        collection_id=collection.collection_id,
+        dimension=3,
+    )
+    cold_manager = _cold_manager_with_env_generator(mocker=mocker, dimension=3)
+
+    embedding = embed_samples.embed_text_for_collection(
+        session=db_session, collection_id=collection.collection_id, text="a red car"
+    )
+
+    assert len(embedding) == 3
+    # The default was rehydrated from the database, not created anew.
+    assert (
+        cold_manager.load_or_get_default_model(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == model_id
+    )
+
+
 @pytest.mark.usefixtures("patched_manager")
 def test_embed_text_for_collection__no_default_model(
     db_session: Session,
+    mocker: MockerFixture,
 ) -> None:
     """Without a default model the interactive text path raises a clear error."""
+    _disable_env_loader(mocker=mocker)
     collection = create_collection(session=db_session)
-    with pytest.raises(ValueError, match="No embedding_model_id provided and no default embedding"):
+    with pytest.raises(ValueError, match="No default embedding model registered"):
         embed_samples.embed_text_for_collection(
-            collection_id=collection.collection_id, text="a red car"
+            session=db_session, collection_id=collection.collection_id, text="a red car"
         )
 
 
@@ -456,6 +520,24 @@ def _register_default_random_model(
         collection_id=collection_id,
         set_as_default=True,
     ).embedding_model_id
+
+
+def _cold_manager_with_env_generator(mocker: MockerFixture, dimension: int) -> EmbeddingManager:
+    """Route embed_samples to a fresh manager that rebuilds its generator from the env.
+
+    Simulates a just-started process: an empty in-memory cache plus an environment
+    that can load the same generator.
+    """
+    cold_manager = EmbeddingManager()
+    mocker.patch.object(
+        EmbeddingManagerProvider, "get_embedding_manager", return_value=cold_manager
+    )
+    mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=RandomEmbeddingGenerator(dimension=dimension),
+    )
+    return cold_manager
 
 
 def _disable_env_loader(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## What has changed and why?

Default models were previously looked up only in the `_collection_id_to_default_model_id` map which would be cleared on server restarts. This means that updating any hosted instance (without reindexing, for example() would make text/image search not functional.
In this PR, the DB is also checked when the default model is not found in the map before raising.

## How has it been tested?

New tests + Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Image and text embedding operations now consistently use the collection’s registered default embedding model, including when it is not already cached.
  - Embedding requests now maintain database-backed session handling throughout processing.

- **Bug Fixes**
  - Improved handling when a collection has no default embedding model by providing a clear error instead of proceeding without one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->