### PR TITLE
Give lightly-studio-serve its own release trigger

### DIFF
--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -1,11 +1,12 @@
 """Command-line entry point for the release tooling.
 
-Backs the "Prepare Release" and "Draft Release" GitHub Actions workflows.
-Each subcommand does one small, independently testable piece of preparing or
-publishing a release: promoting the changelog, assembling the release notes,
-and guarding against a handful of ways those can quietly go wrong. Bumping
-and writing the `[project]` version is left to `uv version --bump` directly
-in the workflow (see version.py's docstring); `read-version` only reads it.
+Backs the "Prepare Release", "Draft Release" and "Finish Release" GitHub Actions
+workflows. Each subcommand does one small, independently testable piece of preparing
+or publishing a release: resolving which package a stage acts on, promoting the
+changelog, assembling the release notes, and guarding against a handful of ways those
+can quietly go wrong. Bumping and writing the `[project]` version is left to
+`uv version --bump` directly in the workflow (see version.py's docstring);
+`read-version` only reads it.
 
 Usage:
     python -m prepare_release promote-changelog --changelog CHANGELOG.md \
@@ -18,21 +19,35 @@ import argparse
 import sys
 from pathlib import Path
 
-from prepare_release import changelog, lock, pr_body, release_notes, version
+from prepare_release import changelog, lock, packages, pr_body, release_notes, version, wheel
 from prepare_release.errors import PrepareReleaseError
 
+PACKAGE_CONFIG = "package-config"
+LIST_PACKAGES = "list-packages"
 CHECK_LABELFORMAT_PIN = "check-labelformat-pin"
 PROMOTE_CHANGELOG = "promote-changelog"
 ASSERT_LOCK_DIFF = "assert-lock-diff"
 RENDER_PR_BODY = "render-pr-body"
 READ_VERSION = "read-version"
 RENDER_RELEASE_NOTES = "render-release-notes"
+CHECK_WHEEL_DEPENDENCIES = "check-wheel-dependencies"
 
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: parses `argv`, dispatches to the matching subcommand."""
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    package_config = subparsers.add_parser(
+        PACKAGE_CONFIG, help="print a package's release paths as `key=value` lines"
+    )
+    package_selector = package_config.add_mutually_exclusive_group(required=True)
+    package_selector.add_argument("--package", help="distribution name, e.g. lightly-studio")
+    package_selector.add_argument("--tag", help="release tag, e.g. v1.2.3")
+
+    subparsers.add_parser(
+        LIST_PACKAGES, help="print every releasable package as `<distribution> <pyproject>`"
+    )
 
     check_pin = subparsers.add_parser(
         CHECK_LABELFORMAT_PIN, help="fail if labelformat is pinned by git sha"
@@ -56,6 +71,7 @@ def main(argv: list[str] | None = None) -> int:
     pr_body_parser = subparsers.add_parser(RENDER_PR_BODY, help="assemble the release PR body")
     pr_body_parser.add_argument("--changelog", type=Path, required=True)
     pr_body_parser.add_argument("--version", required=True)
+    pr_body_parser.add_argument("--package", required=True)
     pr_body_parser.add_argument("--output", type=Path, required=True)
 
     read_version = subparsers.add_parser(
@@ -76,6 +92,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     release_notes_parser.add_argument("--output", type=Path, required=True)
 
+    wheel_deps = subparsers.add_parser(
+        CHECK_WHEEL_DEPENDENCIES, help="fail if the built wheel resolves to a forbidden dependency"
+    )
+    wheel_deps.add_argument("--package", required=True)
+    wheel_deps.add_argument("--dist", type=Path, required=True, help="directory holding the wheel")
+
     args = parser.parse_args(argv)
 
     try:
@@ -87,15 +109,28 @@ def main(argv: list[str] | None = None) -> int:
 
 def _dispatch(args: argparse.Namespace) -> int:
     handlers = {
+        PACKAGE_CONFIG: _cmd_package_config,
+        LIST_PACKAGES: _cmd_list_packages,
         CHECK_LABELFORMAT_PIN: _cmd_check_labelformat_pin,
         PROMOTE_CHANGELOG: _cmd_promote_changelog,
         ASSERT_LOCK_DIFF: _cmd_assert_lock_diff,
         RENDER_PR_BODY: _cmd_render_pr_body,
         READ_VERSION: _cmd_read_version,
         RENDER_RELEASE_NOTES: _cmd_render_release_notes,
+        CHECK_WHEEL_DEPENDENCIES: _cmd_check_wheel_dependencies,
     }
     handlers[args.command](args)
     return 0
+
+
+def _cmd_package_config(args: argparse.Namespace) -> None:
+    package = packages.for_tag(args.tag) if args.tag else packages.get(args.package)
+    print(packages.render_config(package), end="")
+
+
+def _cmd_list_packages(args: argparse.Namespace) -> None:  # noqa: ARG001
+    for package in packages.PACKAGES:
+        print(f"{package.distribution} {package.pyproject}")
 
 
 def _cmd_check_labelformat_pin(args: argparse.Namespace) -> None:
@@ -125,7 +160,9 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
     section_body = changelog.extract_released_section(
         changelog_text=args.changelog.read_text(), version=args.version
     )
-    body = pr_body.render_pr_body(section_body=section_body, version=args.version)
+    body = pr_body.render_pr_body(
+        section_body=section_body, version=args.version, package=packages.get(args.package)
+    )
     args.output.write_text(body)
 
 
@@ -141,6 +178,10 @@ def _cmd_render_release_notes(args: argparse.Namespace) -> None:
         changelog_section=section, generated_notes=args.generated.read_text()
     )
     args.output.write_text(body)
+
+
+def _cmd_check_wheel_dependencies(args: argparse.Namespace) -> None:
+    wheel.check_wheel_dependencies(dist_dir=args.dist, package=packages.get(args.package))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/prepare_release/packages.py
+++ b/.github/scripts/prepare_release/packages.py
@@ -1,0 +1,139 @@
+"""The releasable packages of this repository, and where each one's release inputs live.
+
+`lightly-studio` and `lightly-studio-embed` release on their own cadences through the
+same three workflows. Everything that differs between the two is here: which
+`pyproject.toml` carries the version, which `CHANGELOG.md` the notes come from, what
+prefixes the tag so the two version namespaces cannot collide, and what must never
+reach the published wheel.
+
+The workflows read this through `package-config`, so a new member is described once
+here rather than in three YAML files that then drift apart.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from prepare_release.errors import PrepareReleaseError
+
+
+@dataclass(frozen=True)
+class Package:
+    """One releasable distribution and the paths the release stages read.
+
+    Attributes:
+        distribution: The name on PyPI, and the value of the `package` workflow input.
+        display_name: The product name, for the tag message and the release PR body.
+        directory: The workspace member directory, relative to the repository root.
+        changelog: The changelog to promote, and to take the release notes from.
+        tag_prefix: Prefixed to `v<version>` to form the release tag. Empty for
+            `lightly-studio`, which keeps the bare `v<version>` namespace it already
+            published under.
+        needs_node: Whether building the distribution needs Node.js.
+        forbidden_dependencies: Substrings that no name in the built wheel's resolved
+            dependency tree may contain.
+    """
+
+    distribution: str
+    display_name: str
+    directory: str
+    changelog: str
+    tag_prefix: str
+    needs_node: bool
+    forbidden_dependencies: tuple[str, ...] = ()
+
+    @property
+    def pyproject(self) -> str:
+        """The `pyproject.toml` that carries this package's version."""
+        return f"{self.directory}/pyproject.toml"
+
+    @property
+    def branch_prefix(self) -> str:
+        """Prefixed to `v<version>` to form the release branch name.
+
+        A branch cannot hold the `/` that separates a prefixed tag, so the tag prefix
+        is flattened. `lightly-studio` keeps the `release-v<version>` it uses today.
+        """
+        return "release-" + self.tag_prefix.replace("/", "-")
+
+
+PACKAGES = (
+    Package(
+        distribution="lightly-studio",
+        display_name="LightlyStudio",
+        directory="lightly_studio",
+        changelog="CHANGELOG.md",
+        tag_prefix="",
+        needs_node=True,
+    ),
+    Package(
+        distribution="lightly-studio-embed",
+        display_name="LightlyStudio Embed",
+        directory="lightly_studio_embed",
+        changelog="lightly_studio_embed/CHANGELOG.md",
+        tag_prefix="lightly-studio-embed/",
+        needs_node=False,
+        # The wheel is installed next to a customer's own CUDA and torch pins, so none of
+        # the heavy things LightlyStudio itself needs may arrive with it - not even
+        # through a transitive dependency. Matched as substrings of the normalized name,
+        # which is what catches the whole `nvidia-*-cu12` and `torch*` families at once.
+        forbidden_dependencies=(
+            "torch",
+            "cuda",
+            "nvidia",
+            "duckdb",
+            "opencv",
+            "lightly-studio",
+        ),
+    ),
+)
+
+
+def get(distribution: str) -> Package:
+    """Returns the package published under `distribution`.
+
+    Raises:
+        PrepareReleaseError: No package is published under that name.
+    """
+    for package in PACKAGES:
+        if package.distribution == distribution:
+            return package
+    raise PrepareReleaseError(f"unknown package {distribution!r}, expected one of {_known()}")
+
+
+def for_tag(tag: str) -> Package:
+    """Returns the package a release tag belongs to.
+
+    The longest matching prefix wins, so `lightly-studio-embed/v0.1.1` resolves to the
+    embed package rather than to `lightly-studio`, whose prefix is empty.
+
+    Raises:
+        PrepareReleaseError: The tag matches no package's `<prefix>v<version>` shape.
+    """
+    candidates = [package for package in PACKAGES if tag.startswith(f"{package.tag_prefix}v")]
+    if not candidates:
+        raise PrepareReleaseError(
+            f"tag {tag!r} belongs to no known package, expected one of "
+            f"{', '.join(f'{p.tag_prefix}v<version>' for p in PACKAGES)}"
+        )
+    return max(candidates, key=lambda package: len(package.tag_prefix))
+
+
+def render_config(package: Package) -> str:
+    """Renders `package` as the `key=value` lines a workflow step appends to `$GITHUB_OUTPUT`."""
+    fields = {
+        "distribution": package.distribution,
+        "display_name": package.display_name,
+        "directory": package.directory,
+        "pyproject": package.pyproject,
+        "changelog": package.changelog,
+        "tag_prefix": package.tag_prefix,
+        "branch_prefix": package.branch_prefix,
+        "needs_node": str(package.needs_node).lower(),
+        "forbidden_dependencies": " ".join(package.forbidden_dependencies),
+    }
+    return "".join(f"{key}={value}\n" for key, value in fields.items())
+
+
+def _known() -> str:
+    return ", ".join(package.distribution for package in PACKAGES)

--- a/.github/scripts/prepare_release/packages.py
+++ b/.github/scripts/prepare_release/packages.py
@@ -73,10 +73,7 @@ PACKAGES = (
         changelog="lightly_studio_serve/CHANGELOG.md",
         tag_prefix="lightly-studio-serve/",
         needs_node=False,
-        # The wheel is installed next to a customer's own CUDA and torch pins, so none of
-        # the heavy things LightlyStudio itself needs may arrive with it - not even
-        # through a transitive dependency. Matched as substrings of the normalized name,
-        # which is what catches the whole `nvidia-*-cu12` and `torch*` families at once.
+        # Substrings of the normalized name, so one entry covers a whole family.
         forbidden_dependencies=(
             "torch",
             "cuda",

--- a/.github/scripts/prepare_release/packages.py
+++ b/.github/scripts/prepare_release/packages.py
@@ -1,6 +1,6 @@
 """The releasable packages of this repository, and where each one's release inputs live.
 
-`lightly-studio` and `lightly-studio-embed` release on their own cadences through the
+`lightly-studio` and `lightly-studio-serve` release on their own cadences through the
 same three workflows. Everything that differs between the two is here: which
 `pyproject.toml` carries the version, which `CHANGELOG.md` the notes come from, what
 prefixes the tag so the two version namespaces cannot collide, and what must never
@@ -67,11 +67,11 @@ PACKAGES = (
         needs_node=True,
     ),
     Package(
-        distribution="lightly-studio-embed",
-        display_name="LightlyStudio Embed",
-        directory="lightly_studio_embed",
-        changelog="lightly_studio_embed/CHANGELOG.md",
-        tag_prefix="lightly-studio-embed/",
+        distribution="lightly-studio-serve",
+        display_name="LightlyStudio Serve",
+        directory="lightly_studio_serve",
+        changelog="lightly_studio_serve/CHANGELOG.md",
+        tag_prefix="lightly-studio-serve/",
         needs_node=False,
         # The wheel is installed next to a customer's own CUDA and torch pins, so none of
         # the heavy things LightlyStudio itself needs may arrive with it - not even
@@ -104,8 +104,8 @@ def get(distribution: str) -> Package:
 def for_tag(tag: str) -> Package:
     """Returns the package a release tag belongs to.
 
-    The longest matching prefix wins, so `lightly-studio-embed/v0.1.1` resolves to the
-    embed package rather than to `lightly-studio`, whose prefix is empty.
+    The longest matching prefix wins, so `lightly-studio-serve/v0.1.1` resolves to the
+    serve package rather than to `lightly-studio`, whose prefix is empty.
 
     Raises:
         PrepareReleaseError: The tag matches no package's `<prefix>v<version>` shape.

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -2,17 +2,7 @@
 
 from __future__ import annotations
 
-# What the workflow already asserted before opening the PR, so the reviewer does
-# not re-check it by hand. Keep in sync with prepare_release.yml.
-_GUARDS = """\
-The workflow already checked that:
-
-- exactly `CHANGELOG.md`, `lightly_studio/pyproject.toml` and `uv.lock` changed,
-- the `uv.lock` diff is only this version bump,
-- `CHANGELOG.md` keeps an empty `[Unreleased]` skeleton and every earlier release is byte-identical,
-- Labelformat is pinned by version, not by git sha.
-
-What is left is editorial, and it is what this review is for."""
+from prepare_release.packages import Package
 
 _CHECKLIST = """\
 - [ ] The notes read as user-facing release notes: no ticket ids (`LIG 1234`), PR numbers or
@@ -24,28 +14,46 @@ _CHECKLIST = """\
 - [ ] CI is green on this branch."""
 
 
-def render_pr_body(section_body: str, version: str) -> str:
+def render_pr_body(section_body: str, version: str, package: Package) -> str:
     """Assembles the release PR body.
 
     Args:
-        section_body: The CHANGELOG section already promoted for this version.
+        section_body: The changelog section already promoted for this version.
         version: The version being released, e.g. "1.0.6".
+        package: The package being released.
 
     Returns:
         The Markdown body for the release PR.
     """
     return (
-        f"Prepares the LightlyStudio {version} release: promotes the `[Unreleased]` changelog "
-        f"section, bumps the version and relocks.\n\n"
+        f"Prepares the {package.display_name} {version} release: promotes the `[Unreleased]` "
+        f"section of `{package.changelog}`, bumps the version and relocks.\n\n"
         f"## Release notes for {version}\n\n"
-        f"Edit `CHANGELOG.md` on this branch rather than this description - the changelog is what "
-        f"gets published, this is a copy of it from when the PR was opened.\n\n"
+        f"Edit `{package.changelog}` on this branch rather than this description - the changelog "
+        f"is what gets published, this is a copy of it from when the PR was opened.\n\n"
         f"{section_body}\n\n"
         f"## Review checklist\n\n"
-        f"{_GUARDS}\n\n"
+        f"{_guards(package)}\n\n"
         f"{_CHECKLIST}\n\n"
         f"Merging tags this commit and opens a **draft** GitHub release. Nothing is public "
         f"until someone runs Finish Release with `target: pypi`, which builds the wheel, "
         f"publishes it to PyPI and "
         f"un-drafts the release; the docs are still manual.\n"
     )
+
+
+def _guards(package: Package) -> str:
+    """Lists what the workflow already asserted, so the reviewer does not re-check it by hand.
+
+    Keep in sync with prepare_release.yml.
+    """
+    return f"""\
+The workflow already checked that:
+
+- exactly `{package.changelog}`, `{package.pyproject}` and `uv.lock` changed,
+- the `uv.lock` diff is only this version bump,
+- `{package.changelog}` keeps an empty `[Unreleased]` skeleton and every earlier release is \
+byte-identical,
+- Labelformat is pinned by version, not by git sha.
+
+What is left is editorial, and it is what this review is for."""

--- a/.github/scripts/prepare_release/release_notes.py
+++ b/.github/scripts/prepare_release/release_notes.py
@@ -46,9 +46,7 @@ def render_release_notes(changelog_section: str, generated_notes: str) -> str:
     """
     generated = sanitize_generated_notes(generated_notes).strip()
     if not generated:
-        # A first release of a package has no earlier tag to diff against, so the
-        # Draft Release workflow hands this nothing rather than another package's
-        # commits. The changelog section is then the whole body.
+        # A first release has no earlier tag to diff against.
         return f"{_CHANGELOG_HEADING}\n\n{changelog_section.strip()}\n"
     return f"{_CHANGELOG_HEADING}\n\n{changelog_section.strip()}\n\n{generated}\n"
 

--- a/.github/scripts/prepare_release/release_notes.py
+++ b/.github/scripts/prepare_release/release_notes.py
@@ -38,16 +38,19 @@ def render_release_notes(changelog_section: str, generated_notes: str) -> str:
 
     Args:
         changelog_section: The `[X.Y.Z]` block from `CHANGELOG.md`.
-        generated_notes: The body returned by the releases/generate-notes API.
+        generated_notes: The body returned by the releases/generate-notes API,
+            or empty when there is no earlier release of this package to diff against.
 
     Returns:
         The Markdown body for the GitHub release.
     """
-    return (
-        f"{_CHANGELOG_HEADING}\n\n"
-        f"{changelog_section.strip()}\n\n"
-        f"{sanitize_generated_notes(generated_notes).strip()}\n"
-    )
+    generated = sanitize_generated_notes(generated_notes).strip()
+    if not generated:
+        # A first release of a package has no earlier tag to diff against, so the
+        # Draft Release workflow hands this nothing rather than another package's
+        # commits. The changelog section is then the whole body.
+        return f"{_CHANGELOG_HEADING}\n\n{changelog_section.strip()}\n"
+    return f"{_CHANGELOG_HEADING}\n\n{changelog_section.strip()}\n\n{generated}\n"
 
 
 def sanitize_generated_notes(notes: str) -> str:

--- a/.github/scripts/prepare_release/wheel.py
+++ b/.github/scripts/prepare_release/wheel.py
@@ -19,8 +19,7 @@ from pathlib import Path
 from prepare_release.errors import PrepareReleaseError
 from prepare_release.packages import Package
 
-# PEP 503 name normalization, so `nvidia_cublas_cu12` and `NVIDIA-cuBLAS-cu12` are the
-# same name to match against.
+# PEP 503 name normalization.
 _NAME_SEPARATOR_RE = re.compile(r"[-_.]+")
 
 
@@ -77,8 +76,7 @@ def assert_no_forbidden_dependencies(installed: Sequence[str], package: Package)
         PrepareReleaseError: A forbidden name is installed.
     """
     own_name = normalize_name(package.distribution)
-    # Both sides are normalized: a pattern written `opencv_python` or `NVIDIA` would
-    # otherwise never match a normalized name, and this guard would fail open.
+    # Both sides normalized, so a pattern written `opencv_python` cannot fail open.
     patterns = [normalize_name(pattern) for pattern in package.forbidden_dependencies]
     offenders = sorted(
         name

--- a/.github/scripts/prepare_release/wheel.py
+++ b/.github/scripts/prepare_release/wheel.py
@@ -77,11 +77,14 @@ def assert_no_forbidden_dependencies(installed: Sequence[str], package: Package)
         PrepareReleaseError: A forbidden name is installed.
     """
     own_name = normalize_name(package.distribution)
+    # Both sides are normalized: a pattern written `opencv_python` or `NVIDIA` would
+    # otherwise never match a normalized name, and this guard would fail open.
+    patterns = [normalize_name(pattern) for pattern in package.forbidden_dependencies]
     offenders = sorted(
         name
         for name in installed
         if normalize_name(name) != own_name
-        and any(pattern in normalize_name(name) for pattern in package.forbidden_dependencies)
+        and any(pattern in normalize_name(name) for pattern in patterns)
     )
     if offenders:
         raise PrepareReleaseError(

--- a/.github/scripts/prepare_release/wheel.py
+++ b/.github/scripts/prepare_release/wheel.py
@@ -1,0 +1,110 @@
+"""Check what a built wheel actually pulls in, before it can be published.
+
+`lightly-studio-embed` exists to be installed next to a customer's own CUDA and torch
+pins, so the one thing that must stay true of it is that it stays light. A
+`pyproject.toml` review cannot establish that: the offending dependency arrives one
+level down. This installs the wheel into a throwaway environment and looks at what
+came with it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from prepare_release.errors import PrepareReleaseError
+from prepare_release.packages import Package
+
+# PEP 503 name normalization, so `nvidia_cublas_cu12` and `NVIDIA-cuBLAS-cu12` are the
+# same name to match against.
+_NAME_SEPARATOR_RE = re.compile(r"[-_.]+")
+
+
+def check_wheel_dependencies(dist_dir: Path, package: Package) -> None:
+    """Resolves the wheel in `dist_dir` and fails on a forbidden dependency.
+
+    Raises:
+        PrepareReleaseError: `dist_dir` holds no single wheel, or the resolved tree
+            contains a forbidden name.
+    """
+    wheel = find_wheel(dist_dir)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        environment = Path(temp_dir) / "venv"
+        _uv("venv", str(environment))
+        _uv("pip", "install", "--python", str(environment), str(wheel))
+        listing = _uv("pip", "list", "--python", str(environment), "--format", "json")
+    assert_no_forbidden_dependencies(installed=parse_installed_names(listing), package=package)
+
+
+def find_wheel(dist_dir: Path) -> Path:
+    """Returns the one wheel in `dist_dir`.
+
+    Raises:
+        PrepareReleaseError: There is not exactly one wheel there. More than one means
+            an earlier build was not cleaned away, and checking the wrong one is worse
+            than not checking.
+    """
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise PrepareReleaseError(f"expected exactly one wheel in {dist_dir}, found {len(wheels)}")
+    return wheels[0]
+
+
+def parse_installed_names(pip_list_json: str) -> list[str]:
+    """Returns the distribution names in `uv pip list --format json` output.
+
+    Raises:
+        PrepareReleaseError: The output is not the expected list of named entries.
+    """
+    try:
+        entries = json.loads(pip_list_json)
+        return [str(entry["name"]) for entry in entries]
+    except (json.JSONDecodeError, TypeError, KeyError) as error:
+        raise PrepareReleaseError(f"could not read the installed package list: {error}") from error
+
+
+def assert_no_forbidden_dependencies(installed: Sequence[str], package: Package) -> None:
+    """Fails if any installed name contains one of `package.forbidden_dependencies`.
+
+    The package itself is skipped: `lightly-studio-embed` carries the `lightly-studio`
+    substring that it forbids of everything else.
+
+    Raises:
+        PrepareReleaseError: A forbidden name is installed.
+    """
+    own_name = normalize_name(package.distribution)
+    offenders = sorted(
+        name
+        for name in installed
+        if normalize_name(name) != own_name
+        and any(pattern in normalize_name(name) for pattern in package.forbidden_dependencies)
+    )
+    if offenders:
+        raise PrepareReleaseError(
+            f"the {package.distribution} wheel resolves to dependencies it must not have: "
+            + ", ".join(offenders)
+        )
+
+
+def normalize_name(name: str) -> str:
+    """Returns the PEP 503 normalized form of a distribution name."""
+    return _NAME_SEPARATOR_RE.sub("-", name).lower()
+
+
+def _uv(*args: str) -> str:
+    """Runs `uv` with `args` and returns its standard output.
+
+    Raises:
+        PrepareReleaseError: `uv` is missing or exited non-zero.
+    """
+    try:
+        completed = subprocess.run(["uv", *args], capture_output=True, text=True, check=True)
+    except FileNotFoundError as error:
+        raise PrepareReleaseError("uv is not installed") from error
+    except subprocess.CalledProcessError as error:
+        raise PrepareReleaseError(f"`uv {' '.join(args)}` failed:\n{error.stderr}") from error
+    return completed.stdout

--- a/.github/scripts/prepare_release/wheel.py
+++ b/.github/scripts/prepare_release/wheel.py
@@ -1,6 +1,6 @@
 """Check what a built wheel actually pulls in, before it can be published.
 
-`lightly-studio-embed` exists to be installed next to a customer's own CUDA and torch
+`lightly-studio-serve` exists to be installed next to a customer's own CUDA and torch
 pins, so the one thing that must stay true of it is that it stays light. A
 `pyproject.toml` review cannot establish that: the offending dependency arrives one
 level down. This installs the wheel into a throwaway environment and looks at what
@@ -70,7 +70,7 @@ def parse_installed_names(pip_list_json: str) -> list[str]:
 def assert_no_forbidden_dependencies(installed: Sequence[str], package: Package) -> None:
     """Fails if any installed name contains one of `package.forbidden_dependencies`.
 
-    The package itself is skipped: `lightly-studio-embed` carries the `lightly-studio`
+    The package itself is skipped: `lightly-studio-serve` carries the `lightly-studio`
     substring that it forbids of everything else.
 
     Raises:

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -149,6 +149,8 @@ def test_main__render_pr_body__writes_file(tmp_path: Path):
                 str(changelog_file),
                 "--version",
                 "1.1.0",
+                "--package",
+                "lightly-studio",
                 "--output",
                 str(output),
             ]
@@ -157,3 +159,49 @@ def test_main__render_pr_body__writes_file(tmp_path: Path):
     )
     body = output.read_text()
     assert "Added thing one" in body
+
+
+def test_main__package_config(capsys: pytest.CaptureFixture):
+    assert cli.main(["package-config", "--package", "lightly-studio"]) == 0
+    assert "pyproject=lightly_studio/pyproject.toml\n" in capsys.readouterr().out
+
+
+def test_main__package_config__by_tag(capsys: pytest.CaptureFixture):
+    assert cli.main(["package-config", "--tag", "lightly-studio-embed/v0.1.1"]) == 0
+    assert "distribution=lightly-studio-embed\n" in capsys.readouterr().out
+
+
+def test_main__package_config__unknown_package_exits_nonzero(capsys: pytest.CaptureFixture):
+    assert cli.main(["package-config", "--package", "lightly-train"]) == 1
+    assert "unknown package" in capsys.readouterr().err
+
+
+def test_main__package_config__requires_a_selector():
+    with pytest.raises(SystemExit):
+        cli.main(["package-config"])
+
+
+def test_main__list_packages(capsys: pytest.CaptureFixture):
+    assert cli.main(["list-packages"]) == 0
+    assert capsys.readouterr().out == (
+        "lightly-studio lightly_studio/pyproject.toml\n"
+        "lightly-studio-embed lightly_studio_embed/pyproject.toml\n"
+    )
+
+
+def test_main__check_wheel_dependencies__no_wheel_exits_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+):
+    assert (
+        cli.main(
+            [
+                "check-wheel-dependencies",
+                "--package",
+                "lightly-studio-embed",
+                "--dist",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+    assert "expected exactly one wheel" in capsys.readouterr().err

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -167,8 +167,8 @@ def test_main__package_config(capsys: pytest.CaptureFixture):
 
 
 def test_main__package_config__by_tag(capsys: pytest.CaptureFixture):
-    assert cli.main(["package-config", "--tag", "lightly-studio-embed/v0.1.1"]) == 0
-    assert "distribution=lightly-studio-embed\n" in capsys.readouterr().out
+    assert cli.main(["package-config", "--tag", "lightly-studio-serve/v0.1.1"]) == 0
+    assert "distribution=lightly-studio-serve\n" in capsys.readouterr().out
 
 
 def test_main__package_config__unknown_package_exits_nonzero(capsys: pytest.CaptureFixture):
@@ -185,7 +185,7 @@ def test_main__list_packages(capsys: pytest.CaptureFixture):
     assert cli.main(["list-packages"]) == 0
     assert capsys.readouterr().out == (
         "lightly-studio lightly_studio/pyproject.toml\n"
-        "lightly-studio-embed lightly_studio_embed/pyproject.toml\n"
+        "lightly-studio-serve lightly_studio_serve/pyproject.toml\n"
     )
 
 
@@ -197,7 +197,7 @@ def test_main__check_wheel_dependencies__no_wheel_exits_nonzero(
             [
                 "check-wheel-dependencies",
                 "--package",
-                "lightly-studio-embed",
+                "lightly-studio-serve",
                 "--dist",
                 str(tmp_path),
             ]

--- a/.github/scripts/tests/test_packages.py
+++ b/.github/scripts/tests/test_packages.py
@@ -1,0 +1,78 @@
+import pytest
+
+from prepare_release import packages
+from prepare_release.errors import PrepareReleaseError
+
+EMBED = packages.get("lightly-studio-embed")
+STUDIO = packages.get("lightly-studio")
+
+
+class TestPackage:
+    def test_pyproject(self):
+        assert STUDIO.pyproject == "lightly_studio/pyproject.toml"
+
+    def test_branch_prefix(self):
+        assert STUDIO.branch_prefix == "release-"
+
+    def test_branch_prefix__prefixed_package_flattens_the_slash(self):
+        assert EMBED.branch_prefix == "release-lightly-studio-embed-"
+
+
+def test_get():
+    assert packages.get("lightly-studio").directory == "lightly_studio"
+
+
+def test_get__unknown():
+    with pytest.raises(PrepareReleaseError, match="unknown package 'lightly-train'"):
+        packages.get("lightly-train")
+
+
+def test_for_tag():
+    assert packages.for_tag("v1.2.3") is STUDIO
+
+
+def test_for_tag__longest_prefix_wins():
+    assert packages.for_tag("lightly-studio-embed/v0.1.2") is EMBED
+
+
+def test_for_tag__unknown():
+    with pytest.raises(PrepareReleaseError, match="belongs to no known package"):
+        packages.for_tag("nightly/v1.2.3")
+
+
+def test_for_tag__no_version_marker():
+    with pytest.raises(PrepareReleaseError, match="belongs to no known package"):
+        packages.for_tag("1.2.3")
+
+
+def test_render_config():
+    assert packages.render_config(STUDIO) == (
+        "distribution=lightly-studio\n"
+        "display_name=LightlyStudio\n"
+        "directory=lightly_studio\n"
+        "pyproject=lightly_studio/pyproject.toml\n"
+        "changelog=CHANGELOG.md\n"
+        "tag_prefix=\n"
+        "branch_prefix=release-\n"
+        "needs_node=true\n"
+        "forbidden_dependencies=\n"
+    )
+
+
+def test_render_config__embed():
+    assert packages.render_config(EMBED) == (
+        "distribution=lightly-studio-embed\n"
+        "display_name=LightlyStudio Embed\n"
+        "directory=lightly_studio_embed\n"
+        "pyproject=lightly_studio_embed/pyproject.toml\n"
+        "changelog=lightly_studio_embed/CHANGELOG.md\n"
+        "tag_prefix=lightly-studio-embed/\n"
+        "branch_prefix=release-lightly-studio-embed-\n"
+        "needs_node=false\n"
+        "forbidden_dependencies=torch cuda nvidia duckdb opencv lightly-studio\n"
+    )
+
+
+def test_tags_cannot_collide():
+    tags = [f"{package.tag_prefix}v1.2.3" for package in packages.PACKAGES]
+    assert len(set(tags)) == len(tags)

--- a/.github/scripts/tests/test_packages.py
+++ b/.github/scripts/tests/test_packages.py
@@ -3,7 +3,7 @@ import pytest
 from prepare_release import packages
 from prepare_release.errors import PrepareReleaseError
 
-EMBED = packages.get("lightly-studio-embed")
+SERVE = packages.get("lightly-studio-serve")
 STUDIO = packages.get("lightly-studio")
 
 
@@ -15,7 +15,7 @@ class TestPackage:
         assert STUDIO.branch_prefix == "release-"
 
     def test_branch_prefix__prefixed_package_flattens_the_slash(self):
-        assert EMBED.branch_prefix == "release-lightly-studio-embed-"
+        assert SERVE.branch_prefix == "release-lightly-studio-serve-"
 
 
 def test_get():
@@ -32,7 +32,7 @@ def test_for_tag():
 
 
 def test_for_tag__longest_prefix_wins():
-    assert packages.for_tag("lightly-studio-embed/v0.1.2") is EMBED
+    assert packages.for_tag("lightly-studio-serve/v0.1.2") is SERVE
 
 
 def test_for_tag__unknown():
@@ -59,15 +59,15 @@ def test_render_config():
     )
 
 
-def test_render_config__embed():
-    assert packages.render_config(EMBED) == (
-        "distribution=lightly-studio-embed\n"
-        "display_name=LightlyStudio Embed\n"
-        "directory=lightly_studio_embed\n"
-        "pyproject=lightly_studio_embed/pyproject.toml\n"
-        "changelog=lightly_studio_embed/CHANGELOG.md\n"
-        "tag_prefix=lightly-studio-embed/\n"
-        "branch_prefix=release-lightly-studio-embed-\n"
+def test_render_config__serve():
+    assert packages.render_config(SERVE) == (
+        "distribution=lightly-studio-serve\n"
+        "display_name=LightlyStudio Serve\n"
+        "directory=lightly_studio_serve\n"
+        "pyproject=lightly_studio_serve/pyproject.toml\n"
+        "changelog=lightly_studio_serve/CHANGELOG.md\n"
+        "tag_prefix=lightly-studio-serve/\n"
+        "branch_prefix=release-lightly-studio-serve-\n"
         "needs_node=false\n"
         "forbidden_dependencies=torch cuda nvidia duckdb opencv lightly-studio\n"
     )

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -1,6 +1,6 @@
 from prepare_release import packages, pr_body
 
-EMBED = packages.get("lightly-studio-embed")
+SERVE = packages.get("lightly-studio-serve")
 STUDIO = packages.get("lightly-studio")
 SECTION = "### Added\n\n- Added thing one."
 
@@ -23,7 +23,7 @@ def test_render_pr_body__says_merging_publishes_nothing():
 
 
 def test_render_pr_body__names_the_package_it_prepares():
-    body = pr_body.render_pr_body(section_body=SECTION, version="0.1.1", package=EMBED)
-    assert "LightlyStudio Embed 0.1.1" in body
-    assert "`lightly_studio_embed/CHANGELOG.md`" in body
-    assert "`lightly_studio_embed/pyproject.toml`" in body
+    body = pr_body.render_pr_body(section_body=SECTION, version="0.1.1", package=SERVE)
+    assert "LightlyStudio Serve 0.1.1" in body
+    assert "`lightly_studio_serve/CHANGELOG.md`" in body
+    assert "`lightly_studio_serve/pyproject.toml`" in body

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -1,18 +1,29 @@
-from prepare_release import pr_body
+from prepare_release import packages, pr_body
+
+EMBED = packages.get("lightly-studio-embed")
+STUDIO = packages.get("lightly-studio")
+SECTION = "### Added\n\n- Added thing one."
 
 
 def test_render_pr_body():
-    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
+    body = pr_body.render_pr_body(section_body=SECTION, version="1.0.6", package=STUDIO)
     assert "Release notes for 1.0.6" in body
     assert "Added thing one" in body
 
 
 def test_render_pr_body__review_checklist():
-    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
+    body = pr_body.render_pr_body(section_body=SECTION, version="1.0.6", package=STUDIO)
     assert "## Review checklist" in body
     assert body.count("- [ ] ") == 5
 
 
 def test_render_pr_body__says_merging_publishes_nothing():
-    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.", version="1.0.6")
+    body = pr_body.render_pr_body(section_body=SECTION, version="1.0.6", package=STUDIO)
     assert "opens a **draft** GitHub release" in body
+
+
+def test_render_pr_body__names_the_package_it_prepares():
+    body = pr_body.render_pr_body(section_body=SECTION, version="0.1.1", package=EMBED)
+    assert "LightlyStudio Embed 0.1.1" in body
+    assert "`lightly_studio_embed/CHANGELOG.md`" in body
+    assert "`lightly_studio_embed/pyproject.toml`" in body

--- a/.github/scripts/tests/test_release_notes.py
+++ b/.github/scripts/tests/test_release_notes.py
@@ -64,3 +64,10 @@ def test_sanitize_generated_notes__leaves_non_bullet_lines_alone():
     notes = "## What's Changed\n**Full Changelog**: https://x/compare/v1.0.4...v1.0.5"
 
     assert release_notes.sanitize_generated_notes(notes) == notes
+
+
+def test_render_release_notes__no_generated_half():
+    body = release_notes.render_release_notes(
+        changelog_section="### Added\n\n- Added thing one.", generated_notes=""
+    )
+    assert body == "## Changelog\n\n### Added\n\n- Added thing one.\n"

--- a/.github/scripts/tests/test_wheel.py
+++ b/.github/scripts/tests/test_wheel.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 
 from prepare_release import packages, wheel
@@ -65,3 +67,11 @@ def test_assert_no_forbidden_dependencies__lists_every_offender():
 
 def test_normalize_name():
     assert wheel.normalize_name("NVIDIA_cuBLAS.cu12") == "nvidia-cublas-cu12"
+
+
+def test_assert_no_forbidden_dependencies__normalizes_the_patterns_too():
+    package = replace(EMBED, forbidden_dependencies=("OpenCV_Python",))
+    with pytest.raises(PrepareReleaseError, match="opencv-python-headless"):
+        wheel.assert_no_forbidden_dependencies(
+            installed=["opencv-python-headless"], package=package
+        )

--- a/.github/scripts/tests/test_wheel.py
+++ b/.github/scripts/tests/test_wheel.py
@@ -1,0 +1,67 @@
+import pytest
+
+from prepare_release import packages, wheel
+from prepare_release.errors import PrepareReleaseError
+
+EMBED = packages.get("lightly-studio-embed")
+
+
+def test_find_wheel(tmp_path):
+    (tmp_path / "lightly_studio_embed-0.1.0-py3-none-any.whl").touch()
+    (tmp_path / "lightly_studio_embed-0.1.0.tar.gz").touch()
+    assert wheel.find_wheel(tmp_path).name == "lightly_studio_embed-0.1.0-py3-none-any.whl"
+
+
+def test_find_wheel__none(tmp_path):
+    with pytest.raises(PrepareReleaseError, match="found 0"):
+        wheel.find_wheel(tmp_path)
+
+
+def test_find_wheel__several(tmp_path):
+    (tmp_path / "a-0.1.0-py3-none-any.whl").touch()
+    (tmp_path / "a-0.2.0-py3-none-any.whl").touch()
+    with pytest.raises(PrepareReleaseError, match="found 2"):
+        wheel.find_wheel(tmp_path)
+
+
+def test_parse_installed_names():
+    listing = '[{"name": "numpy", "version": "2.1.0"}, {"name": "pillow", "version": "11.0.0"}]'
+    assert wheel.parse_installed_names(listing) == ["numpy", "pillow"]
+
+
+def test_parse_installed_names__not_json():
+    with pytest.raises(PrepareReleaseError, match="could not read"):
+        wheel.parse_installed_names("error: no environment found")
+
+
+def test_parse_installed_names__missing_name():
+    with pytest.raises(PrepareReleaseError, match="could not read"):
+        wheel.parse_installed_names('[{"version": "2.1.0"}]')
+
+
+def test_assert_no_forbidden_dependencies():
+    wheel.assert_no_forbidden_dependencies(
+        installed=["fastapi", "numpy", "pillow", "pydantic", "uvicorn", "lightly-studio-embed"],
+        package=EMBED,
+    )
+
+
+def test_assert_no_forbidden_dependencies__transitive_torch():
+    with pytest.raises(PrepareReleaseError, match="torchvision"):
+        wheel.assert_no_forbidden_dependencies(installed=["numpy", "torchvision"], package=EMBED)
+
+
+def test_assert_no_forbidden_dependencies__normalizes_before_matching():
+    with pytest.raises(PrepareReleaseError, match="nvidia_cublas_cu12"):
+        wheel.assert_no_forbidden_dependencies(installed=["nvidia_cublas_cu12"], package=EMBED)
+
+
+def test_assert_no_forbidden_dependencies__lists_every_offender():
+    with pytest.raises(PrepareReleaseError, match="duckdb, lightly-studio, opencv-python"):
+        wheel.assert_no_forbidden_dependencies(
+            installed=["opencv-python", "duckdb", "lightly-studio"], package=EMBED
+        )
+
+
+def test_normalize_name():
+    assert wheel.normalize_name("NVIDIA_cuBLAS.cu12") == "nvidia-cublas-cu12"

--- a/.github/scripts/tests/test_wheel.py
+++ b/.github/scripts/tests/test_wheel.py
@@ -5,13 +5,13 @@ import pytest
 from prepare_release import packages, wheel
 from prepare_release.errors import PrepareReleaseError
 
-EMBED = packages.get("lightly-studio-embed")
+SERVE = packages.get("lightly-studio-serve")
 
 
 def test_find_wheel(tmp_path):
-    (tmp_path / "lightly_studio_embed-0.1.0-py3-none-any.whl").touch()
-    (tmp_path / "lightly_studio_embed-0.1.0.tar.gz").touch()
-    assert wheel.find_wheel(tmp_path).name == "lightly_studio_embed-0.1.0-py3-none-any.whl"
+    (tmp_path / "lightly_studio_serve-0.1.0-py3-none-any.whl").touch()
+    (tmp_path / "lightly_studio_serve-0.1.0.tar.gz").touch()
+    assert wheel.find_wheel(tmp_path).name == "lightly_studio_serve-0.1.0-py3-none-any.whl"
 
 
 def test_find_wheel__none(tmp_path):
@@ -43,25 +43,25 @@ def test_parse_installed_names__missing_name():
 
 def test_assert_no_forbidden_dependencies():
     wheel.assert_no_forbidden_dependencies(
-        installed=["fastapi", "numpy", "pillow", "pydantic", "uvicorn", "lightly-studio-embed"],
-        package=EMBED,
+        installed=["fastapi", "numpy", "pillow", "pydantic", "uvicorn", "lightly-studio-serve"],
+        package=SERVE,
     )
 
 
 def test_assert_no_forbidden_dependencies__transitive_torch():
     with pytest.raises(PrepareReleaseError, match="torchvision"):
-        wheel.assert_no_forbidden_dependencies(installed=["numpy", "torchvision"], package=EMBED)
+        wheel.assert_no_forbidden_dependencies(installed=["numpy", "torchvision"], package=SERVE)
 
 
 def test_assert_no_forbidden_dependencies__normalizes_before_matching():
     with pytest.raises(PrepareReleaseError, match="nvidia_cublas_cu12"):
-        wheel.assert_no_forbidden_dependencies(installed=["nvidia_cublas_cu12"], package=EMBED)
+        wheel.assert_no_forbidden_dependencies(installed=["nvidia_cublas_cu12"], package=SERVE)
 
 
 def test_assert_no_forbidden_dependencies__lists_every_offender():
     with pytest.raises(PrepareReleaseError, match="duckdb, lightly-studio, opencv-python"):
         wheel.assert_no_forbidden_dependencies(
-            installed=["opencv-python", "duckdb", "lightly-studio"], package=EMBED
+            installed=["opencv-python", "duckdb", "lightly-studio"], package=SERVE
         )
 
 
@@ -70,7 +70,7 @@ def test_normalize_name():
 
 
 def test_assert_no_forbidden_dependencies__normalizes_the_patterns_too():
-    package = replace(EMBED, forbidden_dependencies=("OpenCV_Python",))
+    package = replace(SERVE, forbidden_dependencies=("OpenCV_Python",))
     with pytest.raises(PrepareReleaseError, match="opencv-python-headless"):
         wheel.assert_no_forbidden_dependencies(
             installed=["opencv-python-headless"], package=package

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -64,10 +64,21 @@ jobs:
             exit 0
           fi
 
-          # The version of $2 at commit $1. Exit 2 says the package does not exist
+          # Both sides of the push are resolved first, so that the 404 below can only
+          # mean "no such file at that commit". A 404 on an unresolvable ref reads
+          # the same, and would otherwise turn a broken run into a silent no-op.
+          for ref in "${BEFORE}" "${AFTER}"; do
+            if ! gh api "repos/${GITHUB_REPOSITORY}/commits/${ref}" --jq .sha > /dev/null; then
+              echo "::error::Cannot resolve ${ref}; use the workflow_dispatch hatch instead."
+              exit 1
+            fi
+          done
+
+          # The version of $2 at commit $1. Exit 2 says the file does not exist
           # there; every other failure is exit 1 and stops the run. Errexit cannot
           # carry that: the caller suppresses it, and dropping a release because
-          # the API blipped is worse than failing loudly.
+          # the API blipped is worse than failing loudly. Diagnostics go to stderr,
+          # because stdout of this function is the version the caller captures.
           version_at() {
             if ! gh api "repos/${GITHUB_REPOSITORY}/contents/$2?ref=$1" \
                    -H "Accept: application/vnd.github.raw" \
@@ -75,8 +86,8 @@ jobs:
               if grep -q "(HTTP 404)" "${RUNNER_TEMP}/detect-err"; then
                 return 2
               fi
-              echo "::error::Could not read $2 at $1:"
-              cat "${RUNNER_TEMP}/detect-err"
+              echo "::error::Could not read $2 at $1:" >&2
+              cat "${RUNNER_TEMP}/detect-err" >&2
               return 1
             fi
             python3 -m prepare_release read-version \
@@ -300,18 +311,31 @@ jobs:
           # commits. The window is pinned to this package's own last release
           # instead. `lightly-studio`'s empty prefix selects exactly the `v*`
           # tags, which are its own.
-          previous="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq \
-            "[.[] | select(.draft == false) | .tag_name
-              | select(startswith(\"${TAG_PREFIX}v\"))] | first // empty")"
-          notes_args=(-f tag_name="${TAG}" -f target_commitish="${SHA}")
+          # `--paginate` because releases come back newest-first across every package,
+          # so this package's own last release drops off page one once the other has
+          # released enough times. Written to a file rather than piped into `head`,
+          # which would SIGPIPE `gh` and trip `pipefail`. Prereleases are skipped, as
+          # GitHub's own default does.
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq \
+            ".[] | select(.draft == false and .prerelease == false) | .tag_name
+              | select(startswith(\"${TAG_PREFIX}v\"))" > "${RUNNER_TEMP}/releases"
+          previous="$(head -n 1 "${RUNNER_TEMP}/releases")"
+
           if [ -n "${previous}" ]; then
-            notes_args+=(-f previous_tag_name="${previous}")
             echo "Release notes cover ${previous}..${TAG}."
+            gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${TAG}" \
+              -f target_commitish="${SHA}" \
+              -f previous_tag_name="${previous}" \
+              --jq .body > "${RUNNER_TEMP}/generated-notes.md"
           else
-            echo "No earlier ${TAG_PREFIX}v* release; letting GitHub pick the window."
+            # A first release has nothing of its own to diff against, and left to
+            # itself generate-notes would reach for the newest release of any
+            # package - so a first `lightly-studio-embed` release would be handed
+            # LightlyStudio's commits. The changelog section stands alone instead.
+            echo "::notice::No earlier ${TAG_PREFIX}v* release; the notes are the changelog section alone."
+            : > "${RUNNER_TEMP}/generated-notes.md"
           fi
-          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" "${notes_args[@]}" \
-            --jq .body > "${RUNNER_TEMP}/generated-notes.md"
           python3 -m prepare_release render-release-notes \
             --changelog "${RUNNER_TEMP}/CHANGELOG.md" \
             --version "${VERSION}" \

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
     paths:
       - "lightly_studio/pyproject.toml"
-      - "lightly_studio_embed/pyproject.toml"
+      - "lightly_studio_serve/pyproject.toml"
   # Retry hatch for a run that failed on something transient. It reaches the
   # same commit as the push would, so it is safe to run at any time.
   workflow_dispatch:
@@ -16,7 +16,7 @@ on:
       package:
         description: Package to draft a release for.
         type: choice
-        options: [lightly-studio, lightly-studio-embed]
+        options: [lightly-studio, lightly-studio-serve]
         default: lightly-studio
 
 permissions:
@@ -331,7 +331,7 @@ jobs:
           else
             # A first release has nothing of its own to diff against, and left to
             # itself generate-notes would reach for the newest release of any
-            # package - so a first `lightly-studio-embed` release would be handed
+            # package - so a first `lightly-studio-serve` release would be handed
             # LightlyStudio's commits. The changelog section stands alone instead.
             echo "::notice::No earlier ${TAG_PREFIX}v* release; the notes are the changelog section alone."
             : > "${RUNNER_TEMP}/generated-notes.md"

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -33,6 +33,10 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Reads only: the write the workflow needs is the tag and the release, both
+    # of which happen in draft-release.
+    permissions:
+      contents: read
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
     steps:
@@ -60,22 +64,40 @@ jobs:
             exit 0
           fi
 
-          # `|| return 1` rather than errexit: the caller suppresses it, and reading
-          # the version out of a 404 body left in the file would be worse than a miss.
+          # The version of $2 at commit $1. Exit 2 says the package does not exist
+          # there; every other failure is exit 1 and stops the run. Errexit cannot
+          # carry that: the caller suppresses it, and dropping a release because
+          # the API blipped is worse than failing loudly.
           version_at() {
-            gh api "repos/${GITHUB_REPOSITORY}/contents/$2?ref=$1" \
-              -H "Accept: application/vnd.github.raw" \
-              > "${RUNNER_TEMP}/detect.toml" 2>/dev/null || return 1
-            python3 -m prepare_release read-version --pyproject "${RUNNER_TEMP}/detect.toml"
+            if ! gh api "repos/${GITHUB_REPOSITORY}/contents/$2?ref=$1" \
+                   -H "Accept: application/vnd.github.raw" \
+                   > "${RUNNER_TEMP}/detect.toml" 2>"${RUNNER_TEMP}/detect-err"; then
+              if grep -q "(HTTP 404)" "${RUNNER_TEMP}/detect-err"; then
+                return 2
+              fi
+              echo "::error::Could not read $2 at $1:"
+              cat "${RUNNER_TEMP}/detect-err"
+              return 1
+            fi
+            python3 -m prepare_release read-version \
+              --pyproject "${RUNNER_TEMP}/detect.toml" || return 1
           }
 
           : > "${RUNNER_TEMP}/detected"
           while read -r distribution pyproject; do
+            before_status=0
+            after_status=0
+            before_version="$(version_at "${BEFORE}" "${pyproject}")" || before_status=$?
+            after_version="$(version_at "${AFTER}" "${pyproject}")" || after_status=$?
+            if [ "${before_status}" -eq 1 ] || [ "${after_status}" -eq 1 ]; then
+              exit 1
+            fi
             # A package that does not exist on both sides of the push is not being
             # released: adding one is not a release of it, and the first release
             # goes through Prepare Release like every other.
-            before_version="$(version_at "${BEFORE}" "${pyproject}")" || continue
-            after_version="$(version_at "${AFTER}" "${pyproject}")" || continue
+            if [ "${before_status}" -ne 0 ] || [ "${after_status}" -ne 0 ]; then
+              continue
+            fi
             if [ "${before_version}" != "${after_version}" ]; then
               echo "${distribution}" >> "${RUNNER_TEMP}/detected"
               echo "${distribution}: ${before_version} -> ${after_version}."

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -94,6 +94,11 @@ jobs:
               --pyproject "${RUNNER_TEMP}/detect.toml" || return 1
           }
 
+          # Written to a file rather than read from a process substitution, whose exit
+          # status errexit does not see: a failure here would otherwise leave the loop
+          # with nothing to read and skip every release silently.
+          python3 -m prepare_release list-packages > "${RUNNER_TEMP}/packages"
+
           : > "${RUNNER_TEMP}/detected"
           while read -r distribution pyproject; do
             before_status=0
@@ -113,7 +118,7 @@ jobs:
               echo "${distribution}" >> "${RUNNER_TEMP}/detected"
               echo "${distribution}: ${before_version} -> ${after_version}."
             fi
-          done < <(python3 -m prepare_release list-packages)
+          done < "${RUNNER_TEMP}/packages"
 
           packages="$(jq -Rcs 'split("\n") | map(select(length > 0))' < "${RUNNER_TEMP}/detected")"
           echo "packages=${packages}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,30 +1,40 @@
 name: Draft Release
 
 on:
-  # Merging the "Bump version to X.Y.Z" pull request is the decision to
-  # release, so it is what starts this. The path filter is only a cheap
-  # pre-filter; what is released is worked out below.
+  # Merging the "Bump <package> version to X.Y.Z" pull request is the decision
+  # to release, so it is what starts this. The path filter is only a cheap
+  # pre-filter; which package is released, if any, is worked out below.
   push:
     branches: [main]
-    paths: ["lightly_studio/pyproject.toml"]
+    paths:
+      - "lightly_studio/pyproject.toml"
+      - "lightly_studio_embed/pyproject.toml"
   # Retry hatch for a run that failed on something transient. It reaches the
   # same commit as the push would, so it is safe to run at any time.
   workflow_dispatch:
+    inputs:
+      package:
+        description: Package to draft a release for.
+        type: choice
+        options: [lightly-studio, lightly-studio-embed]
+        default: lightly-studio
 
 permissions:
   contents: write
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 env:
   PYTHONPATH: ${{ github.workspace }}/.github/scripts
 
 jobs:
-  draft-release:
+  # Which packages this push is about, decided before anything is tagged. A
+  # release of one package must leave the other's version untouched, so that is
+  # what is asked: not "was a pyproject.toml edited" - a dependency bump does
+  # that too - but "did this package's version change".
+  detect:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
+    outputs:
+      packages: ${{ steps.detect.outputs.packages }}
     steps:
       # The tooling is taken from main, never from the released commit: running
       # that commit's own release code would execute it with a write token.
@@ -34,11 +44,86 @@ jobs:
           ref: main
           persist-credentials: false
 
+      - name: Decide which packages this run is about
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          DISPATCHED_PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" != "push" ]; then
+            packages="$(jq -cn --arg p "${DISPATCHED_PACKAGE}" '[$p]')"
+            echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+            echo "Dispatched run: drafting ${DISPATCHED_PACKAGE}."
+            exit 0
+          fi
+
+          # `|| return 1` rather than errexit: the caller suppresses it, and reading
+          # the version out of a 404 body left in the file would be worse than a miss.
+          version_at() {
+            gh api "repos/${GITHUB_REPOSITORY}/contents/$2?ref=$1" \
+              -H "Accept: application/vnd.github.raw" \
+              > "${RUNNER_TEMP}/detect.toml" 2>/dev/null || return 1
+            python3 -m prepare_release read-version --pyproject "${RUNNER_TEMP}/detect.toml"
+          }
+
+          : > "${RUNNER_TEMP}/detected"
+          while read -r distribution pyproject; do
+            # A package that does not exist on both sides of the push is not being
+            # released: adding one is not a release of it, and the first release
+            # goes through Prepare Release like every other.
+            before_version="$(version_at "${BEFORE}" "${pyproject}")" || continue
+            after_version="$(version_at "${AFTER}" "${pyproject}")" || continue
+            if [ "${before_version}" != "${after_version}" ]; then
+              echo "${distribution}" >> "${RUNNER_TEMP}/detected"
+              echo "${distribution}: ${before_version} -> ${after_version}."
+            fi
+          done < <(python3 -m prepare_release list-packages)
+
+          packages="$(jq -Rcs 'split("\n") | map(select(length > 0))' < "${RUNNER_TEMP}/detected")"
+          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Packages to draft: ${packages}"
+
+  draft-release:
+    needs: detect
+    if: needs.detect.outputs.packages != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      # Each package's release stands on its own, so one failing must not cancel
+      # the other halfway through tagging.
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.detect.outputs.packages) }}
+    # Per package: two packages drafting at once is fine, the same package
+    # drafting twice at once is not.
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.package }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout the release tooling
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      # Everything that differs between the packages comes from here, so the steps
+      # below name no package of their own.
+      - name: Resolve the package
+        id: package
+        run: |
+          python3 -m prepare_release package-config \
+            --package "${{ matrix.package }}" >> "$GITHUB_OUTPUT"
+
       - name: Find the version and the commit that set it
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
           PUSHED: ${{ github.sha }}
+          PYPROJECT: ${{ steps.package.outputs.pyproject }}
+          TAG_PREFIX: ${{ steps.package.outputs.tag_prefix }}
         # A merge queue batch lands as a single push, so the commit that
         # triggered this run is the tip of the batch and not necessarily the
         # version bump - which is how a release ends up containing more than
@@ -50,7 +135,7 @@ jobs:
         run: |
           set -euo pipefail
           version_at() {
-            gh api "repos/${GITHUB_REPOSITORY}/contents/lightly_studio/pyproject.toml?ref=$1" \
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${PYPROJECT}?ref=$1" \
               -H "Accept: application/vnd.github.raw" > "${RUNNER_TEMP}/pyproject-$1.toml"
             python3 -m prepare_release read-version --pyproject "${RUNNER_TEMP}/pyproject-$1.toml"
           }
@@ -65,20 +150,30 @@ jobs:
           fi
 
           version="$(version_at "${tip}")"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/commits?path=${PYPROJECT}&sha=${tip}&per_page=100" \
+            --jq '.[].sha' > "${RUNNER_TEMP}/commits"
           bump=""
           reached_previous_version=false
-          for commit in $(gh api \
-            "repos/${GITHUB_REPOSITORY}/commits?path=lightly_studio/pyproject.toml&sha=${tip}&per_page=100" \
-            --jq '.[].sha'); do
+          while read -r commit; do
             if [ "$(version_at "${commit}")" = "${version}" ]; then
               bump="${commit}"
             else
               reached_previous_version=true
               break
             fi
-          done
+          done < "${RUNNER_TEMP}/commits"
 
-          if [ -z "${bump}" ] || [ "${reached_previous_version}" = false ]; then
+          # Reaching the end of a history shorter than one page means the oldest
+          # commit that touched the file is the one that introduced this version,
+          # which is what the first release of a package looks like. A full page
+          # means the walk may just have been truncated, so that stays an error.
+          truncated=false
+          if [ "${reached_previous_version}" = false ] && \
+             [ "$(wc -l < "${RUNNER_TEMP}/commits")" -ge 100 ]; then
+            truncated=true
+          fi
+          if [ -z "${bump}" ] || [ "${truncated}" = true ]; then
             echo "::error::Could not identify the commit that set version ${version}."
             exit 1
           fi
@@ -86,7 +181,7 @@ jobs:
           {
             echo "sha=${bump}"
             echo "version=${version}"
-            echo "tag=v${version}"
+            echo "tag=${TAG_PREFIX}v${version}"
           } >> "$GITHUB_OUTPUT"
           echo "Version ${version} was set by ${bump}."
 
@@ -171,13 +266,29 @@ jobs:
           TAG: ${{ steps.resolve.outputs.tag }}
           SHA: ${{ steps.resolve.outputs.sha }}
           VERSION: ${{ steps.resolve.outputs.version }}
+          CHANGELOG: ${{ steps.package.outputs.changelog }}
+          TAG_PREFIX: ${{ steps.package.outputs.tag_prefix }}
         run: |
           set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=${SHA}" \
+          gh api "repos/${GITHUB_REPOSITORY}/contents/${CHANGELOG}?ref=${SHA}" \
             -H "Accept: application/vnd.github.raw" > "${RUNNER_TEMP}/CHANGELOG.md"
-          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="${TAG}" \
-            -f target_commitish="${SHA}" \
+
+          # Left to itself, generate-notes takes the previous release whatever
+          # package it belongs to, so the notes would cover the other package's
+          # commits. The window is pinned to this package's own last release
+          # instead. `lightly-studio`'s empty prefix selects exactly the `v*`
+          # tags, which are its own.
+          previous="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq \
+            "[.[] | select(.draft == false) | .tag_name
+              | select(startswith(\"${TAG_PREFIX}v\"))] | first // empty")"
+          notes_args=(-f tag_name="${TAG}" -f target_commitish="${SHA}")
+          if [ -n "${previous}" ]; then
+            notes_args+=(-f previous_tag_name="${previous}")
+            echo "Release notes cover ${previous}..${TAG}."
+          else
+            echo "No earlier ${TAG_PREFIX}v* release; letting GitHub pick the window."
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" "${notes_args[@]}" \
             --jq .body > "${RUNNER_TEMP}/generated-notes.md"
           python3 -m prepare_release render-release-notes \
             --changelog "${RUNNER_TEMP}/CHANGELOG.md" \
@@ -193,13 +304,14 @@ jobs:
           TAG: ${{ steps.resolve.outputs.tag }}
           SHA: ${{ steps.resolve.outputs.sha }}
           VERSION: ${{ steps.resolve.outputs.version }}
+          DISPLAY_NAME: ${{ steps.package.outputs.display_name }}
         # Created through the API so the checkout keeps `persist-credentials: false`;
         # `gh release create` would only make a lightweight tag.
         run: |
           set -euo pipefail
           tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags" \
             -f tag="${TAG}" \
-            -f message="LightlyStudio ${VERSION}" \
+            -f message="${DISPLAY_NAME} ${VERSION}" \
             -f object="${SHA}" \
             -f type=commit \
             --jq .sha)"

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -197,18 +197,27 @@ jobs:
             fi
           done < "${RUNNER_TEMP}/commits"
 
-          # Reaching the end of a history shorter than one page means the oldest
-          # commit that touched the file is the one that introduced this version,
-          # which is what the first release of a package looks like. A full page
-          # means the walk may just have been truncated, so that stays an error.
-          truncated=false
-          if [ "${reached_previous_version}" = false ] && \
-             [ "$(wc -l < "${RUNNER_TEMP}/commits")" -ge 100 ]; then
-            truncated=true
-          fi
-          if [ -z "${bump}" ] || [ "${truncated}" = true ]; then
-            echo "::error::Could not identify the commit that set version ${version}."
+          if [ -z "${bump}" ]; then
+            echo "::error::No commit touching ${PYPROJECT} carries version ${version}."
             exit 1
+          fi
+
+          if [ "${reached_previous_version}" = false ]; then
+            # A full page means the walk may simply have been truncated before it
+            # reached the previous version, which must not be read as there being
+            # none.
+            if [ "$(wc -l < "${RUNNER_TEMP}/commits")" -ge 100 ]; then
+              echo "::error::Could not identify the commit that set version ${version}:"
+              echo "::error::the walk hit the page limit without reaching an earlier version."
+              exit 1
+            fi
+            # Otherwise this version has been in the file since it first appeared,
+            # so no commit ever "set" it and there is nothing earlier to leave out -
+            # the whole history up to the tip is this first release. The tip is also
+            # the only commit where the rest of the release inputs are guaranteed to
+            # exist: the commit that introduced the package predates its changelog.
+            echo "::notice::No earlier version of ${PYPROJECT}; releasing ${version} from the tip."
+            bump="${tip}"
           fi
 
           {

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -26,15 +26,10 @@ env:
   PYTHONPATH: ${{ github.workspace }}/.github/scripts
 
 jobs:
-  # Which packages this push is about, decided before anything is tagged. A
-  # release of one package must leave the other's version untouched, so that is
-  # what is asked: not "was a pyproject.toml edited" - a dependency bump does
-  # that too - but "did this package's version change".
+  # Which packages this push changed the version of, not merely whose pyproject.toml it edited.
   detect:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Reads only: the write the workflow needs is the tag and the release, both
-    # of which happen in draft-release.
     permissions:
       contents: read
     outputs:
@@ -64,9 +59,7 @@ jobs:
             exit 0
           fi
 
-          # Both sides of the push are resolved first, so that the 404 below can only
-          # mean "no such file at that commit". A 404 on an unresolvable ref reads
-          # the same, and would otherwise turn a broken run into a silent no-op.
+          # Resolved first, so that the 404 below can only mean "no such file at that commit".
           for ref in "${BEFORE}" "${AFTER}"; do
             if ! gh api "repos/${GITHUB_REPOSITORY}/commits/${ref}" --jq .sha > /dev/null; then
               echo "::error::Cannot resolve ${ref}; use the workflow_dispatch hatch instead."
@@ -74,11 +67,7 @@ jobs:
             fi
           done
 
-          # The version of $2 at commit $1. Exit 2 says the file does not exist
-          # there; every other failure is exit 1 and stops the run. Errexit cannot
-          # carry that: the caller suppresses it, and dropping a release because
-          # the API blipped is worse than failing loudly. Diagnostics go to stderr,
-          # because stdout of this function is the version the caller captures.
+          # Exit 2 is "no such file"; exit 1 is any other failure and stops the run.
           version_at() {
             if ! gh api "repos/${GITHUB_REPOSITORY}/contents/$2?ref=$1" \
                    -H "Accept: application/vnd.github.raw" \
@@ -94,9 +83,7 @@ jobs:
               --pyproject "${RUNNER_TEMP}/detect.toml" || return 1
           }
 
-          # Written to a file rather than read from a process substitution, whose exit
-          # status errexit does not see: a failure here would otherwise leave the loop
-          # with nothing to read and skip every release silently.
+          # A file, not a process substitution, whose exit status errexit does not see.
           python3 -m prepare_release list-packages > "${RUNNER_TEMP}/packages"
 
           : > "${RUNNER_TEMP}/detected"
@@ -108,9 +95,7 @@ jobs:
             if [ "${before_status}" -eq 1 ] || [ "${after_status}" -eq 1 ]; then
               exit 1
             fi
-            # A package that does not exist on both sides of the push is not being
-            # released: adding one is not a release of it, and the first release
-            # goes through Prepare Release like every other.
+            # Missing on either side: adding a package is not a release of it.
             if [ "${before_status}" -ne 0 ] || [ "${after_status}" -ne 0 ]; then
               continue
             fi
@@ -130,13 +115,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
-      # Each package's release stands on its own, so one failing must not cancel
-      # the other halfway through tagging.
+      # One package failing must not cancel the other mid-tag.
       fail-fast: false
       matrix:
         package: ${{ fromJSON(needs.detect.outputs.packages) }}
-    # Per package: two packages drafting at once is fine, the same package
-    # drafting twice at once is not.
+    # Per package: the same package must not draft twice at once.
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.package }}
       cancel-in-progress: false
@@ -147,8 +130,7 @@ jobs:
           ref: main
           persist-credentials: false
 
-      # Everything that differs between the packages comes from here, so the steps
-      # below name no package of their own.
+      # Everything that differs between the packages comes from here.
       - name: Resolve the package
         id: package
         run: |
@@ -208,19 +190,14 @@ jobs:
           fi
 
           if [ "${reached_previous_version}" = false ]; then
-            # A full page means the walk may simply have been truncated before it
-            # reached the previous version, which must not be read as there being
-            # none.
+            # A full page may just be truncated, which is not the same as no earlier version.
             if [ "$(wc -l < "${RUNNER_TEMP}/commits")" -ge 100 ]; then
               echo "::error::Could not identify the commit that set version ${version}:"
               echo "::error::the walk hit the page limit without reaching an earlier version."
               exit 1
             fi
-            # Otherwise this version has been in the file since it first appeared,
-            # so no commit ever "set" it and there is nothing earlier to leave out -
-            # the whole history up to the tip is this first release. The tip is also
-            # the only commit where the rest of the release inputs are guaranteed to
-            # exist: the commit that introduced the package predates its changelog.
+            # A first release: nothing earlier to leave out, and the tip is where the
+            # changelog exists.
             echo "::notice::No earlier version of ${PYPROJECT}; releasing ${version} from the tip."
             bump="${tip}"
           fi
@@ -320,16 +297,9 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/contents/${CHANGELOG}?ref=${SHA}" \
             -H "Accept: application/vnd.github.raw" > "${RUNNER_TEMP}/CHANGELOG.md"
 
-          # Left to itself, generate-notes takes the previous release whatever
-          # package it belongs to, so the notes would cover the other package's
-          # commits. The window is pinned to this package's own last release
-          # instead. `lightly-studio`'s empty prefix selects exactly the `v*`
-          # tags, which are its own.
-          # `--paginate` because releases come back newest-first across every package,
-          # so this package's own last release drops off page one once the other has
-          # released enough times. Written to a file rather than piped into `head`,
-          # which would SIGPIPE `gh` and trip `pipefail`. Prereleases are skipped, as
-          # GitHub's own default does.
+          # This package's own last release, so the notes cannot cover the other's commits.
+          # Paginated because releases come back newest-first across both; a file rather
+          # than `head`, which would SIGPIPE `gh` and trip `pipefail`.
           gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq \
             ".[] | select(.draft == false and .prerelease == false) | .tag_name
               | select(startswith(\"${TAG_PREFIX}v\"))" > "${RUNNER_TEMP}/releases"
@@ -343,10 +313,7 @@ jobs:
               -f previous_tag_name="${previous}" \
               --jq .body > "${RUNNER_TEMP}/generated-notes.md"
           else
-            # A first release has nothing of its own to diff against, and left to
-            # itself generate-notes would reach for the newest release of any
-            # package - so a first `lightly-studio-serve` release would be handed
-            # LightlyStudio's commits. The changelog section stands alone instead.
+            # Nothing of its own to diff against: the changelog section stands alone.
             echo "::notice::No earlier ${TAG_PREFIX}v* release; the notes are the changelog section alone."
             : > "${RUNNER_TEMP}/generated-notes.md"
           fi

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -6,7 +6,7 @@ on:
       tag:
         description: >-
           Tag of the draft release to publish, e.g. v1.2.3 or
-          lightly-studio-embed/v0.1.2. The tag decides which package is
+          lightly-studio-serve/v0.1.2. The tag decides which package is
           published, so there is nothing here that can disagree with it.
         type: string
         required: true

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Tag of the draft release to publish, e.g. v1.2.3.
+        description: >-
+          Tag of the draft release to publish, e.g. v1.2.3 or
+          lightly-studio-embed/v0.1.2. The tag decides which package is
+          published, so there is nothing here that can disagree with it.
         type: string
         required: true
       target:
@@ -63,6 +66,7 @@ jobs:
       contents: read
     env:
       TAG: ${{ inputs.tag }}
+      PYTHONPATH: ${{ github.workspace }}/.github/scripts
     steps:
       # `refs/tags/` because actions/checkout resolves an unqualified ref as a
       # branch first, and a branch sharing the tag's name would be built in the
@@ -73,14 +77,21 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           persist-credentials: false
 
+      # The tag prefix says which package this is: `v1.2.3` is lightly-studio,
+      # every other package tags as `<distribution>/v1.2.3`.
+      - name: Resolve the package
+        id: package
+        run: |
+          python3 -m prepare_release package-config --tag "${TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Assert the tag matches the version it points at
         env:
-          PYTHONPATH: ${{ github.workspace }}/.github/scripts
+          PYPROJECT: ${{ steps.package.outputs.pyproject }}
+          TAG_PREFIX: ${{ steps.package.outputs.tag_prefix }}
         run: |
           set -euo pipefail
-          version="$(python3 -m prepare_release read-version \
-            --pyproject lightly_studio/pyproject.toml)"
-          if [ "v${version}" != "${TAG}" ]; then
+          version="$(python3 -m prepare_release read-version --pyproject "${PYPROJECT}")"
+          if [ "${TAG_PREFIX}v${version}" != "${TAG}" ]; then
             echo "::error::${TAG} points at a commit whose version is ${version}."
             exit 1
           fi
@@ -97,8 +108,9 @@ jobs:
         with:
           version: "0.12.6"
 
-      # The wheel bundles the built frontend, so the build needs Node.
+      # Only the wheel that bundles the built frontend needs Node.
       - name: Set Up Node.js
+        if: steps.package.outputs.needs_node == 'true'
         uses: actions/setup-node@v6
         with:
           node-version-file: lightly_studio_view/.nvmrc
@@ -108,12 +120,24 @@ jobs:
       # then runs export-schema under that environment, so a stale lock would
       # change the schema inside the published wheel with no signal.
       - name: Install Dependencies
-        working-directory: lightly_studio
+        working-directory: ${{ steps.package.outputs.directory }}
         run: uv sync --locked --all-groups --all-extras
 
       - name: Build the Distributions
-        working-directory: lightly_studio
+        working-directory: ${{ steps.package.outputs.directory }}
         run: make build
+
+      # Between the build and the upload, so a wheel that fails it never reaches
+      # the publish job. Only packages that declare something forbidden are
+      # resolved: installing LightlyStudio's own tree to learn it contains torch
+      # would cost minutes to confirm what its pyproject.toml already says.
+      - name: Check the Wheel's Dependencies
+        if: steps.package.outputs.forbidden_dependencies != ''
+        working-directory: ${{ steps.package.outputs.directory }}
+        run: |
+          python3 -m prepare_release check-wheel-dependencies \
+            --package "${{ steps.package.outputs.distribution }}" \
+            --dist dist
 
       # A week, to outlast the pypi environment's approval gate: an artifact
       # expiring mid-approval would fail the release after it was granted.
@@ -121,7 +145,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: dist
-          path: lightly_studio/dist
+          path: ${{ steps.package.outputs.directory }}/dist
           if-no-files-found: error
           retention-days: 7
 
@@ -130,7 +154,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # What PyPI's trusted publisher checks the OIDC claim against, so only this
-    # job of this file can publish. `pypi` carries the approval gate and is
+    # job of this file can publish. Each package configures its own publisher
+    # against the same claim; which one is uploaded to is decided by the name in
+    # the artifact, not by the claim. `pypi` carries the approval gate and is
     # restricted to main; `testpypi` has neither, so a rehearsal is unattended.
     environment: ${{ inputs.target }}
     permissions:

--- a/.github/workflows/finish_release.yml
+++ b/.github/workflows/finish_release.yml
@@ -77,8 +77,7 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           persist-credentials: false
 
-      # The tag prefix says which package this is: `v1.2.3` is lightly-studio,
-      # every other package tags as `<distribution>/v1.2.3`.
+      # `v1.2.3` is lightly-studio; every other package tags as `<distribution>/v1.2.3`.
       - name: Resolve the package
         id: package
         run: |
@@ -127,10 +126,7 @@ jobs:
         working-directory: ${{ steps.package.outputs.directory }}
         run: make build
 
-      # Between the build and the upload, so a wheel that fails it never reaches
-      # the publish job. Only packages that declare something forbidden are
-      # resolved: installing LightlyStudio's own tree to learn it contains torch
-      # would cost minutes to confirm what its pyproject.toml already says.
+      # Before the upload, so a wheel that fails it never reaches the publish job.
       - name: Check the Wheel's Dependencies
         if: steps.package.outputs.forbidden_dependencies != ''
         working-directory: ${{ steps.package.outputs.directory }}
@@ -154,9 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # What PyPI's trusted publisher checks the OIDC claim against, so only this
-    # job of this file can publish. Each package configures its own publisher
-    # against the same claim; which one is uploaded to is decided by the name in
-    # the artifact, not by the claim. `pypi` carries the approval gate and is
+    # job of this file can publish. `pypi` carries the approval gate and is
     # restricted to main; `testpypi` has neither, so a rehearsal is unattended.
     environment: ${{ inputs.target }}
     permissions:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -8,7 +8,7 @@ on:
           Package to release. The two release independently: their versions,
           branches and tags share no namespace.
         type: choice
-        options: [lightly-studio, lightly-studio-embed]
+        options: [lightly-studio, lightly-studio-serve]
         default: lightly-studio
       bump:
         description: >-

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -3,6 +3,13 @@ name: Prepare Release
 on:
   workflow_dispatch:
     inputs:
+      package:
+        description: >-
+          Package to release. The two release independently: their versions,
+          branches and tags share no namespace.
+        type: choice
+        options: [lightly-studio, lightly-studio-embed]
+        default: lightly-studio
       bump:
         description: >-
           Semver bump to apply. Nothing is inferred from the changelog -
@@ -23,8 +30,9 @@ permissions:
   contents: write
   pull-requests: write
 
+# Per package, so preparing one release does not wait behind the other's.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ inputs.package }}
   cancel-in-progress: false
 
 env:
@@ -52,14 +60,22 @@ jobs:
           make static-checks
           make test
 
+      # Everything that differs between the packages comes from here, so the steps
+      # below name no package of their own.
+      - name: Resolve the package
+        id: package
+        run: |
+          python3 -m prepare_release package-config \
+            --package "${{ inputs.package }}" >> "$GITHUB_OUTPUT"
+
       - name: Guard against a git-pinned Labelformat
         run: |
           python3 -m prepare_release check-labelformat-pin \
-            --pyproject lightly_studio/pyproject.toml
+            --pyproject "${{ steps.package.outputs.pyproject }}"
 
       - name: Resolve inputs
         id: resolved
-        working-directory: lightly_studio
+        working-directory: ${{ steps.package.outputs.directory }}
         env:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_BUMP: ${{ inputs.bump }}
@@ -70,27 +86,28 @@ jobs:
             version="$(uv version --bump "$INPUT_BUMP" --dry-run --frozen --short)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"
+          echo "branch=${{ steps.package.outputs.branch_prefix }}v$version" >> "$GITHUB_OUTPUT"
+          echo "### Preparing ${{ inputs.package }} v$version" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create release branch
-        run: git checkout -b "release-v${{ steps.resolved.outputs.version }}"
+        run: git checkout -b "${{ steps.resolved.outputs.branch }}"
 
       - name: Promote changelog
         run: |
           python3 -m prepare_release promote-changelog \
-            --changelog CHANGELOG.md \
+            --changelog "${{ steps.package.outputs.changelog }}" \
             --version "${{ steps.resolved.outputs.version }}" \
             --date "$(date -u +%F)"
 
       - name: Bump pyproject.toml version
-        working-directory: lightly_studio
+        working-directory: ${{ steps.package.outputs.directory }}
         run: uv version "${{ steps.resolved.outputs.version }}" --frozen
 
       - name: Snapshot uv.lock before sync
         run: cp uv.lock /tmp/uv.lock.before
 
       - name: uv sync
-        working-directory: lightly_studio
+        working-directory: ${{ steps.package.outputs.directory }}
         run: uv sync
 
       - name: Assert uv.lock diff is narrow
@@ -98,12 +115,15 @@ jobs:
           python3 -m prepare_release assert-lock-diff \
             --before /tmp/uv.lock.before \
             --after uv.lock \
-            --package lightly-studio
+            --package "${{ inputs.package }}"
 
       - name: Confirm exactly the expected files changed
+        env:
+          CHANGELOG: ${{ steps.package.outputs.changelog }}
+          PYPROJECT: ${{ steps.package.outputs.pyproject }}
         run: |
           changed="$(git status --porcelain | awk '{print $2}' | sort)"
-          expected="$(printf '%s\n' CHANGELOG.md lightly_studio/pyproject.toml uv.lock | sort)"
+          expected="$(printf '%s\n' "$CHANGELOG" "$PYPROJECT" uv.lock | sort)"
           if [ "$changed" != "$expected" ]; then
             echo "::error::Unexpected file set changed. Got:"
             echo "$changed"
@@ -113,24 +133,28 @@ jobs:
       - name: Render PR body
         run: |
           python3 -m prepare_release render-pr-body \
-            --changelog CHANGELOG.md \
+            --changelog "${{ steps.package.outputs.changelog }}" \
             --version "${{ steps.resolved.outputs.version }}" \
+            --package "${{ inputs.package }}" \
             --output /tmp/pr_body.md
 
       - name: Commit changes
+        env:
+          CHANGELOG: ${{ steps.package.outputs.changelog }}
+          PYPROJECT: ${{ steps.package.outputs.pyproject }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md lightly_studio/pyproject.toml uv.lock
-          git commit -m "Bump version to ${{ steps.resolved.outputs.version }}"
-          git push origin "release-v${{ steps.resolved.outputs.version }}"
+          git add "$CHANGELOG" "$PYPROJECT" uv.lock
+          git commit -m "Bump ${{ inputs.package }} version to ${{ steps.resolved.outputs.version }}"
+          git push origin "${{ steps.resolved.outputs.branch }}"
 
       - name: Open release PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh pr create \
-            --title "Bump version to ${{ steps.resolved.outputs.version }}" \
+            --title "Bump ${{ inputs.package }} version to ${{ steps.resolved.outputs.version }}" \
             --body-file /tmp/pr_body.md \
             --base main \
-            --head "release-v${{ steps.resolved.outputs.version }}"
+            --head "${{ steps.resolved.outputs.branch }}"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -60,8 +60,7 @@ jobs:
           make static-checks
           make test
 
-      # Everything that differs between the packages comes from here, so the steps
-      # below name no package of their own.
+      # Everything that differs between the packages comes from here.
       - name: Resolve the package
         id: package
         run: |

--- a/lightly_studio_serve/CHANGELOG.md
+++ b/lightly_studio_serve/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to Lightly**Studio** Serve will be documented in this file. The package
+releases on its own cadence, so it keeps its own changelog; the root `CHANGELOG.md` is
+LightlyStudio's.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add the embedder base classes and the embedding types LightlyStudio uses to talk to your
+  model. The HTTP server is not implemented yet, so this release cannot serve a model.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/lightly_studio_serve/CHANGELOG.md
+++ b/lightly_studio_serve/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the embedder base classes and the embedding types LightlyStudio uses to talk to your
-  model. The HTTP server is not implemented yet, so this release cannot serve a model.
-
 ### Changed
 
 ### Deprecated
@@ -23,3 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## \[0.1.0\] - 2026-09-11
+
+### Added
+
+- Add the embedder base classes and the embedding types LightlyStudio uses to talk to your
+  model. The HTTP server is not implemented yet, so this release cannot serve a model.
+

--- a/lightly_studio_serve/Makefile
+++ b/lightly_studio_serve/Makefile
@@ -20,7 +20,7 @@ build: clean
 check-wheel-dependencies: build
 	@echo "Checking the wheel's resolved dependencies..."
 	PYTHONPATH=../.github/scripts python3 -m prepare_release check-wheel-dependencies \
-		--package lightly-studio-embed --dist dist
+		--package lightly-studio-serve --dist dist
 
 .PHONY: test
 test:

--- a/lightly_studio_serve/Makefile
+++ b/lightly_studio_serve/Makefile
@@ -12,6 +12,16 @@ build: clean
 	@echo "Building a distribution package..."
 	uv build --package lightly-studio-serve --out-dir dist
 
+# The wheel is installed next to a customer's own CUDA and torch pins, so it must stay light.
+# Resolved from the built wheel rather than read from pyproject.toml, because the dependency
+# that would break that arrives one level down. The release workflow runs the same check
+# before it publishes anything.
+.PHONY: check-wheel-dependencies
+check-wheel-dependencies: build
+	@echo "Checking the wheel's resolved dependencies..."
+	PYTHONPATH=../.github/scripts python3 -m prepare_release check-wheel-dependencies \
+		--package lightly-studio-embed --dist dist
+
 .PHONY: test
 test:
 	@echo "Running tests..."

--- a/lightly_studio_serve/README.md
+++ b/lightly_studio_serve/README.md
@@ -3,6 +3,9 @@
 Serve your own embedding model to [LightlyStudio](https://github.com/lightly-ai/lightly-studio)
 over HTTP, so that your model's weights never leave your machine.
 
+**The HTTP server is not implemented yet.** So far the package holds the base classes and the
+types that LightlyStudio and a server will share.
+
 The package depends on an HTTP server, numpy and Pillow. It does not depend on torch, CUDA or
 LightlyStudio. You can therefore install it next to your own pins.
 


### PR DESCRIPTION
## What has changed and why?

Gives `lightly-studio-serve` a release trigger of its own, per [LIG-10693](https://linear.app/lightly/issue/LIG-10693/give-lightly-studio-serve-its-own-release-trigger). Until now the only way to publish it was to release LightlyStudio, so a customer who pinned it would see churn from studio releases that changed nothing in it.

- **Reuses the three workflows** rather than adding three new ones, which would duplicate ~400 lines of security-sensitive setup that nobody re-audits once copied. `prepare_release/packages.py` holds everything that differs between the packages; each workflow resolves it once into step outputs.
- **Releasing one leaves the other alone.** Draft asks "did this package's version change across the push", not "was a `pyproject.toml` edited" — a dependency bump does that too.
- **Tags cannot collide.** `lightly-studio` keeps `v1.2.3`; everything else tags `<distribution>/v1.2.3`. Finish derives the package from the tag, so nothing can disagree with it. Release notes pin their window to the package's own previous release — otherwise `generate-notes` takes the latest release of *either* package, which would break LightlyStudio's own notes once serve tags exist.
- **`check-wheel-dependencies`**, which the ticket assumed existed but did not. Installs the built wheel and inspects the *resolved* tree, so a torch-, cuda-, nvidia-, duckdb-, opencv- or lightly-studio-shaped dependency cannot arrive one level down. Runs between build and upload, and as a `make` target.
- **First release is `0.1.0`.** A first release resolves from the tip of `main` rather than the commit that introduced the version — that commit predates the package's changelog, so anchoring on it tagged a commit where the notes could not be read. `lightly_studio_serve/CHANGELOG.md` ships here already promoted to `\[0.1.0\]`, because Prepare cannot promote it: it asserts the version changed, and a first release at the version already in the tree does not. **Re-run `promote-changelog` if the merge date slips** — the heading carries today's date.

So the first release is: merge → **Draft Release** (`package: lightly-studio-serve`) → **Finish Release** (`tag: lightly-studio-serve/v0.1.0`). No Prepare run.

The changelog and README also say plainly that the HTTP server is not implemented yet, so a first release cannot be read as shipping one.

Both packages keep the same `pypi` / `testpypi` environments: a trusted publisher is keyed on workflow filename *and* environment, and the artifact decides which project is uploaded to. So [LIG-10690](https://linear.app/lightly/issue/LIG-10690/publish-lightly-studio-serve-to-pypi-with-a-trusted-publisher) configures `finish_release.yml` + `pypi` for both projects, on both indexes.

## How has it been tested?

- `make static-checks` and `make test` in `.github/scripts` — pass (87 tests, 18 new).
- Rehearsed Prepare for the package by hand: `uv version 0.1.1`, `uv sync`, `assert-lock-diff` — the `uv.lock` diff is exactly one line, and `promote-changelog` + `render-pr-body` produce the expected PR. Reverted after.
- `make check-wheel-dependencies` passes on the real wheel in ~3s. Re-run with `starlette` added to the forbidden list it fails, confirming it sees *transitive* dependencies (`starlette` arrives via `fastapi`), not just declared ones.
- Draft's detect step against stubbed versions: neither bumped → `[]`, studio only, serve only, both, package absent before the push → `[]`, HTTP 502 → exit 1, malformed manifest → exit 1.
- Traced the first-release resolve against real `main`: one commit touches the serve `pyproject.toml`, the walk never reaches an earlier version, 1 < 100 so it is not a truncation → tag lands on the tip.
- `bash -n` over every `run:` block; the YAML parses.
- Not exercised end to end — the GitHub-side stages need a merge. A TestPyPI rehearsal is the last acceptance criterion and the thing to do first after merge.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

@michal-lightly for review, since you reviewed #2257, #2258 and #2289, the rest of this stack. @IgorSusmelj as an alternative.
