### PR TITLE
feat(sdk): compute image quality metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `ImageDataset.compute_image_quality_metadata()` to store brightness, contrast, sharpness, entropy, per-channel means and aspect ratio of every image as float metadata.
 - Add a Split dataset menu action to divide images or videos into tagged splits using the current filters.
 - Add a Glossary page to the docs.
 

--- a/lightly_studio/docs/docs/concepts_and_tools/metadata.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/metadata.md
@@ -129,6 +129,59 @@ how to do this given a python dictionary (e.g. loaded from JSON) or a CSV file.
     dataset.update_metadata(sample_metadata)
     ```
 
+### Compute image quality metadata
+
+[ImageDataset.compute_image_quality_metadata](../api/dataset.md#lightly_studio.ImageDataset.compute_image_quality_metadata)
+decodes every image once and stores a set of pixel statistics as float metadata. Once stored,
+the values show up in the distribution panel, the metadata filters, and the
+`metadata_weighting` sampling strategy like any other numeric metadata.
+
+```python
+import lightly_studio as ls
+
+dataset = ls.ImageDataset.load()
+dataset.compute_image_quality_metadata()
+```
+
+All metrics are computed on the 8-bit RGB image after the EXIF orientation is applied and any
+alpha channel is discarded. `L` is Pillow's `convert("L")` luminance (ITU-R BT.601,
+`0.299 R + 0.587 G + 0.114 B`, rounded to an integer in `[0, 255]`).
+
+| Key | Definition | Range |
+|---|---|---|
+| `brightness` | Mean of `L` | `[0, 255]` |
+| `contrast` | Standard deviation of `L` | `[0, 127.5]` |
+| `sharpness` | Variance of the 4-neighbour Laplacian of `L` over the interior pixels | `[0, ∞)` |
+| `entropy` | Shannon entropy of the 256-bin histogram of `L`, in bits | `[0, 8]` |
+| `red_mean`, `green_mean`, `blue_mean` | Mean of each channel | `[0, 255]` |
+| `aspect_ratio` | `width / height` after EXIF orientation | `(0, ∞)` |
+| `image_quality_version` | Integer version of the metric definitions the values were computed with | |
+
+The metrics describe the pixels, they do not decide whether an image is good or bad. Sharpness
+in particular depends on the image size and content: a downscaled image or a flat scene scores
+low without being blurry. Compare values between the images of one dataset instead of applying
+one threshold everywhere. For example, to review the 100 least sharp images of a dataset, tag
+them by `sharpness`:
+
+```python
+import lightly_studio as ls
+
+dataset = ls.ImageDataset.load()
+dataset.compute_image_quality_metadata()
+
+dataset.query().sampling().metadata_weighting(
+    n_samples_to_select=100,
+    sampling_result_tag_name="least_sharp",
+    metadata_key="sharpness",
+    strength=-1,
+)
+```
+
+An image that is missing or cannot be decoded gets no values and is listed in the log summary,
+so it never looks like a dark or blurry image. Re-running the method skips images that already
+carry values of the current `image_quality_version` and recomputes the rest; pass
+`overwrite=True` to recompute every image.
+
 ### Add metadata calculated from images
 
 You can also iterate the dataset, open each image with PIL, compute derived statistics, and write

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -33,6 +33,7 @@ from lightly_studio.dataset import fsspec_lister, remote_storage
 from lightly_studio.embed import embed_samples
 from lightly_studio.evaluation.image_dataset_evaluate import ImageDatasetEvaluate
 from lightly_studio.export.image_dataset_export import ImageDatasetExport
+from lightly_studio.metadata import compute_image_quality
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
@@ -126,6 +127,55 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         if sample is None:
             raise IndexError(f"No sample found for sample_id: {sample_id}")
         return ImageSample(inner=sample)
+
+    def compute_image_quality_metadata(
+        self,
+        overwrite: bool = False,
+        max_workers: int | None = None,
+    ) -> None:
+        """Computes per-image quality metrics from pixels and stores them as float metadata.
+
+        Stores ``brightness``, ``contrast``, ``sharpness``, ``entropy``, ``red_mean``,
+        ``green_mean``, ``blue_mean`` and ``aspect_ratio`` for every image, plus the
+        integer ``image_quality_version`` the values were computed with. The Metadata page
+        of the docs defines every metric. The metrics describe pixels and are not a good/bad
+        classifier: compare them between the images of one dataset rather than applying
+        one threshold to every dataset.
+
+        Each image is decoded once through the same fsspec path as ingest, by a bounded
+        thread pool, and the values are written in batches. A missing or undecodable
+        image gets no values, so it never looks like a dark or blurry image.
+
+        Args:
+            overwrite:
+                If False, images that already carry metrics of the current version are
+                skipped, so an interrupted run resumes. If True, every image is recomputed.
+            max_workers:
+                Number of images decoded concurrently. Defaults to 4 for local files and
+                to ``LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS`` when any file is remote.
+
+        Raises:
+            AllInputFilesFailedError: If at least one image was attempted and none could
+                be read.
+
+        Example:
+            ```python
+            dataset.compute_image_quality_metadata()
+            # Tag the 100 least sharp images of this dataset.
+            dataset.query().sampling().metadata_weighting(
+                n_samples_to_select=100,
+                sampling_result_tag_name="least_sharp",
+                metadata_key="sharpness",
+                strength=-1,
+            )
+            ```
+        """
+        compute_image_quality.compute_image_quality_metadata(
+            session=self.session,
+            collection_id=self.collection_id,
+            overwrite=overwrite,
+            max_workers=max_workers,
+        )
 
     def add_images_from_path(
         self,

--- a/lightly_studio/src/lightly_studio/metadata/compute_image_quality.py
+++ b/lightly_studio/src/lightly_studio/metadata/compute_image_quality.py
@@ -1,0 +1,257 @@
+"""Computes per-image quality metrics from pixels and stores them as metadata.
+
+Every metric is a plain float computed from one decode of the image, so that the
+distribution panel, the metadata filters, and ``metadata_weighting`` sampling can use
+it without extra work. The metrics describe the pixels, they are not a good/bad
+classifier: sharpness in particular depends on image scale and content, so compare it
+between images of one dataset, do not apply one threshold to every dataset.
+
+Definitions, all on the 8-bit RGB image after EXIF orientation is applied and any
+alpha channel is discarded. ``L`` is Pillow's ``convert("L")`` luminance
+(ITU-R BT.601: ``0.299 R + 0.587 G + 0.114 B``, rounded to an integer in ``[0, 255]``):
+
+- ``brightness``: mean of ``L``, in ``[0, 255]``.
+- ``contrast``: population standard deviation of ``L``, in ``[0, 127.5]``.
+- ``sharpness``: variance of the 4-neighbour Laplacian ``4 L(x,y) - L(x-1,y) - L(x+1,y)
+  - L(x,y-1) - L(x,y+1)`` over the interior pixels, in ``[0, inf)``. It is ``0.0`` for a
+  constant image and for an image with fewer than 3 pixels in either dimension.
+- ``entropy``: Shannon entropy of the 256-bin histogram of ``L``, in bits, in ``[0, 8]``.
+- ``red_mean``, ``green_mean``, ``blue_mean``: per-channel means, in ``[0, 255]``.
+- ``aspect_ratio``: ``width / height`` after EXIF orientation, in ``(0, inf)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import fsspec
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image, ImageOps
+from sqlmodel import Session
+from tqdm import tqdm
+
+from lightly_studio.core.file_outcome_report import (
+    BROKEN_IMAGE_ERRORS,
+    FileOutcome,
+    FileOutcomeReport,
+)
+from lightly_studio.dataset import remote_storage
+from lightly_studio.resolvers import image_resolver, metadata_resolver
+from lightly_studio.utils import batching, parallelize
+
+logger = logging.getLogger(__name__)
+
+# Bump when a metric definition changes. Samples computed with another version are
+# recomputed on the next run, so results of two definitions never mix in one dataset.
+IMAGE_QUALITY_METRICS_VERSION = 1
+# Integer metadata key that records the version the sample's metrics were computed with.
+IMAGE_QUALITY_VERSION_KEY = "image_quality_version"
+# Decoding releases the GIL, so a few threads overlap on local files without oversubscribing.
+DEFAULT_LOCAL_WORKERS = 4
+# Metric dicts are small; one write per this many images keeps commits infrequent.
+WRITE_BATCH_SIZE = 1_000
+# The 4-neighbour Laplacian needs an interior pixel, so at least 3 pixels per side.
+_MIN_LAPLACIAN_SIDE = 3
+
+
+def compute_image_quality_metadata(
+    session: Session,
+    collection_id: UUID,
+    overwrite: bool = False,
+    max_workers: int | None = None,
+) -> None:
+    """Computes image quality metrics for each image in the collection.
+
+    Each image is read once through fsspec and decoded once; all metrics come from that
+    decode. Images are processed by a bounded thread pool and written in batches, so
+    memory stays bounded for large collections. A missing or undecodable image gets no
+    metric values, so it never looks like a dark or blurry image; the outcome is logged.
+
+    Args:
+        session:
+            The database session.
+        collection_id:
+            The ID of the collection for which to compute the metrics.
+        overwrite:
+            If False, images that already carry metrics of the current
+            ``IMAGE_QUALITY_METRICS_VERSION`` are skipped, so an interrupted run resumes.
+            If True, every image is recomputed.
+        max_workers:
+            Number of images decoded concurrently. Defaults to
+            ``DEFAULT_LOCAL_WORKERS`` for local files and to
+            ``LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS`` when any file is remote.
+
+    Raises:
+        AllInputFilesFailedError: If at least one image was attempted and none could
+            be read.
+        ValueError: If ``max_workers`` is less than 1.
+    """
+    inputs = _collect_inputs(session=session, collection_id=collection_id, overwrite=overwrite)
+    paths = [image_input.path for image_input in inputs]
+    remote_storage.configure_connections(paths=paths)
+    if max_workers is None:
+        max_workers = _default_workers(paths=paths)
+
+    results = parallelize.thread_imap_lazy(
+        function=_compute_one,
+        iterable=inputs,
+        max_workers=max_workers,
+        buffer_size=max_workers,
+    )
+    report = FileOutcomeReport(label_overrides={FileOutcome.ADDED: "computed"})
+    progress = tqdm(results, total=len(inputs), desc="Computing image quality", unit=" images")
+    for batch in batching.batched(items=progress, batch_size=WRITE_BATCH_SIZE):
+        _write_batch(session=session, results=batch, report=report)
+    report.raise_if_all_failed()
+    report.log_summary()
+
+
+def compute_image_quality_metrics(image: Image.Image) -> dict[str, float]:
+    """Computes the quality metrics of one decoded image.
+
+    See the module docstring for the definition of every metric.
+
+    Args:
+        image: A decoded Pillow image in any mode.
+
+    Returns:
+        A mapping from metric name to its float value.
+    """
+    rgb = _normalize_image(image)
+    width, height = rgb.size
+    gray: NDArray[np.uint8] = np.asarray(rgb.convert("L"))
+    channel_means = np.asarray(rgb, dtype=np.uint8).reshape(-1, 3).mean(axis=0)
+    return {
+        "brightness": float(gray.mean()),
+        "contrast": float(gray.std()),
+        "sharpness": _laplacian_variance(gray=gray),
+        "entropy": _histogram_entropy(gray=gray),
+        "red_mean": float(channel_means[0]),
+        "green_mean": float(channel_means[1]),
+        "blue_mean": float(channel_means[2]),
+        "aspect_ratio": width / height,
+    }
+
+
+@dataclass(frozen=True)
+class _ImageInput:
+    """One image to process, with its filesystem resolved on the caller thread."""
+
+    sample_id: UUID
+    path: str
+    filesystem: fsspec.AbstractFileSystem
+    filesystem_path: str
+
+
+@dataclass(frozen=True)
+class _ImageResult:
+    """The outcome of one image; ``metrics`` is set only for ``FileOutcome.ADDED``."""
+
+    sample_id: UUID
+    path: str
+    outcome: FileOutcome
+    metrics: dict[str, float] | None = None
+
+
+def _collect_inputs(session: Session, collection_id: UUID, overwrite: bool) -> list[_ImageInput]:
+    """List the images to process, skipping up-to-date ones unless ``overwrite``."""
+    versions, _ = metadata_resolver.get_metadata_values_for_key(
+        session=session, collection_id=collection_id, key=IMAGE_QUALITY_VERSION_KEY
+    )
+    samples = image_resolver.get_for_export(
+        session=session, collection_id=collection_id, collection_filter=None
+    )
+    inputs = []
+    for sample in samples:
+        if not overwrite and versions.get(sample.sample_id) == IMAGE_QUALITY_METRICS_VERSION:
+            continue
+        # Resolve the filesystem here so worker threads share the cached client.
+        filesystem, filesystem_path = fsspec.core.url_to_fs(sample.file_path_abs)
+        inputs.append(
+            _ImageInput(
+                sample_id=sample.sample_id,
+                path=sample.file_path_abs,
+                filesystem=filesystem,
+                filesystem_path=filesystem_path,
+            )
+        )
+    return inputs
+
+
+def _default_workers(paths: list[str]) -> int:
+    """Return the configured remote worker count if any path is remote, else the local one."""
+    if any(remote_storage.is_remote(path) for path in paths):
+        return remote_storage.image_probe_workers(paths=paths)
+    return DEFAULT_LOCAL_WORKERS
+
+
+def _compute_one(image_input: _ImageInput) -> _ImageResult:
+    """Read and decode one image and compute its metrics, classifying any file failure."""
+    if not image_input.filesystem.exists(image_input.filesystem_path):
+        return _ImageResult(
+            sample_id=image_input.sample_id, path=image_input.path, outcome=FileOutcome.MISSING
+        )
+    try:
+        with (
+            image_input.filesystem.open(image_input.filesystem_path, mode="rb") as file,
+            Image.open(file) as image,
+        ):
+            metrics = compute_image_quality_metrics(image=image)
+    except BROKEN_IMAGE_ERRORS:
+        return _ImageResult(
+            sample_id=image_input.sample_id, path=image_input.path, outcome=FileOutcome.BROKEN
+        )
+    return _ImageResult(
+        sample_id=image_input.sample_id,
+        path=image_input.path,
+        outcome=FileOutcome.ADDED,
+        metrics=metrics,
+    )
+
+
+def _write_batch(
+    session: Session, results: Iterable[_ImageResult], report: FileOutcomeReport
+) -> None:
+    """Record every outcome and write the metrics of the readable images in one call."""
+    sample_metadata: list[tuple[UUID, Mapping[str, Any]]] = []
+    for result in results:
+        report.record(path=result.path, outcome=result.outcome)
+        if result.metrics is None:
+            continue
+        metadata: dict[str, float | int] = dict(result.metrics)
+        metadata[IMAGE_QUALITY_VERSION_KEY] = IMAGE_QUALITY_METRICS_VERSION
+        sample_metadata.append((result.sample_id, metadata))
+    metadata_resolver.bulk_update_metadata(session=session, sample_metadata=sample_metadata)
+
+
+def _normalize_image(image: Image.Image) -> Image.Image:
+    """Apply the EXIF orientation and convert to 8-bit RGB, discarding any alpha channel."""
+    transposed = ImageOps.exif_transpose(image)
+    assert transposed is not None
+    return transposed.convert("RGB")
+
+
+def _laplacian_variance(gray: NDArray[np.uint8]) -> float:
+    """Variance of the 4-neighbour Laplacian over the interior pixels, 0.0 if there are none."""
+    if gray.shape[0] < _MIN_LAPLACIAN_SIDE or gray.shape[1] < _MIN_LAPLACIAN_SIDE:
+        return 0.0
+    # Built in place so that only one float32 array the size of the interior is held.
+    laplacian = np.multiply(gray[1:-1, 1:-1], 4.0, dtype=np.float32)
+    np.subtract(laplacian, gray[:-2, 1:-1], out=laplacian)
+    np.subtract(laplacian, gray[2:, 1:-1], out=laplacian)
+    np.subtract(laplacian, gray[1:-1, :-2], out=laplacian)
+    np.subtract(laplacian, gray[1:-1, 2:], out=laplacian)
+    return float(laplacian.var(dtype=np.float64))
+
+
+def _histogram_entropy(gray: NDArray[np.uint8]) -> float:
+    """Shannon entropy in bits of the 256-bin histogram of ``gray``."""
+    counts = np.bincount(gray.ravel(), minlength=256)
+    probabilities = counts[counts > 0] / counts.sum()
+    # max() turns the -0.0 of a single-bin histogram into 0.0.
+    return max(0.0, float(-(probabilities * np.log2(probabilities)).sum()))

--- a/lightly_studio/tests/core/image/test_image_dataset__image_quality.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__image_quality.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from lightly_studio import ImageDataset
+from lightly_studio.metadata import compute_image_quality
+
+
+class TestDataset:
+    def test_compute_image_quality_metadata(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        Image.new("RGB", (16, 8), color=(100, 100, 100)).save(tmp_path / "gray.png")
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_images_from_path(path=tmp_path, embed=False)
+
+        dataset.compute_image_quality_metadata()
+
+        (sample,) = dataset.query().to_list()
+        assert sample.metadata["brightness"] == pytest.approx(100.0)
+        assert sample.metadata["contrast"] == 0.0
+        assert sample.metadata["sharpness"] == 0.0
+        assert sample.metadata["entropy"] == 0.0
+        assert sample.metadata["aspect_ratio"] == 2.0
+        assert (
+            sample.metadata["image_quality_version"]
+            == compute_image_quality.IMAGE_QUALITY_METRICS_VERSION
+        )
+
+    def test_compute_image_quality_metadata__broken_image_gets_no_values(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        Image.new("RGB", (8, 8), color=(0, 0, 0)).save(tmp_path / "dark.png")
+        broken_path = tmp_path / "broken.jpg"
+        Image.new("RGB", (8, 8)).save(broken_path)
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_images_from_path(path=tmp_path, embed=False)
+        # Corrupt the file after ingest so the decode fails at metric time.
+        broken_path.write_bytes(b"not an image")
+
+        dataset.compute_image_quality_metadata()
+
+        samples = {s.file_name: s for s in dataset.query().to_list()}
+        assert samples["dark.png"].metadata["brightness"] == 0.0
+        # A broken file must not receive a zero that looks like a dark image.
+        assert samples["broken.jpg"].metadata["brightness"] is None
+        assert samples["broken.jpg"].metadata["image_quality_version"] is None

--- a/lightly_studio/tests/metadata/test_compute_image_quality.py
+++ b/lightly_studio/tests/metadata/test_compute_image_quality.py
@@ -1,0 +1,283 @@
+"""Test computing image quality metrics."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+from pytest_mock import MockerFixture
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.core.file_outcome_report import AllInputFilesFailedError
+from lightly_studio.metadata import compute_image_quality
+from lightly_studio.resolvers import metadata_resolver
+from tests.helpers_resolvers import ImageStub, create_collection, create_images
+
+# 8x8 checkerboard with 2x2 cells, drawn out so the expected values can be checked by hand.
+_CHECKERBOARD = np.array(
+    [
+        [0, 0, 255, 255, 0, 0, 255, 255],
+        [0, 0, 255, 255, 0, 0, 255, 255],
+        [255, 255, 0, 0, 255, 255, 0, 0],
+        [255, 255, 0, 0, 255, 255, 0, 0],
+        [0, 0, 255, 255, 0, 0, 255, 255],
+        [0, 0, 255, 255, 0, 0, 255, 255],
+        [255, 255, 0, 0, 255, 255, 0, 0],
+        [255, 255, 0, 0, 255, 255, 0, 0],
+    ],
+    dtype=np.uint8,
+)
+
+
+def test_compute_image_quality_metadata(db_session: Session, tmp_path: Path) -> None:
+    collection = create_collection(session=db_session)
+    gray_path = tmp_path / "gray.png"
+    Image.new("RGB", (16, 8), color=(100, 100, 100)).save(gray_path)
+    board_path = tmp_path / "board.png"
+    Image.fromarray(_CHECKERBOARD).save(board_path)
+    create_images(
+        db_session,
+        collection.collection_id,
+        [ImageStub(path=str(gray_path)), ImageStub(path=str(board_path))],
+    )
+
+    compute_image_quality.compute_image_quality_metadata(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    samples = {s.file_name: s for s in DatasetQuery(collection, db_session)}
+    gray = samples["gray.png"]
+    assert gray.metadata["brightness"] == 100.0
+    assert gray.metadata["contrast"] == 0.0
+    assert gray.metadata["sharpness"] == 0.0
+    assert gray.metadata["entropy"] == 0.0
+    assert gray.metadata["aspect_ratio"] == 2.0
+    assert gray.metadata["image_quality_version"] == 1
+    board = samples["board.png"]
+    assert board.metadata["brightness"] == 127.5
+    assert board.metadata["contrast"] == 127.5
+    assert board.metadata["sharpness"] > 0.0
+    assert board.metadata["entropy"] == 1.0
+    # Every value is stored as a float so the schema type is stable across images.
+    _, schema_type = metadata_resolver.get_metadata_values_for_key(
+        session=db_session, collection_id=collection.collection_id, key="aspect_ratio"
+    )
+    assert schema_type == "float"
+
+
+def test_compute_image_quality_metadata__missing_and_broken_get_no_values(
+    db_session: Session, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    collection = create_collection(session=db_session)
+    dark_path = tmp_path / "dark.png"
+    Image.new("RGB", (8, 8), color=(0, 0, 0)).save(dark_path)
+    broken_path = tmp_path / "broken.jpg"
+    broken_path.write_bytes(b"not an image")
+    missing_path = tmp_path / "missing.jpg"
+    create_images(
+        db_session,
+        collection.collection_id,
+        [ImageStub(path=str(p)) for p in (dark_path, broken_path, missing_path)],
+    )
+
+    with caplog.at_level(logging.INFO):
+        compute_image_quality.compute_image_quality_metadata(
+            session=db_session, collection_id=collection.collection_id
+        )
+
+    samples = {s.file_name: s for s in DatasetQuery(collection, db_session)}
+    assert samples["dark.png"].metadata["brightness"] == 0.0
+    # A failure must not become a zero that looks like a dark image.
+    for file_name in ("broken.jpg", "missing.jpg"):
+        assert samples[file_name].metadata["brightness"] is None
+        assert samples[file_name].metadata["image_quality_version"] is None
+    assert "computed=1, already_present=0, missing=1, broken=1" in caplog.text
+
+
+def test_compute_image_quality_metadata__resumes_and_overwrites(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    collection = create_collection(session=db_session)
+    paths = [tmp_path / "a.png", tmp_path / "b.png"]
+    for path in paths:
+        Image.new("RGB", (8, 8), color=(50, 50, 50)).save(path)
+    images = create_images(
+        db_session, collection.collection_id, [ImageStub(path=str(p)) for p in paths]
+    )
+    compute_one = mocker.spy(compute_image_quality, "_compute_one")
+
+    compute_image_quality.compute_image_quality_metadata(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert compute_one.call_count == 2
+
+    # A second run skips images that carry the current version.
+    compute_image_quality.compute_image_quality_metadata(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert compute_one.call_count == 2
+
+    # An image computed with another version is recomputed.
+    metadata_resolver.bulk_update_metadata(
+        session=db_session,
+        sample_metadata=[(images[0].sample_id, {"image_quality_version": 0})],
+    )
+    compute_image_quality.compute_image_quality_metadata(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert compute_one.call_count == 3
+
+    compute_image_quality.compute_image_quality_metadata(
+        session=db_session, collection_id=collection.collection_id, overwrite=True
+    )
+    assert compute_one.call_count == 5
+
+
+def test_compute_image_quality_metadata__writes_in_batches(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    collection = create_collection(session=db_session)
+    paths = [tmp_path / f"{i}.png" for i in range(3)]
+    for path in paths:
+        Image.new("RGB", (4, 4)).save(path)
+    create_images(db_session, collection.collection_id, [ImageStub(path=str(p)) for p in paths])
+    mocker.patch.object(compute_image_quality, "WRITE_BATCH_SIZE", 2)
+    bulk_update = mocker.spy(metadata_resolver, "bulk_update_metadata")
+
+    compute_image_quality.compute_image_quality_metadata(
+        session=db_session, collection_id=collection.collection_id, max_workers=2
+    )
+
+    assert [len(call.kwargs["sample_metadata"]) for call in bulk_update.call_args_list] == [2, 1]
+
+
+def test_compute_image_quality_metadata__all_failed_raises(
+    db_session: Session, tmp_path: Path
+) -> None:
+    collection = create_collection(session=db_session)
+    create_images(
+        db_session, collection.collection_id, [ImageStub(path=str(tmp_path / "missing.jpg"))]
+    )
+
+    with pytest.raises(AllInputFilesFailedError):
+        compute_image_quality.compute_image_quality_metadata(
+            session=db_session, collection_id=collection.collection_id
+        )
+
+
+def test_compute_image_quality_metadata__unexpected_error_propagates(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    collection = create_collection(session=db_session)
+    path = tmp_path / "a.png"
+    Image.new("RGB", (4, 4)).save(path)
+    create_images(db_session, collection.collection_id, [ImageStub(path=str(path))])
+    mocker.patch.object(
+        compute_image_quality, "compute_image_quality_metrics", side_effect=RuntimeError("bug")
+    )
+
+    with pytest.raises(RuntimeError, match="bug"):
+        compute_image_quality.compute_image_quality_metadata(
+            session=db_session, collection_id=collection.collection_id
+        )
+
+    (sample,) = DatasetQuery(collection, db_session)
+    assert sample.metadata["image_quality_version"] is None
+
+
+def test_compute_image_quality_metadata__invalid_workers(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+
+    with pytest.raises(ValueError, match="max_workers"):
+        compute_image_quality.compute_image_quality_metadata(
+            session=db_session, collection_id=collection.collection_id, max_workers=0
+        )
+
+
+def test_compute_image_quality_metrics__constant_gray() -> None:
+    metrics = compute_image_quality.compute_image_quality_metrics(
+        image=Image.new("RGB", (6, 3), color=(128, 128, 128))
+    )
+
+    assert metrics == {
+        "brightness": 128.0,
+        "contrast": 0.0,
+        "sharpness": 0.0,
+        "entropy": 0.0,
+        "red_mean": 128.0,
+        "green_mean": 128.0,
+        "blue_mean": 128.0,
+        "aspect_ratio": 2.0,
+    }
+
+
+def test_compute_image_quality_metrics__checkerboard() -> None:
+    metrics = compute_image_quality.compute_image_quality_metrics(
+        image=Image.fromarray(_CHECKERBOARD)
+    )
+
+    assert metrics["brightness"] == 127.5
+    assert metrics["contrast"] == 127.5
+    # Two equally likely gray levels carry exactly one bit.
+    assert metrics["entropy"] == 1.0
+    # With 2x2 cells every interior pixel has one same and one opposite neighbour per axis,
+    # so its Laplacian is +-2 * 255. The mean is 0, so the variance is the square of that.
+    assert metrics["sharpness"] == pytest.approx((2 * 255) ** 2)
+
+
+def test_compute_image_quality_metrics__blurred_is_less_sharp() -> None:
+    board = Image.fromarray(_CHECKERBOARD)
+    blurred = board.resize((4, 4), Image.Resampling.BILINEAR).resize(
+        (8, 8), Image.Resampling.BILINEAR
+    )
+
+    sharp = compute_image_quality.compute_image_quality_metrics(image=board)
+    soft = compute_image_quality.compute_image_quality_metrics(image=blurred)
+
+    assert 0.0 < soft["sharpness"] < sharp["sharpness"]
+    assert soft["contrast"] < sharp["contrast"]
+
+
+def test_compute_image_quality_metrics__colour_channels() -> None:
+    metrics = compute_image_quality.compute_image_quality_metrics(
+        image=Image.new("RGB", (2, 2), color=(255, 0, 0))
+    )
+
+    assert metrics["red_mean"] == 255.0
+    assert metrics["green_mean"] == 0.0
+    assert metrics["blue_mean"] == 0.0
+    # Pillow's BT.601 luminance of pure red, rounded to 8 bit.
+    assert metrics["brightness"] == 76.0
+
+
+def test_compute_image_quality_metrics__exif_orientation_applied(tmp_path: Path) -> None:
+    path = tmp_path / "rotated.png"
+    exif = Image.Exif()
+    exif[0x0112] = 6  # Rotate 90 degrees clockwise on display.
+    Image.new("RGB", (4, 2)).save(path, exif=exif)
+
+    with Image.open(path) as image:
+        metrics = compute_image_quality.compute_image_quality_metrics(image=image)
+
+    assert metrics["aspect_ratio"] == 0.5
+
+
+def test_compute_image_quality_metrics__alpha_discarded() -> None:
+    metrics = compute_image_quality.compute_image_quality_metrics(
+        image=Image.new("RGBA", (2, 2), color=(255, 255, 255, 0))
+    )
+
+    assert metrics["brightness"] == 255.0
+
+
+def test_compute_image_quality_metrics__too_small_for_laplacian() -> None:
+    metrics = compute_image_quality.compute_image_quality_metrics(
+        image=Image.fromarray(_CHECKERBOARD[:2, :])
+    )
+
+    assert metrics["sharpness"] == 0.0
+    assert metrics["contrast"] == 127.5


### PR DESCRIPTION
## What has changed and why?

Refs #2050

LightlyStudio has no built-in way to compute per-image quality metrics, so the "remove or select low-quality images" step stays a hand-written PIL loop (the recipe in the Metadata docs). This PR adds `ImageDataset.compute_image_quality_metadata()`, mirroring `compute_typicality_metadata()`: one call stores a set of pixel statistics as float metadata, and the distribution panel, the metadata filters and `metadata_weighting` sampling pick them up with no extra work.

- New module `lightly_studio/metadata/compute_image_quality.py`, called from a new `ImageDataset.compute_image_quality_metadata(overwrite=False, max_workers=None)` method. The method lives on `ImageDataset` rather than `Dataset` because it decodes `ImageTable.file_path_abs`.
- Each image is read once through the same fsspec path as ingest (`fsspec.core.url_to_fs` on the caller thread, `filesystem.exists` / `filesystem.open` in the worker, `remote_storage.configure_connections` up front) and decoded once; every metric comes from that one decode. Pillow + numpy only, no second image stack (`cv2` is not imported anywhere in `src` today, so I did not introduce it).
- Bounded concurrency and memory: `parallelize.thread_imap_lazy` with `buffer_size == max_workers`, so at most `max_workers` decoded images are in flight, and results are written in batches of 1000 through `metadata_resolver.bulk_update_metadata`. Default workers: 4 for local files, `LIGHTLY_STUDIO_REMOTE_IMAGE_PROBE_WORKERS` when any path is remote.
- Failures are separate from values: a missing or undecodable image (the shared `BROKEN_IMAGE_ERRORS`) gets no metric keys at all and is counted in a `FileOutcomeReport` log summary; if every attempted image fails, `AllInputFilesFailedError` is raised like ingest and embedding do. A corrupt file can never look like a dark or blurry image.
- Provenance and resume: every written sample also gets the integer `image_quality_version` (currently `1`). Without `overwrite`, samples already at the current version are skipped, so an interrupted run resumes; samples with another version are recomputed, so a changed definition never silently mixes with old values. `overwrite=True` recomputes everything.
- Docs: a "Compute image quality metadata" section in the Metadata page with the definitions table, the normalization rules, and an example that tags the 100 least sharp images of a dataset with `metadata_weighting(strength=-1)` rather than a global blur threshold.

### Metric definitions

All metrics are computed on the 8-bit RGB image after `ImageOps.exif_transpose` and `convert("RGB")` (alpha is discarded, transparent pixels contribute their stored colour). `L` is Pillow's `convert("L")` luminance: ITU-R BT.601 `0.299 R + 0.587 G + 0.114 B`, rounded to an integer in `[0, 255]`. All values are stored as `float`, so the metadata schema type is stable across images.

| Key | Definition | Range |
|---|---|---|
| `brightness` | mean of `L` | `[0, 255]` |
| `contrast` | population standard deviation of `L` | `[0, 127.5]` |
| `sharpness` | variance of the 4-neighbour Laplacian `4L(x,y) - L(x-1,y) - L(x+1,y) - L(x,y-1) - L(x,y+1)` over interior pixels; `0.0` for a constant image and for images with fewer than 3 px on a side | `[0, inf)` |
| `entropy` | Shannon entropy of the 256-bin histogram of `L`, in bits | `[0, 8]` |
| `red_mean`, `green_mean`, `blue_mean` | per-channel mean | `[0, 255]` |
| `aspect_ratio` | `width / height` after EXIF orientation | `(0, inf)` |
| `image_quality_version` | integer version of the definitions the values were computed with | |

The docstrings and the docs say explicitly that these describe pixels and are not a good/bad classifier, and that Laplacian sharpness depends on image scale and content.

### Deliberately out of scope (first slice)

- `file_size`: not cheaply available for remote files without an extra `info()` round trip per image; can be a follow-up with its own I/O budget.
- `width` / `height` as metadata: already first-class sample fields with their own GUI filters. `aspect_ratio` is the one derived value stored, since after EXIF orientation it can differ from the stored dimensions.
- An HTTP route / GUI entry point: the issue asks for the SDK method; the API can wrap the same module later exactly as `metadata/typicality` does.
- Video frames and other sample types.

## How has it been tested?

New tests (all deterministic fixtures, no example dataset needed):

- `tests/metadata/test_compute_image_quality.py` (14 tests): constant gray (expected brightness, zero contrast / sharpness / entropy), 2x2-cell checkerboard (brightness 127.5, contrast 127.5, entropy exactly 1 bit, sharpness exactly `510**2`, derived by hand in the test), blurred checkerboard is strictly less sharp than the original, pure-red channel means and BT.601 luminance 76, EXIF orientation 6 changes `aspect_ratio` from 2.0 to 0.5, RGBA alpha discarded, 2-row image gets sharpness 0.0; end-to-end on DuckDB: values and schema type `float`, missing and broken images get no keys and the log summary reads `computed=1, already_present=0, missing=1, broken=1`, resume / recompute-on-version-change / `overwrite=True` (spied `_compute_one` call counts 2 -> 2 -> 3 -> 5), batched writes (`WRITE_BATCH_SIZE=2` over 3 images yields writes of 2 then 1), all-failed raises `AllInputFilesFailedError`, an unexpected worker error propagates and writes nothing, `max_workers=0` raises `ValueError`.
- `tests/core/image/test_image_dataset__image_quality.py` (2 tests): the public `ImageDataset` method end to end, including a file corrupted after ingest.

Before the change (contract test): `ImportError: cannot import name 'compute_image_quality' from 'lightly_studio.metadata'`. After: `16 passed`.

Full backend suite passes locally except `test_server_static_webapp`, which needs the built frontend (see the evidence record); `make static-checks` (uv lock check, ruff, mypy on 984 files, ruff format) passes; `make -C docs docs` (strict) builds and validates the new anchor.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Evidence record

- Repository / issue: lightly-ai/lightly-studio, issue #2050 ("[FEAT] Add dataset.compute_image_quality_metadata() for per-image quality metrics").
- Upstream SHA / patch SHA: base `62996452a31cf19560ed6339c5b0a4904b9a043b` (origin/main) / patch `bbbf582fcdb84858ebfbb50ae07faf10171f579b`.
- Issue ownership and competing PR result (2026-09-12 21:50 UTC): issue open, no assignees, zero comments, zero cross-references in the timeline; `gh search prs -- 2050` and `gh search prs -- "compute_image_quality_metadata brightness blur entropy"` returned nothing; no open PR touches image quality. Re-checked immediately before opening this PR.
- Reproducer red: `uv run pytest tests/core/image/test_image_dataset__image_quality.py` on the base tree -> `ImportError: cannot import name 'compute_image_quality' from 'lightly_studio.metadata'` (1 error during collection).
- Patched green: `uv run pytest tests/metadata/test_compute_image_quality.py tests/core/image/test_image_dataset__image_quality.py` -> `16 passed`.
- Full checks executed: `make static-checks` in `lightly_studio` (exit 0: `uv lock --check`, `ruff check`, `mypy .` "Success: no issues found in 984 source files", `ruff format --check`); full backend suite `uv run pytest -n auto` -> `2536 passed, 53 skipped, 1 failed` in 2:39; the one failure is `tests/api/test_server.py::test_server_static_webapp` at `GET /favicon.png` (404), which needs the built frontend in `dist_lightly_studio_view_app` and was run here against the `make mock-webapp-dist` stub (an empty `index.html`); it imports nothing this PR touches; `make -C docs docs` (mkdocs `--strict`) -> built in 17 s, exit 0. Python 3.9.6, uv 0.12.6 (the repo pin; installed into a local tool dir because the machine's uv is 0.10.6).
- Checks not executed and why: `make test-postgres` (needs a Docker Postgres container; the change uses only the existing `bulk_update_metadata` / `get_metadata_values_for_key` resolvers, no new SQL); frontend and e2e suites (no frontend change); remote-storage paths against a real bucket (the fsspec calls are the same three used by `_probe_image` in ingest, exercised here on the local filesystem).

https://claude.ai/code/session_01DkE5qM85ht9Uoq3aAqcKf7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added image-quality metadata computation for brightness, contrast, sharpness, entropy, color-channel means, and aspect ratio.
  - Supports resuming or recomputing metadata with overwrite controls.
  - Handles unreadable images without blocking successful results.

- **Documentation**
  - Added guidance covering available metrics, value ranges, sampling, preprocessing, and recomputation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->