### PR TITLE
Kondrat lig 10661 fuse lidar channels into one frame

### DIFF
--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -15,6 +15,13 @@ POSTGRES_STARTUP_TIMEOUT_SECONDS ?= 60
 MCAP_PATH ?= datasets/mcap/perception.mcap
 MCAP_MAX_FRAMES ?= 200
 MCAP_TOPIC ?=
+# The recording is both indexed and served from the same path, and the workspace route only
+# opens while the feature flag is on, so the two always travel together.
+MCAP_ENV := MCAP_PATH=$(MCAP_PATH) \
+	MCAP_MAX_FRAMES=$(MCAP_MAX_FRAMES) \
+	MCAP_TOPIC=$(MCAP_TOPIC) \
+	LIGHTLY_STUDIO_MCAP_RECORDING_PATH=$(MCAP_PATH) \
+	LIGHTLY_STUDIO_POINT_CLOUD_ENABLED=1
 
 # Installs the uv version that `required-version` in pyproject.toml pins, so a local
 # `uv lock` writes the same file the workflows do. Keep the version in sync with that pin.
@@ -124,15 +131,20 @@ start-e2e-video-groups: build
 
 # Override the recording, how many frames are indexed, and which channel, e.g.:
 #   make start-e2e-mcap-point-cloud MCAP_PATH=~/recordings/perception.mcap MCAP_MAX_FRAMES=500
+# The script prints every point-cloud channel it finds, and the workspace URL to open: the
+# route is not linked from the navigation yet.
 .PHONY: start-e2e-mcap-point-cloud
 start-e2e-mcap-point-cloud: build
 	@echo "Starting server for e2e point-cloud tests from $(MCAP_PATH)..."
