### PR TITLE
fix(gallery): prevent native image drag during selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Grid thumbnails no longer start a native image drag when the pointer moves slightly during a click, so quick selection clicks are not lost.
+
 ### Security
 
 ## \[1.1.0\] - 2026-09-07

--- a/lightly_studio_view/e2e/videos/video-frame-drift-click.e2e-test.ts
+++ b/lightly_studio_view/e2e/videos/video-frame-drift-click.e2e-test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '../utils';
+
+// Chromium starts a native <img> drag once the pointer moves a few pixels between mousedown
+// and mouseup, and a started drag swallows the click. Frame thumbnails are <img> elements.
+const CLICK_DRIFT_PX = 6;
+
+test('a click that drifts a few pixels still toggles frame selection', async ({
+    page,
+    videoFramesPage
+}) => {
+    const frame = videoFramesPage.getVideoFrameByIndex(1);
+    await expect(frame).toBeVisible();
+    const box = await frame.boundingBox();
+    expect(box).not.toBeNull();
+
+    const x = box!.x + box!.width / 2;
+    const y = box!.y + box!.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + CLICK_DRIFT_PX, y + 2, { steps: 3 });
+    await page.mouse.up();
+
+    expect(await videoFramesPage.getNumSelectedSamples()).toBe(1);
+});

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -65,6 +65,14 @@
         event.preventDefault();
         onSelect(event);
     }
+
+    // Browsers start a native drag on an <img> once the pointer drifts a few pixels between
+    // mousedown and mouseup, and a started drag swallows the click. The item owns the
+    // selection click, so it cancels native drags of whatever thumbnail it renders.
+    // Drag-to-search runs on pointer events and is unaffected.
+    function handleDragStart(event: DragEvent) {
+        event.preventDefault();
+    }
 </script>
 
 <div class="select-none" {style}>
@@ -85,6 +93,7 @@
         onpointerup={drag.handlePointerUp}
         onpointercancel={drag.handlePointerCancel}
         onlostpointercapture={drag.handleLostPointerCapture}
+        ondragstart={handleDragStart}
         onkeydown={handleKeyDown}
         aria-label={ariaLabel}
         role="button"

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
@@ -123,6 +123,55 @@ describe('GridItem', () => {
         vi.restoreAllMocks();
     });
 
