### PR TITLE
Fix: Release unused GPU memory after embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reduce peak memory usage during image indexing by up to 45% by clearing unused GPU cache.
 - Increase max_concurrency of requests to the backend from 100 to 128 to reduce chance of seeing 503 errors in the frontend.
 - Improved metadata loading by reducing latency by up to 70% and increasing throughput by up to 4× under concurrent requests.
 - Speed up distribution plot tag comparisons by up to 4.9x by requesting and calculating only the metadata field being viewed.

--- a/lightly_studio/src/lightly_studio/embed/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/embed/image_crop_embedding.py
@@ -18,6 +18,7 @@ from lightly_studio.core.file_outcome_report import (
     FileOutcome,
     FileOutcomeReport,
 )
+from lightly_studio.embed import image_embedding
 from lightly_studio.embed.image_embedding import EmbeddingContext
 from lightly_studio.utils import executor, parallelize
 
@@ -149,6 +150,7 @@ def embed_image_crops_batched(
             progress_bar=progress_bar,
         )
 
+    image_embedding.release_gpu_cache(device=context.device)
     report.raise_if_all_failed()
     report.log_summary()
 

--- a/lightly_studio/src/lightly_studio/embed/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/embed/image_embedding.py
@@ -131,6 +131,16 @@ def embed_pil_images_batched(
     )
 
 
+def release_gpu_cache(device: torch.device) -> None:
+    """Release unused GPU memory while keeping model tensors loaded."""
+    if device.type == "cuda":
+        with torch.cuda.device(device):
+            torch.cuda.empty_cache()
+    elif device.type == "mps":
+        torch.mps.synchronize()
+        torch.mps.empty_cache()
+
+
 def _embed_items_batched(
     items: Sequence[_ItemT],
     preprocess_item: Callable[[_ItemT], torch.Tensor | None],
@@ -178,6 +188,7 @@ def _embed_items_batched(
         show_progress=show_progress,
         progress=progress,
     )
+    release_gpu_cache(device=context.device)
     return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
 
 


### PR DESCRIPTION
## What has changed and why?

- Clear unused GPU cache after image and crop embedding on Apple MPS and CUDA. (under some pytorch versions and on some systems cache is not freed. E.g. on macos with MPS memory is still occupied and with this PR resolved)
- Reduced memory after indexing 128 images from 3.2 GB to 1.8 GB in the macOS test. (this is the dummy dataset tested on my machine)

## How has it been tested?

- manual testing on notebook

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced peak memory usage during image indexing by releasing unused GPU memory after image embedding and crop processing.
  - Added memory cleanup support for CUDA and MPS devices.
- **Documentation**
  - Added changelog notes covering up to 45% lower peak memory usage during image indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->