-	MCAP_PATH=$(MCAP_PATH) \
-	MCAP_MAX_FRAMES=$(MCAP_MAX_FRAMES) \
-	MCAP_TOPIC=$(MCAP_TOPIC) \
-	LIGHTLY_STUDIO_MCAP_RECORDING_PATH=$(MCAP_PATH) \
-	LIGHTLY_STUDIO_POINT_CLOUD_ENABLED=1 \
-		uv run e2e-tests/index_mcap_point_cloud.py
+	$(MCAP_ENV) uv run e2e-tests/index_mcap_point_cloud.py
+
+# The same recording, rebuilding only the frontend bundle the server serves: the fast loop
+# while working on the workspace itself, since `build` reinstalls node modules and rebuilds
+# the wheel on every run. Takes the same MCAP_* overrides.
+.PHONY: start-mcap-point-cloud
+start-mcap-point-cloud: build-dirty-lightly_studio_view
+	@echo "Starting the point-cloud workspace from $(MCAP_PATH)..."
+	$(MCAP_ENV) uv run e2e-tests/index_mcap_point_cloud.py
 
 .PHONY: start-postgres
 start-postgres: stop-postgres

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/ProviderDiagnostics/useRecordingProbe.svelte.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/ProviderDiagnostics/useRecordingProbe.svelte.ts
@@ -245,9 +245,12 @@ async function open(
     const source = await resolveMcapSource({
         sampleId,
         url,
-        // The probe assumes one frame for every recording. Confirming the real sensor
-        // convention per recording is part of resolving a source properly.
-        coordinateFrameId: 'lidar'
+        // The frame every sensor is aligned into, not the frame of any one of them: these
+        // recordings publish their lidars relative to the vehicle cabin. The reader falls
+        // back to the read channel's own frame when a recording names its vehicle frame
+        // differently, so this stays a default rather than a requirement. Confirming it
+        // per recording is part of resolving a source properly.
+        coordinateFrameId: 'CABIN'
     });
     return createRecordingSession({
         source,

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/fuseClouds.test.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/fuseClouds.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { fuseClouds } from './fuseClouds';
+import { buildTransformGraph, resolveTransforms } from './transformTree';
+
+const transforms = resolveTransforms(
+    buildTransformGraph([
+        {
+            transforms: [
+                {
+                    header: { frame_id: 'CABIN' },
+                    child_frame_id: 'lidar_rear_left',
+                    transform: {
+                        translation: { x: -2, y: 1, z: 0.5 },
+                        rotation: { x: 0, y: 0, z: 0, w: 1 }
+                    }
+                }
+            ]
+        }
+    ]),
+    'CABIN'
+);
+
+const cabinCloud = {
+    frameId: 'CABIN',
+    positions: new Float32Array([1, 1, 1]),
+    sourcePointCount: 1
+};
+const sensorCloud = {
+    frameId: 'lidar_rear_left',
+    positions: new Float32Array([0, 0, 0]),
+    sourcePointCount: 3
+};
+
+describe('fuseClouds', () => {
+    it('places each sweep where its sensor sits and concatenates them', () => {
+        const fused = fuseClouds([cabinCloud, sensorCloud], transforms);
+
+        expect([...fused.positions]).toEqual([1, 1, 1, -2, 1, 0.5]);
+    });
+
+    it('counts every point the sensors produced, not only the drawn ones', () => {
+        expect(fuseClouds([cabinCloud, sensorCloud], transforms).sourcePointCount).toBe(4);
+    });
+
+    it('leaves out a sweep whose frame is unknown, and names it', () => {
+        const orphan = {
+            frameId: 'lidar_roof',
+            positions: new Float32Array([9, 9, 9]),
+            sourcePointCount: 1
+        };
+
+        const fused = fuseClouds([cabinCloud, orphan], transforms);
+
+        expect([...fused.positions]).toEqual([1, 1, 1]);
+        expect(fused.skippedFrameIds).toEqual(['lidar_roof']);
+    });
+
+    it('returns an empty frame rather than failing when nothing can be placed', () => {
+        const fused = fuseClouds(
+            [{ frameId: 'unknown', positions: new Float32Array([1, 2, 3]), sourcePointCount: 1 }],
+            transforms
+        );
+
+        expect(fused.positions).toHaveLength(0);
+        expect(fused.sourcePointCount).toBe(1);
+    });
+});

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/fuseClouds.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/fuseClouds.ts
@@ -1,0 +1,38 @@
+import { transformPositionsInto, type RigidTransform } from './rigidTransform';
+
+/** One decoded sensor sweep, still in the frame its message declared. */
+export interface DecodedCloud {
+    /** `header.frame_id` of the sweep's message. */
+    readonly frameId: string;
+    readonly positions: Float32Array;
+    readonly sourcePointCount: number;
+}
+
+/**
+ * Places every sweep whose frame resolves into the target frame and concatenates them.
+ *
+ * A sweep whose frame does not resolve is left out rather than placed at the origin: one
+ * sensor drawn in the wrong place is harder to notice, and worse to label against, than
+ * one sensor missing. `skippedFrameIds` names those so a caller can report them.
+ */
+export function fuseClouds(
+    clouds: readonly DecodedCloud[],
+    transforms: ReadonlyMap<string, RigidTransform>
+) {
+    const placed = clouds.filter((cloud) => transforms.has(cloud.frameId));
+    const total = placed.reduce((count, cloud) => count + cloud.positions.length, 0);
+    const positions = new Float32Array(total);
+    let at = 0;
+    for (const cloud of placed) {
+        at = transformPositionsInto(positions, at, cloud.positions, transforms.get(cloud.frameId)!);
+    }
+    return {
+        positions,
+        // Every sweep read, including any skipped: this is what the sensors produced, which
+        // is the number the displayed count is worth comparing against.
+        sourcePointCount: clouds.reduce((count, cloud) => count + cloud.sourcePointCount, 0),
+        skippedFrameIds: clouds
+            .filter((cloud) => !transforms.has(cloud.frameId))
+            .map((cloud) => cloud.frameId)
+    };
+}

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/mcapFixture.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/mcapFixture.ts
@@ -28,11 +28,53 @@ uint8 datatype
 uint32 count
 `;
 
+const transformSchemaText = `geometry_msgs/TransformStamped[] transforms
+================================================================================
+MSG: geometry_msgs/TransformStamped
+std_msgs/Header header
+string child_frame_id
+geometry_msgs/Transform transform
+================================================================================
+MSG: std_msgs/Header
+builtin_interfaces/Time stamp
+string frame_id
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec
+================================================================================
+MSG: geometry_msgs/Transform
+geometry_msgs/Vector3 translation
+geometry_msgs/Quaternion rotation
+================================================================================
+MSG: geometry_msgs/Vector3
+float64 x
+float64 y
+float64 z
+================================================================================
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+`;
+
+/** Where the fixture's second lidar sits on its vehicle, in the CABIN frame. */
+export const RIGHT_LIDAR_MOUNT = { x: 10, y: -5, z: 1 };
+
 /**
  * Small real indexed MCAP recording for integration tests: duplicate epoch
  * timestamps on a supported lidar channel plus one unsupported channel.
+ *
+ * `fused` adds what a vehicle recording really looks like: a second lidar, in its own
+ * frame, and the `/tf_static` that says where both sit on the vehicle. `omitTransforms`
+ * then leaves that `/tf_static` out, which is a recording whose sensors cannot be aligned.
  */
-export async function mcapFixture({ compressed = false } = {}) {
+export async function mcapFixture({
+    compressed = false,
+    fused = false,
+    omitTransforms = false
+} = {}) {
     const chunks: Uint8Array[] = [];
     let length = 0;
     const writer = new McapWriter({
@@ -62,33 +104,33 @@ export async function mcapFixture({ compressed = false } = {}) {
     const encoder = new MessageWriter(parse(schemaText, { ros2: true }));
     const timestamp = 1_789_000_000_000_000_001n;
     for (const x of [1, 4]) {
-        const data = new Uint8Array(12);
-        const view = new DataView(data.buffer);
-        [x, 2, 3].forEach((v, i) => view.setFloat32(i * 4, v, true));
-        const payload = encoder.writeMessage({
-            header: { stamp: { sec: 1, nanosec: 2 }, frame_id: 'lidar' },
-            height: 1,
-            width: 1,
-            point_step: 12,
-            row_step: 12,
-            data,
-            is_bigendian: false,
-            is_dense: true,
-            fields: ['x', 'y', 'z'].map((name, i) => ({
-                name,
-                offset: i * 4,
-                datatype: 7,
-                count: 1
-            }))
-        });
-        await writer.addMessage({
+        await writeSweep(writer, encoder, {
             channelId,
-            logTime: timestamp,
-            publishTime: timestamp - 1n,
-            sequence: 0,
-            data: payload
+            timestamp,
+            frameId: 'lidar',
+            point: [x, 2, 3]
         });
     }
+
+    let rightChannelId: number | undefined;
+    if (fused) {
+        rightChannelId = await writer.registerChannel({
+            topic: '/lidar_right',
+            schemaId,
+            messageEncoding: 'cdr',
+            metadata: new Map()
+        });
+        // One point at the sensor's own origin, so a fused frame shows it exactly at the
+        // mount `/tf_static` gives that sensor.
+        await writeSweep(writer, encoder, {
+            channelId: rightChannelId,
+            timestamp,
+            frameId: 'lidar_right',
+            point: [0, 0, 0]
+        });
+        if (!omitTransforms) await writeStaticTransforms(writer, timestamp);
+    }
+
     const unsupportedChannelId = await writer.registerChannel({
         topic: '/imu',
         schemaId: await writer.registerSchema({
@@ -113,5 +155,79 @@ export async function mcapFixture({ compressed = false } = {}) {
         bytes.set(chunk, offset);
         offset += chunk.length;
     }
-    return { bytes, channelId, unsupportedChannelId, timestamp };
+    return { bytes, channelId, rightChannelId, unsupportedChannelId, timestamp };
+}
+
+interface SweepOptions {
+    channelId: number;
+    timestamp: bigint;
+    frameId: string;
+    point: [number, number, number];
+}
+
+async function writeSweep(
+    writer: McapWriter,
+    encoder: MessageWriter,
+    { channelId, timestamp, frameId, point }: SweepOptions
+) {
+    const data = new Uint8Array(12);
+    const view = new DataView(data.buffer);
+    point.forEach((value, index) => view.setFloat32(index * 4, value, true));
+    await writer.addMessage({
+        channelId,
+        logTime: timestamp,
+        publishTime: timestamp - 1n,
+        sequence: 0,
+        data: encoder.writeMessage({
+            header: { stamp: { sec: 1, nanosec: 2 }, frame_id: frameId },
+            height: 1,
+            width: 1,
+            point_step: 12,
+            row_step: 12,
+            data,
+            is_bigendian: false,
+            is_dense: true,
+            fields: ['x', 'y', 'z'].map((name, index) => ({
+                name,
+                offset: index * 4,
+                datatype: 7,
+                count: 1
+            }))
+        })
+    });
+}
+
+/** Publishes both lidars as children of the vehicle frame, the way a rig is calibrated. */
+async function writeStaticTransforms(writer: McapWriter, timestamp: bigint) {
+    const channelId = await writer.registerChannel({
+        topic: '/tf_static',
+        schemaId: await writer.registerSchema({
+            name: 'tf2_msgs/msg/TFMessage',
+            encoding: 'ros2msg',
+            data: new TextEncoder().encode(transformSchemaText)
+        }),
+        messageEncoding: 'cdr',
+        metadata: new Map()
+    });
+    const identity = { x: 0, y: 0, z: 0, w: 1 };
+    await writer.addMessage({
+        channelId,
+        logTime: timestamp - 1n,
+        publishTime: timestamp - 1n,
+        sequence: 0,
+        data: new MessageWriter(parse(transformSchemaText, { ros2: true })).writeMessage({
+            transforms: [
+                {
+                    header: { stamp: { sec: 1, nanosec: 0 }, frame_id: 'CABIN' },
+                    child_frame_id: 'lidar',
+                    transform: { translation: { x: 0, y: 0, z: 0 }, rotation: identity }
+                },
+                {
+                    header: { stamp: { sec: 1, nanosec: 0 }, frame_id: 'CABIN' },
+                    child_frame_id: 'lidar_right',
+                    transform: { translation: RIGHT_LIDAR_MOUNT, rotation: identity }
+                }
+            ]
+        })
+    });
 }

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/mcapReader.test.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/mcapReader.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { decompress } from 'lz4js';
 import { canonicalCoordinateFrame, createPointCloudFrame } from '../domain';
-import { mcapFixture } from './mcapFixture';
+import { mcapFixture, RIGHT_LIDAR_MOUNT } from './mcapFixture';
 import { openMcap } from './mcapReader';
 
 // Spied rather than replaced: listing frames must not decompress a single chunk, while
@@ -32,13 +32,13 @@ function serve(bytes: Uint8Array) {
     );
 }
 
-function sourceFor(bytes: Uint8Array) {
+function sourceFor(bytes: Uint8Array, coordinateFrameId = 'lidar') {
     return {
         recordingId: 'r',
         version: 'v1',
         url: '/recording',
         sizeBytes: String(bytes.length),
-        coordinateFrame: canonicalCoordinateFrame('lidar'),
+        coordinateFrame: canonicalCoordinateFrame(coordinateFrameId),
         logClockId: 'log',
         publishClockId: 'publish'
     };
@@ -160,5 +160,114 @@ describe('openMcap', () => {
         await expect(
             session.listFrames(channelId, logTimeNs, logTimeNs, 1001)
         ).rejects.toMatchObject({ code: 'source' });
+    });
+});
+
+describe('openMcap with several lidar channels', () => {
+    async function fusedSession(coordinateFrameId = 'CABIN') {
+        const fixture = await mcapFixture({ fused: true });
+        serve(fixture.bytes);
+        const session = await openMcap(
+            sourceFor(fixture.bytes, coordinateFrameId),
+            new AbortController().signal
+        );
+        return { ...fixture, session };
+    }
+
+    it('fuses every lidar into the frame, placed by /tf_static', async () => {
+        const { session, channelId, timestamp } = await fusedSession();
+
+        const range = await session.listFrames(
+            channelId,
+            timestamp.toString(),
+            timestamp.toString()
+        );
+        const frame = createPointCloudFrame(await session.loadFrame(range.frames[0], 10));
+
+        // The read channel's own point, then the other sensor's origin at its mount: the
+        // second sensor is what a single-channel read leaves as empty space.
+        expect([...frame.positions.copy()]).toEqual([
+            1,
+            2,
+            3,
+            RIGHT_LIDAR_MOUNT.x,
+            RIGHT_LIDAR_MOUNT.y,
+            RIGHT_LIDAR_MOUNT.z
+        ]);
+        expect(frame.sourcePointCount).toBe(2);
+    });
+
+    it('reports the frame everything was aligned into, not the sensor frame', async () => {
+        const { session, channelId, timestamp } = await fusedSession();
+        const range = await session.listFrames(
+            channelId,
+            timestamp.toString(),
+            timestamp.toString()
+        );
+
+        const frame = await session.loadFrame(range.frames[0], 10);
+
+        expect(frame.coordinateFrame.id).toBe('CABIN');
+    });
+
+    it('keeps frame identity on the channel the frame was listed on', async () => {
+        const { session, channelId, rightChannelId, timestamp } = await fusedSession();
+        const range = await session.listFrames(
+            channelId,
+            timestamp.toString(),
+            timestamp.toString()
+        );
+
+        const frame = await session.loadFrame(range.frames[0], 10);
+
+        expect(frame.source.streamId).toBe(String(channelId));
+        expect(frame.source.streamId).not.toBe(String(rightChannelId));
+    });
+
+    it('falls back to the read channel frame when the target is not in /tf_static', async () => {
+        const { session, channelId, timestamp } = await fusedSession('VEHICLE');
+        const range = await session.listFrames(
+            channelId,
+            timestamp.toString(),
+            timestamp.toString()
+        );
+
+        const frame = createPointCloudFrame(await session.loadFrame(range.frames[0], 10));
+
+        // 'lidar' sits at the CABIN origin here, so the other sensor still resolves into it.
+        expect(frame.coordinateFrame.id).toBe('lidar');
+        expect(frame.positions.length).toBe(6);
+    });
+
+    it('splits the point budget across the channels it fuses', async () => {
+        const { session, channelId, timestamp } = await fusedSession();
+        const range = await session.listFrames(
+            channelId,
+            timestamp.toString(),
+            timestamp.toString()
+        );
+
+        // One point per sweep survives a budget of one point per channel.
+        const frame = await session.loadFrame(range.frames[0], 2);
+
+        expect(frame.positions.length).toBe(6);
+    });
+
+    it('refuses to align lidars a recording gives no transforms for', async () => {
+        const { bytes, channelId, timestamp } = await mcapFixture({
+            fused: true,
+            omitTransforms: true
+        });
+        serve(bytes);
+        const session = await openMcap(sourceFor(bytes, 'CABIN'), new AbortController().signal);
+        const range = await session.listFrames(
+            channelId,
+            timestamp.toString(),
+            timestamp.toString()
+        );
+
+        await expect(session.loadFrame(range.frames[0], 10)).rejects.toMatchObject({
+            code: 'source'
+        });
     });
 });

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/mcapReader.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/mcapReader.ts
@@ -1,15 +1,34 @@
 import { MessageReader } from '@foxglove/rosmsg2-serialization';
 import { parse } from '@foxglove/rosmsg';
-import { McapIndexedReader } from '@mcap/core';
+import { McapIndexedReader, type TypedMcapRecords } from '@mcap/core';
 import { decompress } from 'lz4js';
 import { ZSTDDecoder } from 'zstddec';
 import { canonicalCoordinateFrame, assertCompatibleCoordinates } from '../domain';
+import { fuseClouds } from './fuseClouds';
 import { HttpRangeReadable } from './httpRangeReadable';
 import { decodePointCloud2 } from './pointCloud2';
 import { ProviderError } from './providerError';
 import { frameIdentity, type FrameLocator, type McapSource } from './source';
+import {
+    buildTransformGraph,
+    resolveTransforms,
+    type TransformGraph,
+    type TransformMessage
+} from './transformTree';
+
+type Channel = TypedMcapRecords['Channel'];
 
 const maxChunkBytes = 64 * 1024 * 1024;
+/** Where ROS 2 publishes the sensor extrinsics that place each lidar on the vehicle. */
+const TF_STATIC_TOPIC = '/tf_static';
+/**
+ * How far from the anchor sweep another channel's sweep may sit and still be the same moment.
+ *
+ * Lidars on one vehicle are not triggered together, so their sweeps land milliseconds apart.
+ * 50 ms is under one period at the 10 Hz these sensors run at, which is what makes "the
+ * nearest sweep in the window" unambiguous.
+ */
+const FUSION_WINDOW_NS = 50_000_000n;
 /** MCAP record framing: one opcode byte plus a little-endian u64 content length. */
 const RECORD_HEADER_BYTES = 9;
 const MESSAGE_INDEX_OPCODE = 0x07;
@@ -54,7 +73,12 @@ export async function openMcap(source: McapSource, signal: AbortSignal) {
         firstLogTimeNs: reader.statistics?.messageStartTime.toString() ?? null,
         lastLogTimeNs: reader.statistics?.messageEndTime.toString() ?? null
     };
-    const decoders = new Map<number, MessageReader<Parameters<typeof decodePointCloud2>[0]>>();
+    const decoders = new Map<number, MessageReader>();
+    const lidarChannels = Array.from(reader.channelsById.values()).filter((channel) =>
+        isSupported(channel.messageEncoding, reader.schemasById.get(channel.schemaId))
+    );
+    /** Read at most once per recording: extrinsics are static, and every frame needs them. */
+    let publishedTransforms: Promise<TransformGraph> | undefined;
 
     async function loadFrame(locator: FrameLocator, pointBudget: number) {
         validateLocator(locator);
@@ -76,33 +100,140 @@ export async function openMcap(source: McapSource, signal: AbortSignal) {
             signal.throwIfAborted();
             if (message.channelId !== locator.channelId || occurrence++ !== locator.occurrence)
                 continue;
-            let decoder = decoders.get(channel.id);
-            if (!decoder) {
-                decoder = messageReader(schema);
-                decoders.set(channel.id, decoder);
-            }
-            const decoded = decodePointCloud2(decoder.readMessage(message.data), pointBudget);
-            return {
-                ...decoded,
-                id: frameIdentity(source, locator),
-                source: {
-                    recordingId: source.recordingId,
-                    streamId: String(channel.id),
-                    messageId: JSON.stringify([locator.logTimeNs, locator.occurrence]),
-                    publishedAt: {
-                        nanoseconds: message.publishTime.toString(),
-                        clockId: source.publishClockId
-                    }
-                },
-                timestamp: { nanoseconds: message.logTime.toString(), clockId: source.logClockId },
-                coordinateFrame: source.coordinateFrame,
-                cameras: []
-            };
+            return fuseFrame(channel, message, locator, pointBudget);
         }
         throw new ProviderError(
             'source',
             'The requested point-cloud frame is missing from the recording.'
         );
+    }
+
+    /**
+     * Builds one frame from every lidar channel, aligned into a single coordinate frame.
+     *
+     * A vehicle's sensors cover the scene between them, so reading only the channel a frame
+     * is listed on leaves everything the other sensors saw empty. The anchor message still
+     * decides the frame's identity, timestamp and stream, which keeps listing, navigation
+     * and annotation identity unchanged by what is fused into it.
+     */
+    async function fuseFrame(
+        channel: Channel,
+        message: TypedMcapRecords['Message'],
+        locator: FrameLocator,
+        pointBudget: number
+    ) {
+        const budget = Math.max(1, Math.floor(pointBudget / lidarChannels.length));
+        const anchor = decodeCloud(channel, message.data, budget);
+        const siblings = await readSiblings(channel.id, message.logTime, budget);
+        const { targetFrameId, transforms } = await alignment(anchor.frameId);
+        const fused = fuseClouds([anchor, ...siblings], transforms);
+        return {
+            positions: fused.positions,
+            sourcePointCount: fused.sourcePointCount,
+            id: frameIdentity(source, locator),
+            source: {
+                recordingId: source.recordingId,
+                streamId: String(channel.id),
+                messageId: JSON.stringify([locator.logTimeNs, locator.occurrence]),
+                publishedAt: {
+                    nanoseconds: message.publishTime.toString(),
+                    clockId: source.publishClockId
+                }
+            },
+            timestamp: { nanoseconds: message.logTime.toString(), clockId: source.logClockId },
+            coordinateFrame: canonicalCoordinateFrame(targetFrameId),
+            cameras: []
+        };
+    }
+
+    /** The sweep nearest the anchor's log time on each of the other lidar channels. */
+    async function readSiblings(anchorChannelId: number, anchorTime: bigint, budget: number) {
+        const others = lidarChannels.filter((channel) => channel.id !== anchorChannelId);
+        if (others.length === 0) return [];
+        const nearest = new Map<number, { delta: bigint; data: Uint8Array }>();
+        for await (const message of reader.readMessages({
+            topics: others.map((channel) => channel.topic),
+            startTime: anchorTime > FUSION_WINDOW_NS ? anchorTime - FUSION_WINDOW_NS : 0n,
+            endTime: anchorTime + FUSION_WINDOW_NS,
+            validateCrcs: true
+        })) {
+            signal.throwIfAborted();
+            if (!others.some((channel) => channel.id === message.channelId)) continue;
+            const delta = absoluteDelta(message.logTime, anchorTime);
+            const best = nearest.get(message.channelId);
+            if (best && best.delta <= delta) continue;
+            // Copied: the iterator hands out views over a chunk it is free to reuse.
+            nearest.set(message.channelId, { delta, data: message.data.slice() });
+        }
+        // Decoded after the window closes, so a channel costs one decode however many of its
+        // sweeps the window happened to hold.
+        return Array.from(nearest, ([channelId, { data }]) =>
+            decodeCloud(reader.channelsById.get(channelId)!, data, budget)
+        );
+    }
+
+    /**
+     * Resolves where each sensor frame sits, and which frame the fused points end up in.
+     *
+     * One lidar needs no transform at all, so a single-channel recording never reads
+     * `/tf_static`. With several, the frame the caller asked for is the target when
+     * `/tf_static` knows it, and the anchor's own frame otherwise -- a recording whose
+     * vehicle frame is named differently still renders in a frame that is real, with
+     * whatever other sensors resolve into it.
+     */
+    async function alignment(anchorFrameId: string) {
+        const frameId = anchorFrameId || source.coordinateFrame.id;
+        if (lidarChannels.length < 2) {
+            return { targetFrameId: frameId, transforms: resolveTransforms(new Map(), frameId) };
+        }
+        const graph = await (publishedTransforms ??= readTransformGraph());
+        const targetFrameId = graph.has(source.coordinateFrame.id)
+            ? source.coordinateFrame.id
+            : frameId;
+        return { targetFrameId, transforms: resolveTransforms(graph, targetFrameId) };
+    }
+
+    async function readTransformGraph(): Promise<TransformGraph> {
+        const channel = Array.from(reader.channelsById.values()).find(
+            (candidate) => candidate.topic === TF_STATIC_TOPIC
+        );
+        if (!channel) {
+            throw new ProviderError(
+                'source',
+                `This recording has ${lidarChannels.length} lidar channels but no ${TF_STATIC_TOPIC} saying where they sit, so they cannot be aligned into one scene.`
+            );
+        }
+        const messages: TransformMessage[] = [];
+        for await (const message of reader.readMessages({
+            topics: [channel.topic],
+            validateCrcs: true
+        })) {
+            signal.throwIfAborted();
+            messages.push(decoderFor(channel).readMessage<TransformMessage>(message.data));
+        }
+        return buildTransformGraph(messages);
+    }
+
+    function decodeCloud(channel: Channel, data: Uint8Array, budget: number) {
+        return decodePointCloud2(
+            decoderFor(channel).readMessage<Parameters<typeof decodePointCloud2>[0]>(data),
+            budget
+        );
+    }
+
+    function decoderFor(channel: Channel): MessageReader {
+        const existing = decoders.get(channel.id);
+        if (existing) return existing;
+        const schema = reader.schemasById.get(channel.schemaId);
+        if (!schema || schema.encoding !== 'ros2msg') {
+            throw new ProviderError(
+                'schema',
+                `The channel '${channel.topic}' does not carry a ros2msg schema to decode.`
+            );
+        }
+        const created = messageReader(schema);
+        decoders.set(channel.id, created);
+        return created;
     }
 
     async function listFrames(
@@ -200,11 +331,9 @@ export async function openMcap(source: McapSource, signal: AbortSignal) {
  * missing a referenced message type, most often -- which is a problem with the recording's
  * schema rather than with its payload, so it is reported as one.
  */
-function messageReader(schema: { name: string; data: Uint8Array }) {
+function messageReader(schema: { name: string; data: Uint8Array }): MessageReader {
     try {
-        return new MessageReader<Parameters<typeof decodePointCloud2>[0]>(
-            parse(new TextDecoder().decode(schema.data), { ros2: true })
-        );
+        return new MessageReader(parse(new TextDecoder().decode(schema.data), { ros2: true }));
     } catch (error) {
         throw new ProviderError(
             'schema',
@@ -246,6 +375,10 @@ function collectTimes(view: DataView, contentStart: number, times: bigint[]): vo
     for (let at = recordsStart; at + INDEX_ENTRY_BYTES <= recordsEnd; at += INDEX_ENTRY_BYTES) {
         times.push(view.getBigUint64(at, true));
     }
+}
+
+function absoluteDelta(left: bigint, right: bigint): bigint {
+    return left > right ? left - right : right - left;
 }
 
 function isSupported(encoding: string, schema: { name: string; encoding: string } | undefined) {

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/pointCloud2.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/pointCloud2.ts
@@ -8,6 +8,8 @@ interface PointField {
 }
 
 interface PointCloud2Message {
+    /** Sensor frame the points are expressed in; absent in recordings without a header. */
+    header?: { frame_id?: string };
     height: number;
     width: number;
     fields: PointField[];
@@ -29,7 +31,12 @@ const scalarTypes: Record<number, { bytes: number; read: ReadScalar }> = {
     8: { bytes: 8, read: (v, o, le) => v.getFloat64(o, le) }
 };
 
-/** Decode ROS PointCloud2 in its declared sensor frame; no implicit axes conversion. */
+/**
+ * Decode ROS PointCloud2 in its declared sensor frame; no implicit axes conversion.
+ *
+ * The declared frame is returned rather than applied: placing the sweep is the reader's
+ * job, since only it can read `/tf_static` to learn where that frame sits.
+ */
 export function decodePointCloud2(message: PointCloud2Message, pointBudget = 350_000) {
     validateLayout(message, pointBudget);
     const readers = ['x', 'y', 'z'].map((name) => fieldReader(message, name));
@@ -51,7 +58,11 @@ export function decodePointCloud2(message: PointCloud2Message, pointBudget = 350
         positions.set(point, length);
         length += 3;
     }
-    return { positions: positions.slice(0, length), sourcePointCount };
+    return {
+        positions: positions.slice(0, length),
+        sourcePointCount,
+        frameId: message.header?.frame_id ?? ''
+    };
 }
 
 function validateShape(message: PointCloud2Message): void {

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/rigidTransform.test.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/rigidTransform.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+    composeTransforms,
+    IDENTITY_TRANSFORM,
+    invertTransform,
+    rigidTransform,
+    transformPositionsInto
+} from './rigidTransform';
+
+/** A quarter turn about z, the yaw that mounts a sensor facing left. */
+const QUARTER_TURN = Math.SQRT1_2;
+
+describe('rigidTransform', () => {
+    it('turns a quaternion into the rotation it describes', () => {
+        const transform = rigidTransform([0, 0, 0], [0, 0, QUARTER_TURN, QUARTER_TURN])!;
+
+        expect([...transform.rotation].map((value) => Math.round(value))).toEqual([
+            0, -1, 0, 1, 0, 0, 0, 0, 1
+        ]);
+    });
+
+    it('normalizes a quaternion that is not quite unit length', () => {
+        const scaled = rigidTransform([0, 0, 0], [0, 0, QUARTER_TURN * 3, QUARTER_TURN * 3])!;
+
+        scaled.rotation.forEach((value, index) => {
+            expect(value).toBeCloseTo([0, -1, 0, 1, 0, 0, 0, 0, 1][index], 6);
+        });
+    });
+
+    it('refuses a rotation it cannot describe rather than guessing one', () => {
+        expect(rigidTransform([0, 0, 0], [0, 0, 0, 0])).toBeNull();
+        expect(rigidTransform([Number.NaN, 0, 0], [0, 0, 0, 1])).toBeNull();
+        expect(rigidTransform([0, 0, 0], [0, 0, Number.POSITIVE_INFINITY, 1])).toBeNull();
+    });
+});
+
+describe('composeTransforms', () => {
+    it('applies the inner transform first', () => {
+        const yaw = rigidTransform([0, 0, 0], [0, 0, QUARTER_TURN, QUARTER_TURN])!;
+        const shift = rigidTransform([1, 0, 0], [0, 0, 0, 1])!;
+
+        // Rotating after shifting sends the shift along +x onto +y.
+        const composed = composeTransforms(yaw, shift);
+
+        expect(composed.translation[0]).toBeCloseTo(0, 6);
+        expect(composed.translation[1]).toBeCloseTo(1, 6);
+    });
+
+    it('leaves a transform unchanged when composed with the identity', () => {
+        const transform = rigidTransform([2, -3, 1], [0, 0, QUARTER_TURN, QUARTER_TURN])!;
+
+        const composed = composeTransforms(IDENTITY_TRANSFORM, transform);
+
+        expect([...composed.rotation, ...composed.translation]).toEqual([
+            ...transform.rotation,
+            ...transform.translation
+        ]);
+    });
+});
+
+describe('invertTransform', () => {
+    it('undoes the transform it inverts', () => {
+        const transform = rigidTransform([2, -3, 1], [0, 0, QUARTER_TURN, QUARTER_TURN])!;
+
+        const roundTrip = composeTransforms(transform, invertTransform(transform));
+
+        roundTrip.rotation.forEach((value, index) => {
+            expect(value).toBeCloseTo(IDENTITY_TRANSFORM.rotation[index], 6);
+        });
+        roundTrip.translation.forEach((value) => expect(value).toBeCloseTo(0, 6));
+    });
+});
+
+describe('transformPositionsInto', () => {
+    it('writes the transformed points at the offset and reports the next one', () => {
+        const target = new Float32Array(9);
+        const yaw = rigidTransform([0, 0, 5], [0, 0, QUARTER_TURN, QUARTER_TURN])!;
+
+        const next = transformPositionsInto(target, 3, new Float32Array([1, 0, 0, 0, 2, 0]), yaw);
+
+        expect(next).toBe(9);
+        expect([...target].map((value) => Math.round(value))).toEqual([0, 0, 0, 0, 1, 5, -2, 0, 5]);
+    });
+});

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/rigidTransform.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/rigidTransform.ts
@@ -1,0 +1,99 @@
+import type { Quaternion, Vector3 } from '../domain';
+
+/** Row-major 3x3 rotation. */
+type Matrix3 = readonly [number, number, number, number, number, number, number, number, number];
+
+/** A pose: `p_parent = rotation * p_child + translation`, in meters. */
+export interface RigidTransform {
+    readonly rotation: Matrix3;
+    readonly translation: Vector3;
+}
+
+export const IDENTITY_TRANSFORM: RigidTransform = Object.freeze({
+    rotation: Object.freeze([1, 0, 0, 0, 1, 0, 0, 0, 1]) as Matrix3,
+    translation: Object.freeze([0, 0, 0]) as Vector3
+});
+
+/**
+ * Builds a transform from a ROS translation and an xyzw quaternion.
+ *
+ * @returns The transform, or null when the input cannot describe a rotation -- a
+ * non-finite component or a zero-length quaternion. A caller drops that edge rather than
+ * placing points by a guess.
+ */
+export function rigidTransform(translation: Vector3, rotation: Quaternion): RigidTransform | null {
+    if (![...translation, ...rotation].every(Number.isFinite)) return null;
+    const [qx, qy, qz, qw] = rotation;
+    const length = Math.hypot(qx, qy, qz, qw);
+    if (length === 0) return null;
+    const [x, y, z, w] = [qx / length, qy / length, qz / length, qw / length];
+    return {
+        rotation: [
+            1 - 2 * (y * y + z * z),
+            2 * (x * y - z * w),
+            2 * (x * z + y * w),
+            2 * (x * y + z * w),
+            1 - 2 * (x * x + z * z),
+            2 * (y * z - x * w),
+            2 * (x * z - y * w),
+            2 * (y * z + x * w),
+            1 - 2 * (x * x + y * y)
+        ],
+        translation: [translation[0], translation[1], translation[2]]
+    };
+}
+
+/** `outer * inner`: the transform of `inner`'s child into `outer`'s parent. */
+export function composeTransforms(outer: RigidTransform, inner: RigidTransform): RigidTransform {
+    const rotation = [0, 1, 2].flatMap((row) =>
+        [0, 1, 2].map(
+            (column) =>
+                outer.rotation[row * 3] * inner.rotation[column] +
+                outer.rotation[row * 3 + 1] * inner.rotation[3 + column] +
+                outer.rotation[row * 3 + 2] * inner.rotation[6 + column]
+        )
+    ) as unknown as Matrix3;
+    return { rotation, translation: applyTransform(outer, inner.translation) };
+}
+
+/** The inverse pose: a rigid transform inverts by transposing and re-projecting. */
+export function invertTransform(transform: RigidTransform): RigidTransform {
+    const r = transform.rotation;
+    const rotation: Matrix3 = [r[0], r[3], r[6], r[1], r[4], r[7], r[2], r[5], r[8]];
+    const inverse = { rotation, translation: [0, 0, 0] as Vector3 };
+    const [x, y, z] = applyTransform(inverse, transform.translation);
+    return { rotation, translation: [-x, -y, -z] };
+}
+
+function applyTransform(transform: RigidTransform, point: Vector3): Vector3 {
+    const r = transform.rotation;
+    const [x, y, z] = point;
+    return [
+        r[0] * x + r[1] * y + r[2] * z + transform.translation[0],
+        r[3] * x + r[4] * y + r[5] * z + transform.translation[1],
+        r[6] * x + r[7] * y + r[8] * z + transform.translation[2]
+    ];
+}
+
+/**
+ * Writes `source` into `target` at `at`, transformed, and returns the next write offset.
+ *
+ * Transforming while copying keeps one pass and one buffer per fused frame, which matters
+ * at the point budget: a separate transform step would double both.
+ */
+export function transformPositionsInto(
+    target: Float32Array,
+    at: number,
+    source: Float32Array,
+    transform: RigidTransform
+): number {
+    const r = transform.rotation;
+    const [tx, ty, tz] = transform.translation;
+    for (let index = 0; index < source.length; index += 3) {
+        const [x, y, z] = [source[index], source[index + 1], source[index + 2]];
+        target[at + index] = Math.fround(r[0] * x + r[1] * y + r[2] * z + tx);
+        target[at + index + 1] = Math.fround(r[3] * x + r[4] * y + r[5] * z + ty);
+        target[at + index + 2] = Math.fround(r[6] * x + r[7] * y + r[8] * z + tz);
+    }
+    return at + source.length;
+}

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/transformTree.test.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/transformTree.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { buildTransformGraph, resolveTransforms, type TransformMessage } from './transformTree';
+
+function edge(parent: string, child: string, x: number, y = 0, z = 0) {
+    return {
+        header: { frame_id: parent },
+        child_frame_id: child,
+        transform: { translation: { x, y, z }, rotation: { x: 0, y: 0, z: 0, w: 1 } }
+    };
+}
+
+function tf(...transforms: ReturnType<typeof edge>[]): TransformMessage {
+    return { transforms };
+}
+
+describe('resolveTransforms', () => {
+    it('places a sensor published as a child of the target frame', () => {
+        const graph = buildTransformGraph([tf(edge('CABIN', 'lidar_rear_left', -2, 1))]);
+
+        const transforms = resolveTransforms(graph, 'CABIN');
+
+        expect(transforms.get('lidar_rear_left')!.translation).toEqual([-2, 1, 0]);
+    });
+
+    it('inverts a transform published towards the target frame', () => {
+        const graph = buildTransformGraph([tf(edge('lidar_front', 'CABIN', 3))]);
+
+        const transforms = resolveTransforms(graph, 'CABIN');
+
+        expect(transforms.get('lidar_front')!.translation).toEqual([-3, 0, 0]);
+    });
+
+    it('follows a chain of frames to the target', () => {
+        const graph = buildTransformGraph([
+            tf(edge('CABIN', 'mount', 1), edge('mount', 'lidar_front', 0, 2))
+        ]);
+
+        const transforms = resolveTransforms(graph, 'CABIN');
+
+        expect(transforms.get('lidar_front')!.translation).toEqual([1, 2, 0]);
+    });
+
+    it('resolves the target itself, so a recording without transforms still renders', () => {
+        const transforms = resolveTransforms(buildTransformGraph([]), 'lidar');
+
+        expect([...transforms.keys()]).toEqual(['lidar']);
+        expect(transforms.get('lidar')!.translation).toEqual([0, 0, 0]);
+    });
+
+    it('leaves a frame the transforms never mention unresolved', () => {
+        const graph = buildTransformGraph([tf(edge('CABIN', 'lidar_front', 1))]);
+
+        expect(resolveTransforms(graph, 'CABIN').has('lidar_rear_left')).toBe(false);
+    });
+
+    it('drops an edge whose transform cannot describe a pose', () => {
+        const broken = {
+            header: { frame_id: 'CABIN' },
+            child_frame_id: 'lidar_front',
+            transform: {
+                translation: { x: 1, y: 0, z: 0 },
+                rotation: { x: 0, y: 0, z: 0, w: 0 }
+            }
+        };
+
+        expect(resolveTransforms(buildTransformGraph([tf(broken)]), 'CABIN').size).toBe(1);
+    });
+
+    it('reads every /tf_static message, not only the first', () => {
+        const graph = buildTransformGraph([
+            tf(edge('CABIN', 'lidar_front', 1)),
+            tf(edge('CABIN', 'lidar_rear_left', -2))
+        ]);
+
+        expect(resolveTransforms(graph, 'CABIN').size).toBe(3);
+    });
+});

--- a/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/transformTree.ts
+++ b/lightly_studio_view/src/lib/components/PointCloudLabelingWorkspace/provider/transformTree.ts
@@ -1,0 +1,88 @@
+import {
+    composeTransforms,
+    IDENTITY_TRANSFORM,
+    invertTransform,
+    rigidTransform,
+    type RigidTransform
+} from './rigidTransform';
+
+/** A `tf2_msgs/msg/TFMessage`, as `/tf_static` publishes sensor extrinsics. */
+export interface TransformMessage {
+    readonly transforms: readonly {
+        readonly header: { readonly frame_id: string };
+        readonly child_frame_id: string;
+        readonly transform: {
+            readonly translation: { readonly x: number; readonly y: number; readonly z: number };
+            readonly rotation: {
+                readonly x: number;
+                readonly y: number;
+                readonly z: number;
+                readonly w: number;
+            };
+        };
+    }[];
+}
+
+/** Frame -> its neighbours, each with the transform of that neighbour into the frame. */
+export type TransformGraph = ReadonlyMap<string, readonly (readonly [string, RigidTransform])[]>;
+
+/**
+ * Builds the undirected frame graph published on `/tf_static`.
+ *
+ * Both directions are stored so any frame can serve as the target: TF publishes
+ * parent-to-child, and a sensor is usually the child of the frame we want to render in.
+ * Edges whose transform is unusable are dropped, leaving that frame unreachable rather
+ * than misplaced.
+ */
+export function buildTransformGraph(messages: readonly TransformMessage[]): TransformGraph {
+    const graph = new Map<string, (readonly [string, RigidTransform])[]>();
+    for (const message of messages) {
+        for (const entry of message.transforms ?? []) {
+            const { translation, rotation } = entry.transform;
+            const parentFromChild = rigidTransform(
+                [translation.x, translation.y, translation.z],
+                [rotation.x, rotation.y, rotation.z, rotation.w]
+            );
+            const parent = entry.header?.frame_id;
+            const child = entry.child_frame_id;
+            if (!parentFromChild || !parent || !child) continue;
+            addEdge(graph, parent, child, parentFromChild);
+            addEdge(graph, child, parent, invertTransform(parentFromChild));
+        }
+    }
+    return graph;
+}
+
+/**
+ * Resolves `target_from_frame` for every frame connected to `targetFrameId`.
+ *
+ * Breadth-first, so each frame takes the shortest chain of published transforms. The
+ * target itself always resolves to the identity, which is what lets a recording with no
+ * usable `/tf_static` still render the frames already expressed in the target.
+ */
+export function resolveTransforms(
+    graph: TransformGraph,
+    targetFrameId: string
+): ReadonlyMap<string, RigidTransform> {
+    const resolved = new Map<string, RigidTransform>([[targetFrameId, IDENTITY_TRANSFORM]]);
+    const queue = [targetFrameId];
+    while (queue.length > 0) {
+        const frame = queue.shift()!;
+        const targetFromFrame = resolved.get(frame)!;
+        for (const [neighbour, frameFromNeighbour] of graph.get(frame) ?? []) {
+            if (resolved.has(neighbour)) continue;
+            resolved.set(neighbour, composeTransforms(targetFromFrame, frameFromNeighbour));
+            queue.push(neighbour);
+        }
+    }
+    return resolved;
+}
+
+function addEdge(
+    graph: Map<string, (readonly [string, RigidTransform])[]>,
+    from: string,
+    to: string,
+    transform: RigidTransform
+): void {
+    graph.set(from, [...(graph.get(from) ?? []), [to, transform]]);
+}


### PR DESCRIPTION
## What has changed and why?

The labeling workspace rendered one lidar and left the rest of the scene empty.

These recordings carry one `sensor_msgs/msg/PointCloud2` channel per sensor, each covering its own arc around the vehicle. The reader decoded exactly one of them — whichever channel the frame happened to be listed on — so everything the other sensors saw was never read. `/tf_static` was not read at all, so there was nowhere to put a second sensor even if it had been.

A frame now fuses the nearest sweep from every lidar channel, each placed by the extrinsics published on `/tf_static`. This follows the browser prototype in `kondrat-3d-point-cloud-with-browser-processing` (`fusedPointCloudAtOrAfter` + `loadTransforms`).

- `rigidTransform.ts` (new) — quaternion to matrix, compose, invert, and transforming points into a target buffer while copying them, so a fused frame stays one pass and one allocation.
- `transformTree.ts` (new) — the frame graph `/tf_static` publishes, resolved breadth-first into `target_from_sensor`, inverting the edges published towards the target. An edge that cannot describe a pose is dropped, which leaves its frame unreachable rather than misplaced.
- `fuseClouds.ts` (new) — concatenates the placed sweeps. A sweep whose frame does not resolve is left out and named rather than drawn at the origin: one sensor in the wrong place is harder to spot, and worse to label against, than one sensor missing.
- `pointCloud2.ts` — returns `header.frame_id`, which was being dropped, so the reader can tell where a sweep was measured.
- `mcapReader.ts` — reads the nearest sweep on each other lidar channel within 50 ms of the anchor message (under one period at the 10 Hz these sensors run at), splits the point budget across the channels, and fuses. The anchor still owns the frame's identity, timestamp and stream, so listing, navigation, prefetching and annotation identity are unchanged, and a fused frame costs what one frame cost before.
- `useRecordingProbe` — asks for the vehicle frame (`CABIN`) rather than the `lidar` sensor frame, falling back to the read channel's own frame for recordings that name theirs differently.
- `make start-mcap-point-cloud` — `start-e2e-mcap-point-cloud` without the wheel rebuild and `npm ci`, for iterating on the workspace itself.

Two calls worth a second opinion:

1. A recording with several lidars and no `/tf_static` is now refused with an explicit error rather than silently rendered as one sensor — the silent version is the bug this fixes. A single-lidar recording never reads `/tf_static` at all.
2. Fusion happens at read time, with frames still anchored to one channel, so the timeline, frame IDs and annotation identity are untouched. Making a frame a first-class multi-channel entity instead would ripple into the domain contracts.

## How has it been tested?

- Unit tests for `rigidTransform`, `transformTree` and `fuseClouds`: chained frames, inverted edges, unresolvable frames, degenerate rotations, and a recording with no transforms at all.
- `mcapFixture` now builds a two-lidar recording with real `/tf_static`. `mcapReader.test.ts` asserts end to end that the second sensor's sweep lands at its mount, that the frame reports the frame it was aligned into, that identity stays on the anchor channel, that the point budget is split, and that a multi-lidar recording without transforms is refused.
- The transform math was cross-checked numerically against the prototype's implementation over 200 random poses, plus compose/invert, graph resolution and fusion placement — matching to 1e-9, and to float32 precision for transformed point buffers.
- To reproduce in the app: `make start-mcap-point-cloud MCAP_PATH=/absolute/path/to/perception.mcap`, then open the workspace URL it prints. That script also lists every point-cloud channel in the recording, which states the bug in one line.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCAP-based point-cloud labeling with browser-side frame decoding and lazy loading.
  * Added support for browsing point-cloud frames with previous/next navigation, frame counts, loading states, and prefetching.
  * Added point-cloud rendering, multi-sensor frame fusion, coordinate transforms, and Z-up camera positioning.
  * Added recording diagnostics showing metadata, channel support, frame details, errors, and read telemetry.
  * Added range-based MCAP media access for efficient recording playback.
* **Bug Fixes**
  * Preserved nanosecond timestamps accurately when exchanged through the API.
* **Tests**
  * Added comprehensive coverage for MCAP reading, decoding, navigation, rendering, and media access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->