### PR TITLE
Route image ingestion through the embedder registry

### DIFF
--- a/lightly_studio/src/lightly_studio/embed/embed_samples.py
+++ b/lightly_studio/src/lightly_studio/embed/embed_samples.py
@@ -1,12 +1,7 @@
 """Class-free interface for embedding samples and queries.
 
-Wraps the shared embedding logic behind plain module functions so callers no longer
-reach for the ``EmbeddingManager`` singleton, resolve the default model, and check it
-by hand. Each function resolves the collection's default embedding model itself.
-
-The functions currently delegate to the ``EmbeddingManager`` singleton. The internals
-will be swapped for the capability-typed ``EmbedderRegistry`` later; the function
-signatures are the stable surface callers migrate to now.
+Image ingestion uses the capability-typed registry. Other callers delegate to the
+legacy embedding manager while they are migrated.
 """
 
 from __future__ import annotations
@@ -24,11 +19,14 @@ from lightly_studio.dataset.embedding_manager import (
     EmbeddingManagerProvider,
     TextEmbedQuery,
 )
+from lightly_studio.embed import embedder_registry, embedding_storage
+from lightly_studio.models.collection import SampleType
 from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
 from lightly_studio.resolvers import (
     collection_embedding_model_resolver,
     collection_resolver,
     embedding_model_resolver,
+    image_resolver,
 )
 
 logger = logging.getLogger(__name__)
