### PR TITLE
Fix: Fetch only the selected metadata histogram

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -118,7 +118,7 @@
     const sourceHasContent = (source: DistributionSource): boolean =>
         (source.data?.length ?? 0) > 0 ||
         source.histogram != null ||
-        (source.groups?.some(groupHasContent) ?? false);
+        (source.groups?.length ?? 0) > 0;
 
     // With nothing explicitly selected, land on the first source that actually
     // has something to show. Otherwise an empty leading source (e.g. "All types"

--- a/lightly_studio_view/src/lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution.test.ts
@@ -55,3 +55,14 @@ describe('getNumericMetadataHistogramRequestOptions', () => {
         });
     });
 });
+
+it('scopes the request to the selected field and preserves an explicitly empty selection', () => {
+    for (const fields of [['score'], []]) {
+        expect(
+            getNumericMetadataHistogramRequestOptions({ collectionId: 'collection-id', fields })
+        ).toEqual({
+            path: { collection_id: 'collection-id' },
+            body: { fields }
+        });
+    }
+});

--- a/lightly_studio_view/src/lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution.ts
+++ b/lightly_studio_view/src/lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution.ts
@@ -25,26 +25,29 @@ export interface NumericMetadataHistogramOptions {
     collectionId: string;
     filter?: ImageFilter;
     binCount?: number;
+    fields?: string[];
 }
 
 export const getNumericMetadataHistogramRequestOptions = ({
     collectionId,
     filter,
-    binCount
+    binCount,
+    fields
 }: NumericMetadataHistogramOptions) => ({
     path: { collection_id: collectionId },
-    ...(filter || binCount
+    ...(filter || binCount || fields
         ? {
               body: {
                   ...(filter ? { filters: filter } : {}),
-                  ...(binCount ? { bin_count: binCount } : {})
+                  ...(binCount ? { bin_count: binCount } : {}),
+                  ...(fields ? { fields } : {})
               }
           }
         : {})
 });
 
 /**
- * Queries the value-distribution histograms of all numeric metadata fields of
+ * Queries the value-distribution histograms of the requested numeric metadata fields of
  * a collection, keyed by metadata name.
  *
  * The bins come from {@link https://github.com/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/api/routes/api/metadata.py `POST /collections/{id}/metadata/histograms`}: bin edges
@@ -55,7 +58,7 @@ export const getNumericMetadataHistogramRequestOptions = ({
  * filter changes.
  *
  * Accepts a reactive factory function (same pattern as `useImageAnnotationCounts`)
- * so that `collectionId`, `filter`, `binCount`, and `enabled` are re-read inside the
+ * so that `collectionId`, `filter`, `fields`, `binCount`, and `enabled` are re-read inside the
  * TanStack Query reactive context on every change.
  *
  * @param getOptions - Factory returning the query options. Called reactively by
@@ -67,17 +70,19 @@ export const useNumericMetadataDistribution = (
         filter?: ImageFilter;
         /** Number of equal-width bins per histogram (server default: 20). */
         binCount?: number;
+        fields?: string[];
         enabled?: boolean;
     }
 ) =>
     createQuery(() => {
-        const { collectionId, filter, binCount, enabled = true } = getOptions();
+        const { collectionId, filter, binCount, fields, enabled = true } = getOptions();
         // Computed inside the reactive function so a change to collectionId,
-        // filter, or binCount updates the query key and triggers a refetch.
+        // filter, fields, or binCount updates the query key and triggers a refetch.
         const requestOptions = getNumericMetadataHistogramRequestOptions({
             collectionId,
             filter,
-            binCount
+            binCount,
+            fields
         });
         return {
             ...getMetadataHistogramsOptions(requestOptions),

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -66,6 +66,7 @@
     import {
         buildMetadataDistributionSource,
         selectCategoricalMetadataKeys,
+        selectNumericMetadataKeys,
         selectComparisonSampleTags
     } from './metadataDistributionSource';
     import type { CategoryCount } from '$lib/components/BarChart';
@@ -759,11 +760,29 @@
     // User-configurable bin count for the metadata histograms.
     let histogramBinCount = $state(20);
 
+    const numericMetadataKeys = $derived(selectNumericMetadataKeys($metadataInfo));
+    const categoricalMetadataKeys = $derived(selectCategoricalMetadataKeys($metadataInfo));
+    const activeMetadataField = $derived.by<
+        { name: string; type: 'numeric' | 'categorical' } | undefined
+    >(() => {
+        if (activeDistributionSourceId !== 'metadata' || activeDistributionGroupId === undefined) {
+            return undefined;
+        }
+        if (categoricalMetadataKeys.includes(activeDistributionGroupId)) {
+            return { name: activeDistributionGroupId, type: 'categorical' };
+        }
+        if (numericMetadataKeys.includes(activeDistributionGroupId)) {
+            return { name: activeDistributionGroupId, type: 'numeric' };
+        }
+        return undefined;
+    });
+
     const metadataHistogramsQuery = useNumericMetadataDistribution(() => ({
         collectionId: collectionId,
         filter: distributionBaseFilter,
         binCount: histogramBinCount,
-        enabled: distributionPanelVisible
+        fields: activeMetadataField?.type === 'numeric' ? [activeMetadataField.name] : undefined,
+        enabled: distributionPanelVisible && activeMetadataField?.type === 'numeric'
     }));
     // query.data is already Record<string, HistogramData> — the hook applies
     // selectDistributions internally via the TanStack Query `select` option.
@@ -790,22 +809,6 @@
         categoricalMetadataFilteredQuery.data
     );
 
-    const categoricalMetadataKeys = $derived(selectCategoricalMetadataKeys($metadataInfo));
-    const activeMetadataField = $derived.by<
-        { name: string; type: 'numeric' | 'categorical' } | undefined
-    >(() => {
-        if (activeDistributionSourceId !== 'metadata' || activeDistributionGroupId === undefined) {
-            return undefined;
-        }
-        if (categoricalMetadataKeys.includes(activeDistributionGroupId)) {
-            return { name: activeDistributionGroupId, type: 'categorical' };
-        }
-        if (Object.hasOwn(metadataDistributions, activeDistributionGroupId)) {
-            return { name: activeDistributionGroupId, type: 'numeric' };
-        }
-        return undefined;
-    });
-
     const selectedDistributionSampleTags = $derived(
         selectComparisonSampleTags(distributionSampleTagItems, distributionSampleTagIds)
     );
@@ -821,6 +824,7 @@
     const metadataDistributionSource = $derived(
         buildMetadataDistributionSource({
             histograms: metadataDistributions,
+            numericKeys: numericMetadataKeys,
             categoricalKeys: categoricalMetadataKeys,
             categorical: categoricalMetadataDistributions,
             filteredCategorical: categoricalMetadataFilteredDistributions,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/metadataDistributionSource.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/metadataDistributionSource.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildMetadataDistributionSource,
     selectCategoricalMetadataKeys,
+    selectNumericMetadataKeys,
     selectComparisonSampleTags
 } from './metadataDistributionSource';
 import type { SampleTagMetadataDistributions } from '$lib/hooks/useMetadataDistributionsBySampleTags';
@@ -28,6 +29,7 @@ const tagDistributions: SampleTagMetadataDistributions[] = [
 
 const params = {
     histograms: { width },
+    numericKeys: ['width'],
     categoricalKeys: ['city'],
     categorical: { city: [zurich] },
     selectedRanges: { width: { min: 0, max: 1 } },
@@ -36,18 +38,34 @@ const params = {
 };
 
 describe('buildMetadataDistributionSource', () => {
+    it('keeps unloaded numeric keys selectable when only one histogram is fetched', () => {
+        const source = buildMetadataDistributionSource({
+            ...params,
+            numericKeys: ['width', 'height'],
+            categoricalKeys: []
+        });
+        expect(source?.groups?.map(({ id }) => id)).toEqual(['width', 'height']);
+        expect(source?.groups?.[0].histogram).toEqual(width);
+        expect(source?.groups?.[1].histogram).toBeUndefined();
+    });
+
     it('returns null when the dataset has no metadata at all', () => {
         expect(
             buildMetadataDistributionSource({
                 ...params,
                 histograms: {},
+                numericKeys: [],
                 categoricalKeys: []
             })
         ).toBeNull();
     });
 
     it('keeps the source when only categorical keys exist', () => {
-        const source = buildMetadataDistributionSource({ ...params, histograms: {} });
+        const source = buildMetadataDistributionSource({
+            ...params,
+            histograms: {},
+            numericKeys: []
+        });
         expect(source?.groups?.map(({ id }) => id)).toEqual(['city']);
     });
 
@@ -122,6 +140,20 @@ describe('buildMetadataDistributionSource', () => {
         const source = buildMetadataDistributionSource({ ...params, categoricalKeys: ['country'] });
         expect(source?.groups?.[1].categorical?.buckets).toEqual([]);
         expect(source?.groups?.[1].categorical?.comparisonBuckets).toEqual([]);
+    });
+});
+
+describe('selectNumericMetadataKeys', () => {
+    it('selects numeric keys from metadata descriptors, including before data arrives', () => {
+        expect(selectNumericMetadataKeys(undefined)).toEqual([]);
+        expect(
+            selectNumericMetadataKeys([
+                { name: 'width', type: 'integer' },
+                { name: 'score', type: 'float' },
+                { name: 'city', type: 'string' },
+                { name: 'reviewed', type: 'boolean' }
+            ])
+        ).toEqual(['width', 'score']);
     });
 });
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/metadataDistributionSource.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/metadataDistributionSource.ts
@@ -22,12 +22,17 @@ interface ComparisonTagItem {
 }
 
 /**
- * Metadata keys whose values are categorical. Numeric keys come from the
- * histogram response instead, so they are not listed here.
+ * Metadata keys whose values are categorical.
  */
 export const selectCategoricalMetadataKeys = (metadataInfo: MetadataInfo[] | undefined): string[] =>
     (metadataInfo ?? [])
         .filter((info) => info.type === 'string' || info.type === 'boolean')
+        .map((info) => info.name);
+
+/** Numeric keys remain selectable before their histograms have loaded. */
+export const selectNumericMetadataKeys = (metadataInfo: MetadataInfo[] | undefined): string[] =>
+    (metadataInfo ?? [])
+        .filter((info) => info.type === 'integer' || info.type === 'float')
         .map((info) => info.name);
 
 /** The selected comparison tags, in the order the select offers them. */
@@ -42,6 +47,8 @@ export const selectComparisonSampleTags = (
 interface MetadataDistributionSourceParams {
     /** Numeric distributions for the current view, keyed by metadata key. */
     histograms: Record<string, HistogramData>;
+    /** Numeric metadata keys remain selectable before their histogram loads. */
+    numericKeys: string[];
     /** Metadata keys that hold categorical values, in the order to show them. */
     categoricalKeys: string[];
     /** Categorical distributions for the current view, keyed by metadata key. */
@@ -79,7 +86,7 @@ interface MetadataDistributionSourceParams {
 export function buildMetadataDistributionSource(
     params: MetadataDistributionSourceParams
 ): DistributionSource | null {
-    const numericKeys = Object.keys(params.histograms);
+    const numericKeys = params.numericKeys;
     if (numericKeys.length === 0 && params.categoricalKeys.length === 0) return null;
 
     return {


### PR DESCRIPTION
## What has changed and why?

- Request histogram data only for the numeric metadata key currently selected in the distribution panel (using the fields param)
- Refetch the single relevant histogram when the user changes the metadata key.
- Keep other metadata keys available in the selector without loading their histogram data.

## How has it been tested?

- new unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Numeric metadata distributions can now be requested for selected fields, including explicitly empty selections.
  * Numeric metadata fields remain available for selection before their histogram data finishes loading.
  * Dataset distribution panels now recognize sources containing groups when choosing a default source.
* **Bug Fixes**
  * Improved metadata distribution handling for numeric, categorical-only, and datasets without metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->