+    it('cancels native drag of a thumbnail image so the click reaches onSelect', async () => {
+        const onSelect = vi.fn();
+        render(GridItemTestWrapper, { props: { ...defaultProps, onSelect } });
+
+        const gridItem = screen.getByTestId('grid-item');
+        const thumbnail = document.createElement('img');
+        gridItem.appendChild(thumbnail);
+
+        // Browsers fire dragstart on an <img> between mousedown and mouseup as soon as the
+        // pointer drifts a few pixels. Unless it is cancelled, the click never fires.
+        const dragStart = new Event('dragstart', { bubbles: true, cancelable: true });
+        thumbnail.dispatchEvent(dragStart);
+        await fireEvent.click(thumbnail);
+
+        expect(dragStart.defaultPrevented).toBe(true);
+        expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('selects once per click when the pointer drifts below the drag threshold', async () => {
+        const onSelect = vi.fn();
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: { url: '/api/images/sample/sample-1', fileName: 'sample-1.jpg' },
+                onSelect
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        for (const drift of [3, 5]) {
+            await fireEvent(
+                gridItem,
+                createPointerEvent('pointerdown', { clientX: 10, clientY: 10 })
+            );
+            await fireEvent(
+                gridItem,
+                createPointerEvent('pointermove', { clientX: 10 + drift, clientY: 12 })
+            );
+            await fireEvent(
+                gridItem,
+                createPointerEvent('pointerup', { clientX: 10 + drift, clientY: 12 })
+            );
+            await fireEvent.click(gridItem);
+        }
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(onSelect).toHaveBeenCalledTimes(2);
+    });
+
     it('applies selected style and renders selectable tag', () => {
         render(GridItemTestWrapper, {
             props: {

--- a/lightly_studio_view/src/lib/components/VideoFrameItem/VideoFrameItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameItem/VideoFrameItem.svelte
@@ -45,7 +45,11 @@
     role="img"
     style={`width: var(${videoFrame.video.width}); height: var(${videoFrame.video.height});`}
 >
-    <img src={frameUrl} alt={`${videoFrame.sample_id}-${videoFrame.frame_number}`} />
+    <img
+        src={frameUrl}
+        alt={`${videoFrame.sample_id}-${videoFrame.frame_number}`}
+        draggable="false"
+    />
     <VideoFrameAnnotationItem
         width={size}
         height={size}


### PR DESCRIPTION
## What has changed and why?

Closes #804.

**What goes wrong.** Browsers start a native drag on an `<img>` as soon as the pointer moves a few pixels between mousedown and mouseup. Once that drag starts, the `click` never fires, so a quick selection click on a grid thumbnail is silently lost. #1062 made the image-grid thumbnail (`SampleImage`) non-draggable as a side effect of drag-to-search, but the frames grid still renders a plain `<img>` (`VideoFrameItem`), and `GridItem` accepted whatever thumbnail a renderer put inside it.

**What changes.**
- `GridItem` cancels native `dragstart` from anything it renders. It owns the selection click, so it is the one place that guarantees a drifting click is not turned into a drag, for every grid (images, frames, annotations, groups) and any future thumbnail renderer.
- `VideoFrameItem`'s `<img>` gets `draggable="false"`, the same as `SampleImage` already has.

**What deliberately does not change.**
- No `preventDefault` on pointerdown/mousedown, so focus, keyboard toggling (Enter/Space) and text selection outside the grid behave as before.
- Drag-to-search (`useGridItemDrag`) runs on pointer events with an 8px threshold and is untouched; the existing "drops draggable grid items on the search target" test still passes.
- OS file drops onto the search box (`CollectionSearch`) are unrelated to `dragstart` inside the grid and are untouched.

## How has it been tested?

Unit (`GridItem.test.ts`, added tests only):
- `cancels native drag of a thumbnail image so the click reaches onSelect` - **fails before, passes after** (the `dragstart` on a child `<img>` was not cancelled).
- `selects once per click when the pointer drifts below the drag threshold` - guards that a drifting click is one `onSelect` and does not start drag-to-search (passes before and after).
- The existing keyboard test (`Enter`/`Space`) still passes.

Real Chromium (Playwright 1.60, Chromium 148), because jsdom cannot swallow a click:
- A standalone mechanism check: 6px pointer drift on a plain `<img>` -> `dragstart` fires, **0 clicks**; on `<img draggable="false">` or with `dragstart` cancelled on the container -> **1 click**. At 2px drift all three click.
- New e2e `e2e/videos/video-frame-drift-click.e2e-test.ts` (videos project): mouse down on a frame thumbnail, move 6px, mouse up -> exactly one frame selected. **Fails on a build of the unpatched tree (0 selected), passes with the patch (1 selected).**

```
Evidence record
Repository / issue: lightly-ai/lightly-studio #804
Upstream SHA: 62996452 (origin/main)  /  patch SHA: 4adfa504
Issue ownership and competing PR check (2026-09-12 21:49 UTC): issue open, no assignees,
  last comment 2026-06-11 (maintainer: "if the drag/click problem is still reproducible, we can
  keep investigating it"); no cross-referenced PRs; `gh search prs -- 804`, "native image drag
  gallery checkbox selection", "draggable dragstart thumbnail", "thumbnail selection": no match;
  46 open PRs listed, none touching grid selection or dragging.
Reproducer (jsdom): npx vitest run src/lib/components/GridItem/GridItem.test.ts
  before: 1 failed | 10 passed - "cancels native drag ..." expected defaultPrevented true, got false
  after:  11 passed
Reproducer (Chromium 148 mechanism script, 6px drift): clicks {"plain":0,"nodrag":1,"guarded":1}
Reproducer (app e2e, frames grid, unpatched build): CI=1 E2E_BASE_URL=http://localhost:8011 npx playwright test --project=videos --retries=0
  e2e/videos/video-frame-drift-click.e2e-test.ts -> 1 failed: expected 1 selected frame, received 0
Patched (app e2e, frames grid): same command -> 1 passed (2.5s)
Full checks executed:
  make -C lightly_studio_view test            -> Test Files 377 passed, Tests 2957 passed, exit 0
  npm run static-checks (prettier, eslint, svelte-check) -> Prettier clean, ESLint clean,
      svelte-check 0 errors 0 warnings, exit 0
Checks not executed and why:
  make -C lightly_studio_view static-checks from the checkout path failed for all 1227 files in
  prettier-plugin-tailwindcss (ENOENT node_modules/tailwindcss/theme.css) because a stray
  ~/node_modules/tailwindcss@4.1.18 on this machine shadows the project's v3; the same command
  run from a copy of lightly_studio_view outside $HOME with the same node_modules passes.
  Backend checks: not run (frontend-only change).
Toolchain: Node 25.6.1 (package.json engines >=24; .nvmrc pins 24.13.1, no nvm on the machine),
  uv 0.12.6 downloaded locally to match the repo pin (machine default is 0.10.6),
  Playwright 1.60 / Chromium 148.0.7778.96.
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

Suggested reviewer: @IgorSusmelj (#1062 added drag-to-search and the `draggable="false"` on `SampleImage`); alternative: @horatiualmasan (#1521 annotation drag) or @LeonardoRosaa (#997 GridItem, issue thread).

https://claude.ai/code/session_01DkE5qM85ht9Uoq3aAqcKf7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grid and video frame thumbnails no longer trigger native image dragging from slight pointer movement during clicks.
  * Clicking a thumbnail with minor pointer drift now reliably preserves selection behavior.
* **Tests**
  * Added coverage for thumbnail selection with pointer drift and prevention of unintended native image dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->