@@ -74,24 +72,38 @@ def embed_text_for_collection(collection_id: UUID, text: str) -> list[float]:
 def embed_image_samples(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> None:
     """Embed image samples with the collection's default model and store the result.
 
-    Does nothing (and logs a warning) if the collection has no usable default model.
+    Creates a missing default from the image-path bootstrap provider. Logs a warning
+    and skips embedding if no compatible provider is available. Invalid sample IDs
+    fail before default creation; later embedding failures leave the default persisted.
 
     Args:
         session: Database session for resolver operations.
         collection_id: The collection whose default embedding model is used.
         sample_ids: Image sample IDs to embed.
     """
-    manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = manager.load_or_get_default_model(session=session, collection_id=collection_id)
-    if model_id is None:
-        logger.warning("No embedding model loaded. Skipping embedding generation.")
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(f"Collection {collection_id} not found.")
+    if collection.sample_type != SampleType.IMAGE:
+        raise ValueError("Image embedding requires an image collection.")
+    if not sample_ids:
         return
-
-    manager.embed_images(
+    images = image_resolver.get_many_by_id(session=session, sample_ids=sample_ids)
+    if len(images) != len(sample_ids):
+        raise ValueError("Some image sample IDs were not found.")
+    if any(image.sample.collection_id != collection_id for image in images):
+        raise ValueError("Image samples must belong to the requested collection.")
+    resolved = _resolve_for_embedding(
         session=session,
         collection_id=collection_id,
-        sample_ids=sample_ids,
-        embedding_model_id=model_id,
+        get_embedder=embedder_registry.get_registry().get_image_path_embedder,
+    )
+    if resolved is None:
+        return
+    embedder, model_id = resolved
+    result = embedder.embed_images(paths=[image.file_path_abs for image in images])
+    embedding_storage.store_embedding_result(
+        session=session, model_id=model_id, sample_ids=sample_ids, result=result
     )
 
 
@@ -202,7 +214,6 @@ def collection_has_default_embedder(session: Session, collection_id: UUID) -> bo
 def _resolve_for_embedding(
     session: Session,
     collection_id: UUID,
-    capability: Capability,
     get_embedder: Callable[[str | None], _EmbedderT | None],
 ) -> tuple[_EmbedderT, UUID] | None:
     """Resolve or create the collection default for offline embedding."""
@@ -217,8 +228,7 @@ def _resolve_for_embedding(
     embedder = get_embedder(model.name)
     if embedder is None:
         logger.warning(
-            "No %s embedder for space %r. Skipping embedding generation.",
-            capability.value,
+            "No compatible embedder for space %r. Skipping embedding generation.",
             model.name,
         )
         return None

--- a/lightly_studio/src/lightly_studio/embed/embedding_storage.py
+++ b/lightly_studio/src/lightly_studio/embed/embedding_storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 import numpy as np
+from lightly_studio_serve.types import EmbeddingResult
 from numpy.typing import NDArray
 from sqlmodel import Session
 from tqdm import tqdm
@@ -16,6 +17,23 @@ from lightly_studio.utils import batching
 # Number of embeddings inserted per database round-trip. Larger batches mean fewer
 # round-trips but higher peak memory. 1024 balances the two.
 EMBEDDING_INSERTION_BATCH_SIZE = 1024
+
+
+def store_embedding_result(
+    session: Session, model_id: UUID, sample_ids: list[UUID], result: EmbeddingResult
+) -> None:
+    """Validate kept input indices and store their corresponding sample embeddings."""
+    indices = result.kept_indices
+    if any(index < 0 or index >= len(sample_ids) for index in indices):
+        raise ValueError("Embedding kept indices are out of range.")
+    if any(left >= right for left, right in zip(indices, indices[1:])):
+        raise ValueError("Embedding kept indices must be strictly increasing.")
+    store_embeddings(
+        session=session,
+        model_id=model_id,
+        sample_ids=[sample_ids[index] for index in indices],
+        embeddings=result.embeddings,
+    )
 
 
 def store_embeddings(

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -24,6 +24,9 @@ from lightly_studio.database.db_manager import DatabaseBackend, DatabaseEngine
 from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import RandomEmbeddingGenerator
 from lightly_studio.dataset.embedding_manager import EmbeddingManager, EmbeddingManagerProvider
+from lightly_studio.embed import embedder_registry
+from lightly_studio.embed.embedder_registry import EmbedderRegistry
+from lightly_studio.embed.random_embedder import RandomEmbedder
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
     AnnotationCreate,
@@ -570,6 +573,10 @@ def patch_collection(
         "_load_embedding_generator_from_env",
         return_value=RandomEmbeddingGenerator(),
     )
+
+    registry = EmbedderRegistry()
+    registry.register(embedder=RandomEmbedder())
+    mocker.patch.object(embedder_registry, "_registry", registry)
 
     # Create test-specific lightly_studio_active_features.
     mocker.patch.object(features, "lightly_studio_active_features", [])

--- a/lightly_studio/tests/core/test_dataset.py
+++ b/lightly_studio/tests/core/test_dataset.py
@@ -12,7 +12,7 @@ from lightly_studio.core.dataset_query.order_by import OrderByField
 from lightly_studio.core.image import image_dataset
 from lightly_studio.core.video.video_dataset import VideoDataset
 from lightly_studio.database import db_manager
-from lightly_studio.dataset import embedding_manager
+from lightly_studio.embed import embedder_registry
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import image_resolver, tag_resolver
 from tests.helpers_resolvers import (
@@ -458,8 +458,8 @@ def test_generate_embeddings__no_generator(
     patch_collection: None,  # noqa: ARG001
 ) -> None:
     mocker.patch.object(
-        embedding_manager,
-        "_load_embedding_generator_from_env",
+        embedder_registry.get_registry(),
+        "get_image_path_embedder",
         return_value=None,
     )
 
@@ -480,7 +480,7 @@ def test_generate_embeddings__empty_sample_ids(
     mocker: MockerFixture,
     patch_collection: None,  # noqa: ARG001
 ) -> None:
-    spy_load_model = mocker.spy(embedding_manager, "_load_embedding_generator_from_env")
+    spy_load_model = mocker.spy(embedder_registry.get_registry(), "get_image_path_embedder")
 
     session = db_manager.persistent_session()
     dataset = create_collection(session=session)

--- a/lightly_studio/tests/embed/test_embed_image_samples.py
+++ b/lightly_studio/tests/embed/test_embed_image_samples.py
@@ -1,0 +1,148 @@
+"""Image ingestion through the embedding registry."""
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+from lightly_studio_serve.types import EmbeddingResult
+from pytest_mock import MockerFixture
+from sqlmodel import Session, select
+
+from lightly_studio.embed import embed_samples, embedder_registry
+from lightly_studio.embed.embedder_registry import EmbedderRegistry
+from lightly_studio.embed.random_embedder import RandomEmbedder
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from tests.helpers_resolvers import ImageStub, create_collection, create_image, create_images
+
+
+@pytest.fixture
+def image_embedder(mocker: MockerFixture) -> RandomEmbedder:
+    registry = EmbedderRegistry()
+    embedder = RandomEmbedder()
+    registry.register(embedder=embedder)
+    mocker.patch.object(embedder_registry, "_registry", registry)
+    mocker.patch.object(embedder_registry, "_load_builtin_embedder", return_value=None)
+    return embedder
+
+
+@pytest.mark.parametrize("kept_indices", [[0, 1], [1], []])
+def test_embed_image_samples(
+    db_session: Session,
+    image_embedder: RandomEmbedder,
+    mocker: MockerFixture,
+    kept_indices: list[int],
+) -> None:
+    collection = create_collection(session=db_session)
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="/a.jpg"), ImageStub(path="/b.jpg")],
+    )
+    sample_ids = [image.sample_id for image in reversed(images)]
+    vectors = np.array([[index, 2, 3] for index in kept_indices], dtype=np.float32).reshape(-1, 3)
+    embed = mocker.patch.object(
+        type(image_embedder),
+        "embed_images",
+        return_value=EmbeddingResult(embeddings=vectors, kept_indices=kept_indices),
+    )
+    embed_samples.embed_image_samples(
+        session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+    )
+    embed.assert_called_once_with(paths=["/b.jpg", "/a.jpg"])
+    model = embed_samples._get_default_model(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert model is not None
+    assert model.name == "random_model"
+    rows = db_session.exec(select(SampleEmbeddingTable)).all()
+    assert {row.sample_id for row in rows} == {sample_ids[index] for index in kept_indices}
+    for row in rows:
+        assert row.embedding_model_id == model.embedding_model_id
+        np.testing.assert_array_equal(row.embedding, [sample_ids.index(row.sample_id), 2, 3])
+
+
+@pytest.mark.parametrize(
+    "case", ["missing_collection", "wrong_type", "empty", "missing_id", "foreign_id"]
+)
+def test_embed_image_samples__guards(
+    db_session: Session, image_embedder: RandomEmbedder, mocker: MockerFixture, case: str
+) -> None:
+    collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.VIDEO if case == "wrong_type" else SampleType.IMAGE,
+    )
+    collection_id = uuid4() if case == "missing_collection" else collection.collection_id
+    sample_ids = [] if case == "empty" else [uuid4()]
+    if case == "foreign_id":
+        other = create_collection(session=db_session, collection_name="other")
+        sample_ids = [create_image(session=db_session, collection_id=other.collection_id).sample_id]
+    embed = mocker.spy(type(image_embedder), "embed_images")
+    resolve = mocker.spy(embedder_registry.get_registry(), "get_image_path_embedder")
+    if case == "empty":
+        embed_samples.embed_image_samples(
+            session=db_session, collection_id=collection_id, sample_ids=sample_ids
+        )
+    else:
+        with pytest.raises(ValueError, match=r"not found|requires an image collection|must belong"):
+            embed_samples.embed_image_samples(
+                session=db_session, collection_id=collection_id, sample_ids=sample_ids
+            )
+    embed.assert_not_called()
+    resolve.assert_not_called()
+    assert (
+        embed_samples._get_default_model(session=db_session, collection_id=collection.collection_id)
+        is None
+    )
+
+
+@pytest.mark.usefixtures("image_embedder")
+def test_embed_image_samples__unavailable(
+    db_session: Session, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    mocker.patch.object(
+        embedder_registry.get_registry(), "get_image_path_embedder", return_value=None
+    )
+    embed_samples.embed_image_samples(
+        session=db_session, collection_id=collection.collection_id, sample_ids=[image.sample_id]
+    )
+    assert "Skipping embedding generation" in caplog.text
+    assert list(db_session.exec(select(SampleEmbeddingTable)).all()) == []
+    assert (
+        embed_samples._get_default_model(session=db_session, collection_id=collection.collection_id)
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("indices", "rows"), [([-1], 1), ([2], 1), ([0, 0], 2), ([1, 0], 2), ([0], 2), ([], 1)]
+)
+def test_embed_image_samples__invalid_result(
+    db_session: Session,
+    image_embedder: RandomEmbedder,
+    mocker: MockerFixture,
+    indices: list[int],
+    rows: int,
+) -> None:
+    collection = create_collection(session=db_session)
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[ImageStub(path="/a.jpg"), ImageStub(path="/b.jpg")],
+    )
+    mocker.patch.object(
+        type(image_embedder),
+        "embed_images",
+        return_value=EmbeddingResult(
+            embeddings=np.zeros((rows, 3), dtype=np.float32), kept_indices=indices
+        ),
+    )
+    with pytest.raises(ValueError, match=r"indices|Number of embeddings"):
+        embed_samples.embed_image_samples(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_ids=[image.sample_id for image in images],
+        )
+    assert list(db_session.exec(select(SampleEmbeddingTable)).all()) == []

--- a/lightly_studio/tests/embed/test_embed_samples.py
+++ b/lightly_studio/tests/embed/test_embed_samples.py
@@ -27,12 +27,10 @@ from lightly_studio.resolvers import (
     sample_embedding_resolver,
 )
 from tests.helpers_resolvers import (
-    ImageStub,
     create_annotation,
     create_annotation_label,
     create_collection,
     create_image,
-    create_images,
 )
 from tests.resolvers.video.helpers import (
     VideoStub,
@@ -123,57 +121,6 @@ def test_embed_text_for_collection__no_default_model(
         embed_samples.embed_text_for_collection(
             collection_id=collection.collection_id, text="a red car"
         )
-
-
-def test_embed_image_samples(
-    db_session: Session,
-    patched_manager: EmbeddingManager,
-) -> None:
-    """Image samples are embedded and stored under the collection's default model."""
-    collection = create_collection(session=db_session)
-    samples = create_images(
-        db_session=db_session,
-        collection_id=collection.collection_id,
-        images=[ImageStub(path="/test/a.jpg"), ImageStub(path="/test/b.jpg")],
-    )
-    model_id = _register_default_random_model(
-        manager=patched_manager, session=db_session, collection_id=collection.collection_id
-    )
-    sample_ids = [sample.sample_id for sample in samples]
-
-    embed_samples.embed_image_samples(
-        session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
-    )
-
-    count = sample_embedding_resolver.get_embedding_count(
-        session=db_session, collection_id=collection.collection_id, embedding_model_id=model_id
-    )
-    assert count == len(sample_ids)
-
-
-@pytest.mark.usefixtures("patched_manager")
-def test_embed_image_samples__no_default_model_skips(
-    db_session: Session,
-    mocker: MockerFixture,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """With no default model, embedding is skipped, a warning logged, nothing stored."""
-    collection = create_collection(session=db_session)
-    samples = create_images(
-        db_session=db_session,
-        collection_id=collection.collection_id,
-        images=[ImageStub(path="/test/a.jpg"), ImageStub(path="/test/b.jpg")],
-    )
-    _disable_env_loader(mocker=mocker)
-    sample_ids = [sample.sample_id for sample in samples]
-
-    with caplog.at_level(level=logging.WARNING):
-        embed_samples.embed_image_samples(
-            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
-        )
-
-    assert "No embedding model loaded" in caplog.text
-    assert _stored_embeddings(session=db_session) == []
 
 
 def test_embed_annotation_collection(

--- a/lightly_studio/tests/embed/test_embed_samples_resolution.py
+++ b/lightly_studio/tests/embed/test_embed_samples_resolution.py
@@ -51,7 +51,6 @@ def test_resolve_for_embedding__persists_bootstrap_default(
     resolved = embed_samples._resolve_for_embedding(
         session=db_session,
         collection_id=collection.collection_id,
-        capability=Capability.IMAGE_PATH,
         get_embedder=registry.get_image_path_embedder,
     )
 
@@ -85,7 +84,6 @@ def test_resolve_for_embedding__preserves_existing_default(
     resolved = embed_samples._resolve_for_embedding(
         session=db_session,
         collection_id=collection.collection_id,
-        capability=Capability.IMAGE_PATH,
         get_embedder=registry.get_image_path_embedder,
     )
 
@@ -121,7 +119,6 @@ def test_resolve_for_embedding__reloads_persisted_builtin_by_key(
     resolved = embed_samples._resolve_for_embedding(
         session=db_session,
         collection_id=collection.collection_id,
-        capability=Capability.IMAGE_PATH,
         get_embedder=registry.get_image_path_embedder,
     )
 
@@ -147,7 +144,6 @@ def test_resolve_for_embedding__custom_default_requires_reregistration(
     unavailable = embed_samples._resolve_for_embedding(
         session=db_session,
         collection_id=collection.collection_id,
-        capability=Capability.IMAGE_PATH,
         get_embedder=registry.get_image_path_embedder,
     )
     custom = _FakeImageEmbedder(space_key="custom", dimension=2)
@@ -155,7 +151,6 @@ def test_resolve_for_embedding__custom_default_requires_reregistration(
     available = embed_samples._resolve_for_embedding(
         session=db_session,
         collection_id=collection.collection_id,
-        capability=Capability.IMAGE_PATH,
         get_embedder=registry.get_image_path_embedder,
     )
 
@@ -183,7 +178,6 @@ def test_resolve_for_embedding__rejects_runtime_dimension_conflict(
         embed_samples._resolve_for_embedding(
             session=db_session,
             collection_id=collection.collection_id,
-            capability=Capability.IMAGE_PATH,
             get_embedder=registry.get_image_path_embedder,
         )
 
@@ -255,6 +249,5 @@ def test_resolve_for_embedding__rejects_dataset_model_dimension_conflict(
         embed_samples._resolve_for_embedding(
             session=db_session,
             collection_id=collection.collection_id,
-            capability=Capability.IMAGE_PATH,
             get_embedder=registry.get_image_path_embedder,
         )


### PR DESCRIPTION
## What has changed and why?

- Route image ingestion through the embedder registry while preserving persisted collection defaults.
- Validate inputs and map skipped-image results to the correct sample IDs before storage.
- Replace image-ingestion tests and update scoped fixtures; test migration accounts for most of the diff.

PR4 of LIG-10707, stacked on #2277. Default persistence remains separate from embedding storage, so embedding failures retain the default.

## How has it been tested?

From `lightly_studio`:

- `make static-checks`
- `uv run pytest tests/embed/test_embed_image_samples.py tests/embed/test_embed_samples.py tests/embed/test_embed_samples_resolution.py tests/embed/test_embedding_storage.py tests/embed/test_embedder_registry.py tests/core/test_dataset.py -q` — 89 passed.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Alternative reviewer: Lőrincz-Molnár Szabolcs-Botond (recent embedding-manager contributor).
