### PR TITLE
Fix: Use embedding manager for cold-start embedding model resolution

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embedding_utils.py
+++ b/lightly_studio/src/lightly_studio/embed/embedding_utils.py
@@ -13,8 +13,8 @@ from lightly_studio.resolvers import (
 def collection_has_embeddings(session: Session, collection_id: UUID) -> bool:
     """Check if there are any embeddings available for the given collection.
 
-    Resolves the collection's default embedding model from the database and reports whether
-    any embeddings are stored for it. Does not load the model.
+    Loads or resolves the collection's default embedding model and reports whether any
+    embeddings are stored for it.
 
     Args:
         session: Database session for resolver operations.

--- a/lightly_studio/src/lightly_studio/embed/embedding_utils.py
+++ b/lightly_studio/src/lightly_studio/embed/embedding_utils.py
@@ -4,8 +4,8 @@ from uuid import UUID
 
 from sqlmodel import Session
 
+from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.resolvers import (
-    collection_embedding_model_resolver,
     sample_embedding_resolver,
 )
 
@@ -23,7 +23,8 @@ def collection_has_embeddings(session: Session, collection_id: UUID) -> bool:
     Returns:
         True if embeddings exist for the collection, False otherwise.
     """
-    model_id = collection_embedding_model_resolver.get_default_by_collection_id(
+    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
+    model_id = embedding_manager.load_or_get_default_model(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/tests/api/routes/api/test_collection.py
+++ b/lightly_studio/tests/api/routes/api/test_collection.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import (
@@ -13,6 +14,7 @@ from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_OK,
 )
+from lightly_studio.dataset.embedding_manager import EmbeddingManager
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import collection_resolver
 from tests.helpers_resolvers import (
@@ -236,16 +238,22 @@ def test_read_collections_overview(test_client: TestClient, db_session: Session)
 def test_has_embeddings(
     test_client: TestClient,
     db_session: Session,
+    mocker: MockerFixture,
 ) -> None:
     col_id = create_collection(session=db_session).collection_id
     embedding_model_id = create_embedding_model(
         session=db_session, collection_id=col_id, set_as_default=True
     ).embedding_model_id
+    mock_get_model = mocker.patch.object(
+        EmbeddingManager, "load_or_get_default_model", return_value=embedding_model_id
+    )
 
     # Initially, the collection has no embeddings.
     response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() is False
+    mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
+    mock_get_model.reset_mock()
 
     # Add an embedding to the collection.
     create_samples_with_embeddings(
@@ -259,6 +267,7 @@ def test_has_embeddings(
     response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() is True
+    mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
 
 
 @pytest.mark.postgres_only  # Deep copying is enterprise-only (PostgreSQL-backed).

--- a/lightly_studio/tests/embed/test_embedding_utils.py
+++ b/lightly_studio/tests/embed/test_embedding_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from pytest_mock import MockerFixture
 from sqlmodel import Session
 
+from lightly_studio.dataset.embedding_manager import EmbeddingManager
 from lightly_studio.embed import embedding_utils
 from tests.helpers_resolvers import (
     ImageStub,
@@ -11,17 +13,25 @@ from tests.helpers_resolvers import (
 )
 
 
-def test_collection_has_embeddings(db_session: Session) -> None:
+def test_collection_has_embeddings(db_session: Session, mocker: MockerFixture) -> None:
     col_id = create_collection(session=db_session).collection_id
     embedding_model_id = create_embedding_model(
         session=db_session, collection_id=col_id, set_as_default=True
     ).embedding_model_id
+    mock_get_model = mocker.patch.object(
+        EmbeddingManager, "load_or_get_default_model", return_value=embedding_model_id
+    )
 
     # Initially, the collection has no embeddings.
     assert not embedding_utils.collection_has_embeddings(
         session=db_session,
         collection_id=col_id,
     )
+    mock_get_model.assert_called_once_with(
+        session=db_session,
+        collection_id=col_id,
+    )
+    mock_get_model.reset_mock()
 
     # Add an embedding to the collection.
     create_samples_with_embeddings(
@@ -33,6 +43,10 @@ def test_collection_has_embeddings(db_session: Session) -> None:
 
     # Now, the collection should report having embeddings.
     assert embedding_utils.collection_has_embeddings(
+        session=db_session,
+        collection_id=col_id,
+    )
+    mock_get_model.assert_called_once_with(
         session=db_session,
         collection_id=col_id,
     )


### PR DESCRIPTION
## What has changed and why?

Effectively reverts #2221. Reverts a `collection_has_embeddings` change during the in-progress embedding backend refactor. 

Uses `EmbeddingManager`, as before.

- `collection_has_embeddings` resolves the default embedding model via `EmbeddingManager.load_or_get_default_model` instead of `collection_embedding_model_resolver.get_default_by_collection_id`.
- Restores model loading on cold start, so collections without a pre-registered default model still report embeddings correctly.

## How has it been tested?

- Updated unit test in `test_embedding_utils.py`; backend `make static-checks` and the test pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking whether a collection has embeddings by consistently loading or resolving the configured default embedding model.
  * Preserved existing embedding-count and result behavior.
  * Updated collection and embedding checks to use the same default-model handling, providing more consistent results across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->